### PR TITLE
Restrict POST target to existing resources

### DIFF
--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -176,7 +176,7 @@ this specification imposes the following requirements:
 
 Servers MUST create intermediate containers and include corresponding
 containment triples in container representations derived from the URI path
-component of `PUT`, `POST` and `PATCH` requests.
+component of `PUT` and `PATCH` requests.
 [[Source](https://github.com/solid/specification/issues/68#issuecomment-561690124)]
 
 Servers MUST allow creating new resources with a `POST` request to URI path
@@ -188,8 +188,8 @@ subsequent requests to the newly created container's URI as if it is a valid
 LDP container type by including the HTTP response's `Link` header.
 [[Source](https://github.com/solid/specification/pull/160#issuecomment-636822687)]
 
-When a `POST` method request targets a non-container resource without an
-existing representation, the server `MUST` respond with the `404` status code.
+When a `POST` method request targets a resource without an existing
+representation, the server `MUST` respond with the `404` status code.
 [[Source](https://github.com/solid/specification/issues/108#issuecomment-549448159)]
 
 When a `PUT` or `PATCH` method request targets an auxiliary resource, the

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -286,11 +286,16 @@ such that the request's representation data encodes an *RDF document*
 [[!RDF11-CONCEPTS]] (as determined by the `Content-Type` header), the server
 MUST respect `GET` requests on this resource when the value of the `Accept`
 header requests a representation in `text/turtle` or `application/ld+json`.
-
 [[Source](https://github.com/solid/specification/issues/45)]
 [[Source](https://github.com/solid/specification/issues/69)]
 [[Source](https://github.com/solid/specification/issues/109)]
 [[Source](https://github.com/solid/specification/issues/195)]
+
+When a `PUT`, `POST`, `PATCH` or `DELETE` method request targets a resource's
+representation URL, the server MUST respond with a `307` or `308` status code
+and `Location` header specifying the preferred URI reference.
+[[Source](https://github.com/solid/specification/issues/109)]
+
 
 ## Auxiliary Resources ## {#rm}
 

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -284,7 +284,7 @@ https://github.com/solid/specification/issues/41#issuecomment-534679278
 When a server creates a resource on HTTP `PUT`, `POST` or `PATCH` requests
 such that the request's representation data encodes an *RDF document*
 [[!RDF11-CONCEPTS]] (as determined by the `Content-Type` header), the server
-MUST respect `GET` requests on this resource when the value of the `Accept`
+MUST accept `GET` requests on this resource when the value of the `Accept`
 header requests a representation in `text/turtle` or `application/ld+json`
 [[!Turtle]] [[!JSON-LD11]].
 [[Source](https://github.com/solid/specification/issues/45)]

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -286,7 +286,7 @@ such that the request's representation data encodes an *RDF document*
 [[!RDF11-CONCEPTS]] (as determined by the `Content-Type` header), the server
 MUST respect `GET` requests on this resource when the value of the `Accept`
 header requests a representation in `text/turtle` or `application/ld+json`
-[[!Turtle]] [[!JSON-LD]].
+[[!Turtle]] [[!JSON-LD11]].
 [[Source](https://github.com/solid/specification/issues/45)]
 [[Source](https://github.com/solid/specification/issues/69)]
 [[Source](https://github.com/solid/specification/issues/109)]

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -292,9 +292,10 @@ header requests a representation in `text/turtle` or `application/ld+json`
 [[Source](https://github.com/solid/specification/issues/109)]
 [[Source](https://github.com/solid/specification/issues/195)]
 
-When a `PUT`, `POST`, `PATCH` or `DELETE` method request targets a resource's
-representation URL, the server MUST respond with a `307` or `308` status code
-and `Location` header specifying the preferred URI reference.
+When a `PUT`, `POST`, `PATCH` or `DELETE` method request targets a
+representation URL that is different than the resource URL, the server MUST
+respond with a `307` or `308` status code and `Location` header specifying the
+preferred URI reference.
 [[Source](https://github.com/solid/specification/issues/109)]
 
 

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -279,6 +279,20 @@ Issue:
 Pertaining to events and loss of control mitigation:
 https://github.com/solid/specification/issues/41#issuecomment-534679278
 
+### Representations ### {#representations}
+
+When a server creates a resource on HTTP `PUT`, `POST` or `PATCH` requests
+such that the request's representation data encodes an *RDF document*
+[[!RDF11-CONCEPTS]] (as determined by the `Content-Type` header), the server
+MUST respect `GET` requests on this resource when the value of the `Accept`
+header requests a response in `text/turtle` or `application/ld+json`, unless
+HTTP content negotiation requires a different outcome.
+
+[[Source](https://github.com/solid/specification/issues/45)]
+[[Source](https://github.com/solid/specification/issues/69)]
+[[Source](https://github.com/solid/specification/issues/109)]
+[[Source](https://github.com/solid/specification/issues/195)]
+
 ## Auxiliary Resources ## {#rm}
 
 ### Background and Need ### {#ar-need}

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -285,7 +285,8 @@ When a server creates a resource on HTTP `PUT`, `POST` or `PATCH` requests
 such that the request's representation data encodes an *RDF document*
 [[!RDF11-CONCEPTS]] (as determined by the `Content-Type` header), the server
 MUST respect `GET` requests on this resource when the value of the `Accept`
-header requests a representation in `text/turtle` or `application/ld+json`.
+header requests a representation in `text/turtle` or `application/ld+json`
+[[!Turtle]] [[!JSON-LD]].
 [[Source](https://github.com/solid/specification/issues/45)]
 [[Source](https://github.com/solid/specification/issues/69)]
 [[Source](https://github.com/solid/specification/issues/109)]

--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -285,8 +285,7 @@ When a server creates a resource on HTTP `PUT`, `POST` or `PATCH` requests
 such that the request's representation data encodes an *RDF document*
 [[!RDF11-CONCEPTS]] (as determined by the `Content-Type` header), the server
 MUST respect `GET` requests on this resource when the value of the `Accept`
-header requests a response in `text/turtle` or `application/ld+json`, unless
-HTTP content negotiation requires a different outcome.
+header requests a representation in `text/turtle` or `application/ld+json`.
 
 [[Source](https://github.com/solid/specification/issues/45)]
 [[Source](https://github.com/solid/specification/issues/69)]


### PR DESCRIPTION
There is a slight discrepancy in the spec where it recommends:

>Clients who want the server to assign a URI of a resource, MUST use the POST request.

and

>Servers MUST create intermediate containers and include corresponding containment triples in container representations derived from the URI path component of PUT, POST and PATCH requests.

For example, say `/foo/` exists, it is not entirely clear what happens with:

```
POST /foo/bar/baz/
Link: rel=type LDPC
```

The expectation would've been along the lines of creating a new container with a server determined name eg. `/foo/bar/baz/qux/`.

However, that raises a bit of a question as to why `bar/baz/` are created where client determines the name.

In order to minimise confusion and to keep things consistent, the PR restricts `POST` to target only existing resources.