### PR TITLE
Add HTTP section

### DIFF
--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -28,23 +28,42 @@ all `http` URIs MUST redirect to their `https` counterparts
 using a response with a `301` status code and a `Location` header.
 
 A data pod MUST implement the server part
-of HTTP/1.1 Conditional Requests [[!RFC7232]]
+of <cite>HTTP/1.1 Conditional Requests</cite> [[!RFC7232]]
 to ensure that updates requested by clients
 will only be applied if given preconditions are met.
 It SHOULD additionally implement the server part
-of HTTP/1.1 Caching [[!RFC7234]]
-to reduce bandwidth.
+of <cite>HTTP/1.1 Caching</cite> [[!RFC7234]]
+to reduce bandwidth consumption.
 A data pod MAY implement the server part
-of HTTP/1.1 Range Requests [[!RFC7233]]
+of <cite>HTTP/1.1 Range Requests</cite> [[!RFC7233]]
 on large representations
 to achieve further bandwidth reduction.
 
 A data pod MUST implement the server part
-of HTTP/1.1 Authentication [[!RFC7235]].
+of <cite>HTTP/1.1 Authentication</cite> [[!RFC7235]].
 When a client does not provide valid credentials
 when requesting a resource that requires it (see [[#webid]]),
 the data pod MUST send a response with a `401` status code
 (unless `404` is preferred for security reasons).
+
+### Required client-side implementation ### {#http-client}
+
+A Solid client MUST be an HTTP/1.1 client [[!RFC7230]][[!RFC7231]].
+It MAY additionally be an HTTP/2 client [[!RFC7540]]
+to improve performance.
+
+A Solid client MAY implement the client parts of
+<cite>HTTP/1.1 Conditional Requests</cite> [[!RFC7232]]
+to only trigger updates when certain preconditions are met.
+It MAY implement
+<cite>HTTP/1.1 Caching</cite> [[!RFC7234]]
+and
+<cite>HTTP/1.1 Range Requests</cite> [[!RFC7233]]
+to reduce bandwidth consumption.
+
+A Solid client MUST implement the client part
+of <cite>HTTP/1.1 Authentication</cite> [[!RFC7235]]
+if it needs to access resources requiring authentication (see [[#webid]]).
 
 
 ## Linked Data Platform ## {#ldp}

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -5,28 +5,32 @@ Issue: Write introduction to the Authenticated Resource Access section.
 
 ## Hypertext Transfer Protocol ## {#http}
 
-Issue: Write Hypertext Transfer Protocol section.
+A [=data pod=] MUST be an HTTP/1.1 server [[!RFC7230]][[!RFC7231]].
+It SHOULD additionally implement HTTP/2 [[!RFC7540]]
+to improve performance,
+especially in cases where individual clients
+are expected to send high numbers of successive requests.
 
-Draft:
-A Solid data pod MUST implement HTTP/1.1 Message Syntax and Routing [[!RFC7230]]
+A data pod SHOULD use the `https` URI scheme
+in order to secure the connection between clients and servers.
+When both `http` and `https` are supported,
+all `http` URIs MUST redirect to their `https` counterparts
+using a response with a `301` status code and a `Location` header.
 
-Draft:
-A Solid data pod MUST implement HTTP/1.1 Semantics and Content [[!RFC7231]].
+A data pod MUST implement HTTP/1.1 Conditional Requests [[!RFC7232]]
+to ensure that updates requested by clients
+will only be applied if given preconditions are met.
+It SHOULD additionally implement HTTP/1.1 Caching [[!RFC7234]]
+to reduce bandwidth.
+A data pod MAY implement HTTP/1.1 Range Requests [[!RFC7233]]
+on large representations
+to achieve further bandwidth reduction.
 
-Draft:
-A Solid data pod MUST implement HTTP/1.1 Authentication [[!RFC7235]].
-
-Draft:
-A Solid data pod SHOULD implement HTTP/1.1 Conditional Requests [[!RFC7232]].
-
-Draft:
-A Solid data pod SHOULD implement HTTP/1.1 Range Requests [[!RFC7233]].
-
-Draft:
-A Solid data pod SHOULD implement HTTP/1.1 Caching [[!RFC7234]].
-
-Draft:
-A Solid data pod MAY implement HTTP/2 [[!RFC7540]].
+A data pod MUST implement HTTP/1.1 Authentication [[!RFC7235]].
+When a client does not provide valid credentials
+when requesting a resource that requires it (see [[#webid]]),
+the data pod MUST send a response with a `401` status code
+(unless `404` is preferred for security reasons).
 
 
 ## Linked Data Platform ## {#ldp}
@@ -40,7 +44,7 @@ A Solid data pod MUST conform to the LDP specification [[!LDP]].
 ## WebID ## {#webid}
 
 Issue: Explain inline that agents accessing non-public Solid resources
-  need a WebID, and that this is a URL
+  need to authenticate with a WebID, which is a URL
   pointing to a document with an RDF representation.
 
 

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -5,8 +5,10 @@ Issue: Write introduction to the Authenticated Resource Access section.
 
 ## Hypertext Transfer Protocol ## {#http}
 
+### Required server-side implementation ### {#http-server}
+
 A [=data pod=] MUST be an HTTP/1.1 server [[!RFC7230]][[!RFC7231]].
-It SHOULD additionally implement HTTP/2 [[!RFC7540]]
+It SHOULD additionally be an HTTP/2 server [[!RFC7540]]
 to improve performance,
 especially in cases where individual clients
 are expected to send high numbers of successive requests.
@@ -17,16 +19,20 @@ When both `http` and `https` are supported,
 all `http` URIs MUST redirect to their `https` counterparts
 using a response with a `301` status code and a `Location` header.
 
-A data pod MUST implement HTTP/1.1 Conditional Requests [[!RFC7232]]
+A data pod MUST implement the server part
+of HTTP/1.1 Conditional Requests [[!RFC7232]]
 to ensure that updates requested by clients
 will only be applied if given preconditions are met.
-It SHOULD additionally implement HTTP/1.1 Caching [[!RFC7234]]
+It SHOULD additionally implement the server part
+of HTTP/1.1 Caching [[!RFC7234]]
 to reduce bandwidth.
-A data pod MAY implement HTTP/1.1 Range Requests [[!RFC7233]]
+A data pod MAY implement the server part
+of HTTP/1.1 Range Requests [[!RFC7233]]
 on large representations
 to achieve further bandwidth reduction.
 
-A data pod MUST implement HTTP/1.1 Authentication [[!RFC7235]].
+A data pod MUST implement the server part
+of HTTP/1.1 Authentication [[!RFC7235]].
 When a client does not provide valid credentials
 when requesting a resource that requires it (see [[#webid]]),
 the data pod MUST send a response with a `401` status code

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -5,6 +5,14 @@ Issue: Write introduction to the Authenticated Resource Access section.
 
 ## Hypertext Transfer Protocol ## {#http}
 
+### Background and Need ### {#http-need}
+<em>This section is non-normative.</em>
+
+Solid clients and servers need to exchange data securely over the Internet,
+and they do so using the Web protocol HTTP.
+This section describes in detail
+which parts of HTTP must be implemented by clients and servers.
+
 ### Required server-side implementation ### {#http-server}
 
 A [=data pod=] MUST be an HTTP/1.1 server [[!RFC7230]][[!RFC7231]].

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -9,7 +9,7 @@ Issue: Write introduction to the Authenticated Resource Access section.
 <em>This section is non-normative.</em>
 
 Solid clients and servers need to exchange data securely over the Internet,
-and they do so using the Web protocol HTTP.
+and they do so using the HTTP Web standard.
 This section describes in detail
 which parts of HTTP must be implemented by clients and servers.
 
@@ -64,6 +64,8 @@ to improve performance.
 A Solid client MUST implement the client part
 of <cite>HTTP/1.1 Authentication</cite> [[!RFC7235]]
 if it needs to access resources requiring authentication (see [[#webid]]).
+When it receives a response with a `403` or `404` status code,
+it MAY repeat the request with different credentials.
 
 
 ## Linked Data Platform ## {#ldp}

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -21,8 +21,9 @@ to improve performance,
 especially in cases where individual clients
 are expected to send high numbers of successive requests.
 
-A data pod SHOULD use the `https` URI scheme
-in order to secure the connection between clients and servers.
+A data pod SHOULD use TLS connections
+through the `https` URI scheme
+in order to secure the communication between clients and servers.
 When both `http` and `https` are supported,
 all `http` URIs MUST redirect to their `https` counterparts
 using a response with a `301` status code and a `Location` header.
@@ -33,11 +34,10 @@ to ensure that updates requested by clients
 will only be applied if given preconditions are met.
 It SHOULD additionally implement the server part
 of <cite>HTTP/1.1 Caching</cite> [[!RFC7234]]
-to reduce bandwidth consumption.
+to improve performance.
 A data pod MAY implement the server part
 of <cite>HTTP/1.1 Range Requests</cite> [[!RFC7233]]
-on large representations
-to achieve further bandwidth reduction.
+to further improve performance for large representations.
 
 A data pod MUST implement the server part
 of <cite>HTTP/1.1 Authentication</cite> [[!RFC7235]].
@@ -59,7 +59,7 @@ It MAY implement
 <cite>HTTP/1.1 Caching</cite> [[!RFC7234]]
 and
 <cite>HTTP/1.1 Range Requests</cite> [[!RFC7233]]
-to reduce bandwidth consumption.
+to improve performance.
 
 A Solid client MUST implement the client part
 of <cite>HTTP/1.1 Authentication</cite> [[!RFC7235]]

--- a/main/security.bs
+++ b/main/security.bs
@@ -6,7 +6,7 @@ Issue: Write Security Considerations section.
 Data pods SHOULD use TLS connections
 to protect the contents of requests and responses
 from eavesdropping and modification by third parties.
-Regular TCP connections MAY be used
+Unsecured TCP connections without TLS MAY be used
 in testing environments
 or when the data pod is behind a reverse proxy
 that terminates a secure connection.

--- a/main/security.bs
+++ b/main/security.bs
@@ -3,6 +3,14 @@ Security Considerations {#security}
 
 Issue: Write Security Considerations section.
 
+Data pods SHOULD use TLS connections
+to protect the contents of requests and responses
+from eavesdropping and modification by third parties.
+Regular TCP connections MAY be used
+in testing environments
+or when the data pod is behind a reverse proxy
+that terminates a secure connection.
+
 ## Privacy Considerations ## {#privacy}
 
 Issue: Write Privacy Considerations section.


### PR DESCRIPTION
Issues such as https://github.com/inrupt/wac-ldp/issues/114 indicate that we want to explicitly refer to the HTTP specification.

I am following the intent of the current draft specs and implementations, with the exception of:
- suggesting HTTP/2 (only in addition to HTTP/1.1)
- suggesting instead of requiring range requests (unclear whether https://github.com/solid/node-solid-server/issues/442 was a suggestion or requirement)

Feedback most welcome.