### PR TITLE
Restrict POST target to existing resources

### DIFF
--- a/main/resource-access.bs
+++ b/main/resource-access.bs
@@ -176,7 +176,7 @@ this specification imposes the following requirements:
 
 Servers MUST create intermediate containers and include corresponding
 containment triples in container representations derived from the URI path
-component of `PUT`, `POST` and `PATCH` requests.
+component of `PUT` and `PATCH` requests.
 [[Source](https://github.com/solid/specification/issues/68#issuecomment-561690124)]
 
 Servers MUST allow creating new resources with a `POST` request to URI path
@@ -188,8 +188,8 @@ subsequent requests to the newly created container's URI as if it is a valid
 LDP container type by including the HTTP response's `Link` header.
 [[Source](https://github.com/solid/specification/pull/160#issuecomment-636822687)]
 
-When a `POST` method request targets a non-container resource without an
-existing representation, the server `MUST` respond with the `404` status code.
+When a `POST` method request targets a resource without an existing
+representation, the server `MUST` respond with the `404` status code.
 [[Source](https://github.com/solid/specification/issues/108#issuecomment-549448159)]
 
 When a `PUT` or `PATCH` method request targets an auxiliary resource, the


### PR DESCRIPTION
There is a slight discrepancy in the spec where it recommends:

>Clients who want the server to assign a URI of a resource, MUST use the POST request.

and

>Servers MUST create intermediate containers and include corresponding containment triples in container representations derived from the URI path component of PUT, POST and PATCH requests.

For example, say `/foo/` exists, it is not entirely clear what happens with:

```
POST /foo/bar/baz/
Link: rel=type LDPC
```

The expectation would've been along the lines of creating a new container with a server determined name eg. `/foo/bar/baz/qux/`.

However, that raises a bit of a question as to why `bar/baz/` are created where client determines the name.

In order to minimise confusion and to keep things consistent, the PR restricts `POST` to target only existing resources.