### PR TITLE
Rename WebID-OIDC to Solid-OIDC.

### DIFF
--- a/main/index.bs
+++ b/main/index.bs
@@ -67,9 +67,9 @@ any feedback, comments, or questions you might have.
 		"href": "https://solid.github.io/specification/wac/",
 		"title": "Web Access Control"
 	},
-	"webid-oidc": {
-		"href": "https://solid.github.io/specification/webid-oidc/",
-		"title": "WebID-OIDC"
+	"solid-oidc": {
+		"href": "https://solid.github.io/specification/solid-oidc/",
+		"title": "Solid-OIDC"
 	},
 	"webid-tls": {
 		"href": "https://solid.github.io/specification/webid-tls/",

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -82,14 +82,14 @@ Issue: Explain inline that agents accessing non-public Solid resources
   need to authenticate with a WebID, which is a URL
   pointing to a document with an RDF representation.
 
+## Authentication ## {#authentication}
 
-### WebID-OIDC ### {#webid-oidc}
+### Solid-OIDC ### {#solid-oidc}
 
-Issue: Write WebID-OIDC section.
+Issue: Write Solid-OIDC section.
 
 Draft:
-A Solid data pod MUST conform to the WebID-OIDC specification [[!WEBID-OIDC]].
-
+A Solid data pod MUST conform to the Solid-OIDC specification [[!SOLID-OIDC]].
 
 ### WebID-TLS ### {#webid-tls}
 
@@ -97,7 +97,6 @@ Issue: Write WebID-TLS section.
 
 Draft:
 A Solid data pod MAY conform to the WebID-TLS specification [[!WEBID-TLS]].
-
 
 ## Web Access Control ## {#wac}
 

--- a/solid-oidc/index.bs
+++ b/solid-oidc/index.bs
@@ -1,11 +1,11 @@
 <pre class='metadata'>
-Title: WebID-OIDC
+Title: Solid-OIDC Specification v1
 Boilerplate: issues-index no
-Shortname: webid-oidc
+Shortname: solid-oidc
 Level: 1
 Status: w3c/ED
 Group: Solid Community Group
-URL: https://solid.github.io/specification/webid-oidc/
+URL: https://solid.github.io/specification/solid-oidc/
 Repository: https://github.com/solid/specification
 Markup Shorthands: markdown yes
 Max ToC Depth: 2


### PR DESCRIPTION
Renames authentication spec from WebID-OIDC to Solid-OIDC, to address https://github.com/solid/authentication-panel/issues/29.
(Note that this is a PR to another PR, #113.)