### PR TITLE
Allow ACL doc discovery without acl:Control

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -563,7 +563,7 @@ left:4.5em;
 
                       <p>Servers MUST NOT directly associate more than one ACL auxiliary resource to a subject resource.</p>
 
-                      <p>To discover, read, create, or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
+                      <p>To read, create, or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
 
                       <p>A Solid server SHOULD sanity check ACL auxiliary resources upon creation or update to restrict invalid changes, such as by performing shape validation against authorization statements therein.</p>
                     </div>

--- a/protocol.html
+++ b/protocol.html
@@ -565,6 +565,8 @@ left:4.5em;
 
                       <p>To read, create, or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
 
+                      <p>Whether or not <code>acl:Control</code> is also required to *discover* an ACL auxiliary resource, is left up to the server implementer.</p>
+
                       <p>A Solid server SHOULD sanity check ACL auxiliary resources upon creation or update to restrict invalid changes, such as by performing shape validation against authorization statements therein.</p>
                     </div>
                   </section>


### PR DESCRIPTION
This is a spec change proposal.

### Practical Reason
Most current implementations of Solid allow ACL doc discovery without acl:Control.
For instance, NSS and CSS just add `.acl` and ESS adds `?ext=acl`.
It would be a lot of work (including data migration on all existing servers) to change that.

### Simplicity Reason
Using a predictable scheme makes the life of the server developer easier.
Also, reporting the `Link` header in for instance OPTIONS makes it easier
to discover if a server *supports* WAC at all, which is useful both to app
developers and to end-users of apps. You can then see "ah, there is an ACL
link but I don't have access", rather than being kept in the dark about it altogether.

### Reasons against it
* If the ACL doc URL is predictable, there is a real risk that app developers skip
the discovery and just guess it. However, now that different servers already
use different schemes, I don't think many app developers will do this anymore.

* If the ACL doc URL is predictable, it might give an attacker a leg up (help them
overcome the first barrier). The could then for instance try to brute-force their
way into the ACL doc. However, if they can brute-force their way into `acl:Control`
then they would maybe also be able to use that technique to break the barrier to
discovery.