### PR TITLE
Created automated push to site action

### DIFF
--- a/.github/workflows/copy-to-website.yml
+++ b/.github/workflows/copy-to-website.yml
@@ -1,0 +1,19 @@
+name: Copy
+on: 
+  push:
+    branches:
+      - master
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Copy
+      uses: andstor/copycat-action@v3
+      with:
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: /.
+        dst_path: /TR/
+        dst_owner: solid
+        dst_repo_name: solidproject.org
+        exclude: .github/*
+        clean: true


### PR DESCRIPTION
Whenever someone pushes to master of the `/specification` repo, it will clone the repo's contents to `solid/solidproject.org` at the folder `/root/TR/`.

This will be a DIRECT COMMIT TO MASTER on `solid/solidproject.org`.

Note: merging this PR will begin this functionality.