### PR TITLE
reduce requirements on acl:Control to edit and create

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -563,7 +563,7 @@ left:4.5em;
 
                       <p>Servers MUST NOT directly associate more than one ACL auxiliary resource to a subject resource.</p>
 
-                      <p>To modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
+                      <p>To createe or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
 
                       <p>A Solid server SHOULD sanity check ACL auxiliary resources upon creation or update to restrict invalid changes, such as by performing shape validation against authorization statements therein.</p>
                     </div>

--- a/protocol.html
+++ b/protocol.html
@@ -563,7 +563,7 @@ left:4.5em;
 
                       <p>Servers MUST NOT directly associate more than one ACL auxiliary resource to a subject resource.</p>
 
-                      <p>To discover, read, create, or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
+                      <p>To modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
 
                       <p>A Solid server SHOULD sanity check ACL auxiliary resources upon creation or update to restrict invalid changes, such as by performing shape validation against authorization statements therein.</p>
                     </div>

--- a/protocol.html
+++ b/protocol.html
@@ -563,7 +563,7 @@ left:4.5em;
 
                       <p>Servers MUST NOT directly associate more than one ACL auxiliary resource to a subject resource.</p>
 
-                      <p>To createe or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
+                      <p>To create or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
 
                       <p>A Solid server SHOULD sanity check ACL auxiliary resources upon creation or update to restrict invalid changes, such as by performing shape validation against authorization statements therein.</p>
                     </div>


### PR DESCRIPTION
The ACL ontology states:

```Turtle
  acl:Control     a :Class;
         :comment "Allows read/write access to the ACL for the resource(s)";
         :label "control"@en;
         :subClassOf acl:Access .
```

This clearly gives read/write access to the controller. But that is different from disallowing read access to anyone else, which is what the removed text stated. 

There are use cases for making ACLs readable in order to guarantee [privacy of the client](https://solid.github.io/authorization-panel/authorization-ucr/#uc-minimalcredentials). There are ways to extend ACL so that ACLs become readable, see [ACLs on ACLs](https://github.com/solid/authorization-panel/issues/189), and this is also needed by ACP. 
Having the default be as it currently is specified in WAC that ACLs be only visible to those who control them, when no other information is available, is a default choice that makes sense. But closing doors to valid use cases that would allow such extensions is not justifiable.

     