### PR TITLE
Add WAC-Allow definition and requirements

### DIFF
--- a/main/authorization.bs
+++ b/main/authorization.bs
@@ -58,8 +58,8 @@ or `GET` request on the target URL, and checking the `WAC-Allow` header value
 for access parameters listing the allowed access modes per permission group.
 
 Clients' parsing algorithm for the `WAC-Allow` header should incorporate error
-handling. When the received message fails to match an allowed pattern,
-unrecognised access parameters or modes are found, clients MUST ignore the
+handling. When the received message fails to match an allowed pattern, finds 
+unrecognised access parameters or access modes, clients MUST ignore the
 received `WAC-Allow` header-field.
 
 [[Source](https://github.com/solid/specification/issues/171)]

--- a/main/authorization.bs
+++ b/main/authorization.bs
@@ -38,17 +38,29 @@ OWS                 = *(SP / HTAB)
 RWS                 = 1*(SP / HTAB)
 ```
 
-The `access-mode` corresponds to the modes of access (`acl:Read`, `acl:Write`,
-`acl:Append`, `acl:Control`) as defined in the ACL ontology.
+The `WAC-Allow` HTTP header's field-value is a comma-separated list of access
+parameters (`access-param`). `access-param` is a whitespace-separated list of
+access modes ( `access-mode`) granted to a permission group.
 
-Clients can discover their access privileges on a resource by making an HTTP
-`HEAD` or `GET` request on the target URL, and checking the `WAC-Allow` HTTP
-header value for `user` and `public` access paramaters listing the allowed
-access modes.
+This specification defines the following permission groups:
+
+<dl>
+  <dt>`user`</dt>
+  <dd>Permissions granted to the agent requesting the resource.</dd>
+  <dt>`public`</dt>
+  <dd>Permissions granted to the public.</dd>
+</dl>
+
+`access-mode` corresponds to the modes of access as defined in the
+ACL ontology (`acl:Read`, `acl:Write`, `acl:Append`, `acl:Control`).
+
+Clients can discover access privileges on a resource by making an HTTP `HEAD`
+or `GET` request on the target URL, and checking the `WAC-Allow` header value
+for access parameters listing the allowed access modes per permission group.
 
 Clients' parsing algorithm for the `WAC-Allow` header should incorporate error
 handling. When the received message fails to match an allowed pattern,
-unrecognised access paramaters or modes are found, clients MUST ignore the
+unrecognised access parameters or modes are found, clients MUST ignore the
 received `WAC-Allow` header-field.
 
 [[Source](https://github.com/solid/specification/issues/171)]

--- a/main/authorization.bs
+++ b/main/authorization.bs
@@ -3,12 +3,14 @@ Authorization {#authorization}
 
 ## Web Access Control ## {#web-access-control}
 
-Web Access Control (WAC) is a decentralized cross-domain access control
-system. The WAC mechanism is concerned with giving access to agents denoted by
-a [[#webid]] to perform various kinds of read-write operations on resources
-identified by URLs. The Access Control List (ACL) vocabulary is used to
-describe authorization policies about authorized agents with modes of access
-on target resources.
+Web Access Control (<abbr title="Web Access Control">WAC</abbr>) is a
+decentralized cross-domain access control system. The WAC mechanism is
+concerned with giving access to agents denoted by a [[#webid]] to perform
+various kinds of read-write operations on resources identified by URLs. The
+<cite><a href="http://www.w3.org/ns/auth/acl">Access Control List</a></cite>
+(<abbr title="Access Control List">ACL</abbr>) ontology is used to describe
+authorization policies about authorized agents with modes of access on target
+resources.
 
 Servers MUST conform to the Web Access Control specification [[!WAC]].
 
@@ -19,3 +21,31 @@ the HTTP `Link` header with a `rel` value of `acl` [[#acl]].
 In the event that a server can't apply an ACL to a resource, it MUST deny
 access.
 [[Source](https://github.com/solid/specification/issues/130#issue-532777017)]
+
+Servers exposing client's access privileges on a resource URL MUST advertise
+by including the `WAC-Allow` HTTP header in the response of HTTP `HEAD` and
+`GET` requests.
+
+The syntax for `WAC-Allow`, using the ABNF syntax is:
+
+```
+WAC-Allow           = "WAC-Allow" ":" OWS permissions OWS
+permissions         = user-permissions OWS "," OWS public-permissions
+user-permissions    = "user=" quoted-access-modes
+public-permissions  = "public=" quoted-access-modes
+quoted-access-modes = DQUOTE *( access-modes / SP ) DQUOTE
+access-modes        = "read" / "write" / "append" / "control"
+OWS                 = *( SP / HTAB )
+```
+
+The `access-modes` corresponds to the modes of access (`acl:Read`,
+`acl:Write`, `acl:Append`, `acl:Control`) as defined in the ACL ontology.
+
+Clients can discover their access privileges on a resource by making an HTTP
+`HEAD` or `GET` request on the target URL, and checking the `WAC-Allow` HTTP
+header value for `user` and `public` paramaters listing the allowed access
+modes.
+
+[[Source](https://github.com/solid/specification/issues/171)]
+[[Source](https://github.com/solid/specification/issues/170)]
+[[Source](https://github.com/solid/specification/issues/181)]

--- a/main/authorization.bs
+++ b/main/authorization.bs
@@ -31,18 +31,17 @@ Section 1.2 of [[!RFC7231]], is:
 
 ```
 wac-allow           = "WAC-Allow" ":" OWS #access-param OWS
-access-param        = 1*ALPHA OWS "=" OWS quoted-access-modes
+access-param        = permission-group OWS "=" OWS quoted-access-modes
+permission-group    = 1*ALPHA
 quoted-access-modes = DQUOTE OWS *1(access-mode *(RWS access-mode)) OWS DQUOTE
 access-mode         = "read" / "write" / "append" / "control"
-OWS                 = *(SP / HTAB)
-RWS                 = 1*(SP / HTAB)
 ```
 
-The `WAC-Allow` HTTP header's field-value is a comma-separated list of access
-parameters (`access-param`). `access-param` is a whitespace-separated list of
-access modes ( `access-mode`) granted to a permission group.
+The `WAC-Allow` HTTP header's field-value is a comma-separated list of
+`access-param`s. `access-param` is a whitespace-separated list of `access
+mode`s granted to a `permission-group`.
 
-This specification defines the following permission groups:
+This specification defines the following `permission-group`s:
 
 <dl>
   <dt>`user`</dt>

--- a/main/authorization.bs
+++ b/main/authorization.bs
@@ -46,6 +46,11 @@ Clients can discover their access privileges on a resource by making an HTTP
 header value for `user` and `public` access paramaters listing the allowed
 access modes.
 
+Clients' parsing algorithm for the `WAC-Allow` header should incorporate error
+handling. When the received message fails to match an allowed pattern,
+unrecognised access paramaters or modes are found, clients MUST ignore the
+received `WAC-Allow` header-field.
+
 [[Source](https://github.com/solid/specification/issues/171)]
 [[Source](https://github.com/solid/specification/issues/170)]
 [[Source](https://github.com/solid/specification/issues/181)]

--- a/main/authorization.bs
+++ b/main/authorization.bs
@@ -30,16 +30,16 @@ The syntax for the `WAC-Allow` header, using the ABNF syntax defined in
 Section 1.2 of [[!RFC7231]], is:
 
 ```
-wac-allow           = "WAC-Allow" ":" OWS #access-param OWS
-access-param        = permission-group OWS "=" OWS quoted-access-modes
-permission-group    = 1*ALPHA
-quoted-access-modes = DQUOTE OWS *1(access-mode *(RWS access-mode)) OWS DQUOTE
-access-mode         = "read" / "write" / "append" / "control"
+wac-allow        = "WAC-Allow" ":" OWS #access-param OWS
+access-param     = permission-group OWS "=" OWS access-modes
+permission-group = 1*ALPHA
+access-modes     = *1DQUOTE OWS *1(access-mode *(RWS access-mode)) OWS *1DQUOTE
+access-mode      = "read" / "write" / "append" / "control"
 ```
 
 The `WAC-Allow` HTTP header's field-value is a comma-separated list of
 `access-param`s. `access-param` is a whitespace-separated list of `access
-mode`s granted to a `permission-group`.
+modes` granted to a `permission-group`.
 
 This specification defines the following `permission-group`s:
 
@@ -61,6 +61,10 @@ Clients' parsing algorithm for the `WAC-Allow` header should incorporate error
 handling. When the received message fails to match an allowed pattern, finds 
 unrecognised access parameters or access modes, clients MUST ignore the
 received `WAC-Allow` header-field.
+
+The quoted and unquoted values for `access-modes` are equivalent. Servers are
+recommended to use quoted values in the response. Clients' are recommended to
+be able to parse both quoted and unquoted values.
 
 [[Source](https://github.com/solid/specification/issues/171)]
 [[Source](https://github.com/solid/specification/issues/170)]

--- a/main/authorization.bs
+++ b/main/authorization.bs
@@ -26,25 +26,25 @@ Servers exposing client's access privileges on a resource URL MUST advertise
 by including the `WAC-Allow` HTTP header in the response of HTTP `HEAD` and
 `GET` requests.
 
-The syntax for `WAC-Allow`, using the ABNF syntax is:
+The syntax for the `WAC-Allow` header, using the ABNF syntax defined in
+Section 1.2 of [[!RFC7231]], is:
 
 ```
-WAC-Allow           = "WAC-Allow" ":" OWS permissions OWS
-permissions         = user-permissions OWS "," OWS public-permissions
-user-permissions    = "user=" quoted-access-modes
-public-permissions  = "public=" quoted-access-modes
-quoted-access-modes = DQUOTE *( access-modes / SP ) DQUOTE
-access-modes        = "read" / "write" / "append" / "control"
-OWS                 = *( SP / HTAB )
+wac-allow           = "WAC-Allow" ":" OWS #access-param OWS
+access-param        = 1*ALPHA OWS "=" OWS quoted-access-modes
+quoted-access-modes = DQUOTE OWS *1(access-mode *(RWS access-mode)) OWS DQUOTE
+access-mode         = "read" / "write" / "append" / "control"
+OWS                 = *(SP / HTAB)
+RWS                 = 1*(SP / HTAB)
 ```
 
-The `access-modes` corresponds to the modes of access (`acl:Read`,
-`acl:Write`, `acl:Append`, `acl:Control`) as defined in the ACL ontology.
+The `access-mode` corresponds to the modes of access (`acl:Read`, `acl:Write`,
+`acl:Append`, `acl:Control`) as defined in the ACL ontology.
 
 Clients can discover their access privileges on a resource by making an HTTP
 `HEAD` or `GET` request on the target URL, and checking the `WAC-Allow` HTTP
-header value for `user` and `public` paramaters listing the allowed access
-modes.
+header value for `user` and `public` access paramaters listing the allowed
+access modes.
 
 [[Source](https://github.com/solid/specification/issues/171)]
 [[Source](https://github.com/solid/specification/issues/170)]


### PR DESCRIPTION
In response to the following (and possibly other) issues on the `WAC-Allow` header:

* https://github.com/solid/specification/issues/170
* https://github.com/solid/specification/issues/171
* https://github.com/solid/specification/issues/181

Future considerations:

In order for this HTTP header to be reusable by any access control system, we can consider changing the header field-name as well as the parameters and values.

Introduce new modes eg. "delete", if and when needed.

At the moment, access modes corresponds to the ones defined in the ACL ontology (also kept in context of the Web Access Control section), however, we can relax this with some editing.

There is also the alternative approach to using URIs instead of human-friendly terms for the allowed access modes. While that'd be precise it may be less flexible if access control systems change.