### PR TITLE
Clarify discovery, reading, and writing auxiliary resources

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -562,10 +562,6 @@ left:4.5em;
                       <p>An auxiliary resource of type <em>Web Access Control</em> provides access control description of a subject resource (<a href="#web-access-control">Web Access Control</a>).</p>
 
                       <p>Servers MUST NOT directly associate more than one ACL auxiliary resource to a subject resource.</p>
-
-                      <p>To discover, read, create, or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
-
-                      <p>A Solid server SHOULD sanity check ACL auxiliary resources upon creation or update to restrict invalid changes, such as by performing shape validation against authorization statements therein.</p>
                     </div>
                   </section>
 
@@ -576,9 +572,7 @@ left:4.5em;
 
                       <p>Servers MUST NOT directly associate more than one description resource to a subject resource.</p>
 
-                      <p>To create or modify a description resource, an <code>acl:agent</code> MUST have <code>acl:Write</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
-
-                      <p>To discover or read a description resource, an <code>acl:agent</code> MUST have <code>acl:Read</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>
+                      <p>When a HTTP request targets a description resource, the server MUST apply the authorization policy that is used for the subject resource that the description resource is associated with.</p>
 
                       <p>Clients can discover resources that are described by description resources by making an HTTP <code>HEAD</code> or <code>GET</code> request on the target URL, and checking the HTTP <code>Link</code> header with a <code>rel</code> value of <code>describes</code> (inverse of the <code>describedby</code> relation) [<cite><a class="bibref" href="#bib-rfc6892">RFC6892</a></cite>].</p>
                     </div>

--- a/protocol.html
+++ b/protocol.html
@@ -572,7 +572,7 @@ left:4.5em;
 
                       <p>Servers MUST NOT directly associate more than one description resource to a subject resource.</p>
 
-                      <p>When a HTTP request targets a description resource, the server MUST apply the authorization policy that is used for the subject resource that the description resource is associated with.</p>
+                      <p>When an HTTP request targets a description resource, the server MUST apply the authorization policy that is used for the subject resource with which the description resource is associated.</p>
 
                       <p>Clients can discover resources that are described by description resources by making an HTTP <code>HEAD</code> or <code>GET</code> request on the target URL, and checking the HTTP <code>Link</code> header with a <code>rel</code> value of <code>describes</code> (inverse of the <code>describedby</code> relation) [<cite><a class="bibref" href="#bib-rfc6892">RFC6892</a></cite>].</p>
                     </div>


### PR DESCRIPTION
This PR introduces minimal changes necessary to clarify discovery, reading and writing of ACL and Description resources (specifically under Auxiliary Resources) - to be consistent with the rest of the Protocol. Further re-organisation of content is left for future PRs.

The PR also address the key concerns raised in PRs https://github.com/solid/specification/pull/248 and https://github.com/solid/specification/pull/250 . If accepted and merged, then those two PRs should be closed immediately.

---

Access controls that are required to read-write ACL resources are specified by the WAC specification. The outer Protocol - in this case the Auxiliary Resources section - must take care to not introduce potential confusion or conflicts.

As it stands, access controls required to read-write Resource Descriptions are specified in the Auxiliary Resource section.

---

On the removal of line:

>                      <p>To discover, read, create, or modify an ACL auxiliary resource, an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>

As per ACL Ontology: having Control access on a subject resource allows an agent to Read and Write the ACL resource that's associated with it. The text "read, create, or modify" is redundant and should be avoided.

---

WAC currently does not specify access controls needed for the discovery of an ACL resource via the subject resource it is associated with (ie. Link rel=acl). However, the discovery of a ACL resource associated with the subject resource is already described in the Auxiliary Resources section, and currently relies on Read rights:

>Clients can discover auxiliary resources associated with a subject resource by making an HTTP <code>HEAD</code> or <code>GET</code> request on the target URL, and checking the HTTP <code>Link</code> header with the <code>rel</code> parameter [<cite><a class="bibref" href="#bib-rfc8288">RFC8288</a></cite>].

It alludes to server including the Link header to allow a client to discover the ACL resource when agent has Read access on the subject resource.

Aside: It is still possible to specify the inclusion of the Link header also part of 4xx responses, but this is left for a future PR.

---

On the removal of line:

>                      <p>A Solid server SHOULD sanity check ACL auxiliary resources upon creation or update to restrict invalid changes, such as by performing shape validation against authorization statements therein.</p>

The WAC spec will cover this in detail.

---

On modifying the lines for creating, modifying, discovering, reading description resources:

>                      <p>To create or modify a description resource, an <code>acl:agent</code> MUST have <code>acl:Write</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>

>                      <p>To discover or read a description resource, an <code>acl:agent</code> MUST have <code>acl:Read</code> privileges per the <a href="https://github.com/solid/web-access-control-spec#acl-inheritance-algorithm">ACL inheritance algorithm</a> on the resource directly associated with it.</p>

The change simply states that access privileges on description resources come from subject resource's.

For discovery, same reason as earlier when a client can observe the link relation targeting an auxiliary resource. At this time, the commonality is that Read is required on the subject resource for the purpose of discovery.