### PR TITLE
Add Inbox Discovery on Client Error

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -688,6 +688,29 @@ left:4.5em;
               <p>A Solid server MUST conform to the LDN specification by implementing the Receiver parts to receive notifications and make Inbox contents available [<cite><a class="bibref" href="#bib-ldn">LDN</a></cite>].</p>
 
               <p>A Solid client MUST conform to the LDN specification by implementing the Sender or Consumer parts to discover the location of a resource’s Inbox, and to send notifications to an Inbox or to retrieve the contents of an Inbox [<cite><a class="bibref" href="#bib-ldn">LDN</a></cite>].</p>
+
+              <section id="inbox-discovery-client-error" inlist="" rel="schema:hasPart" resource="#inbox-discovery-client-error">
+                <h3 property="schema:name">Inbox Discovery on Client Error</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>This section extends the LDN protocol to allow the discovery of the Inbox URL of a target resource on client errors (HTTP responses with <code>4xx</code> status codes) [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>][<cite><a class="bibref" href="#bib-ldn">LDN</a></cite>].</p>
+
+                  <p>Servers who want to advertise the Inbox URL in a HTTP response with a <code>4xx</code> status code, <code>MUST</code> do one of the following:</p>
+
+                  <ul>
+                    <li>include the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
+                    <li>include an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is target and the object is the Inbox.</li>
+                  </ul>
+
+                  <p>Senders and consumers do the following to discover the Inbox URL in a HTTP response with a <code>4xx</code> status code:</p>
+
+                  <ul>
+                    <li>use the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
+                    <li>parse an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is target and the object is the Inbox.</li>
+                  </ul>
+
+                  <p>These may be carried out in either order, but if the first fails to result in an Inbox the second MUST be tried.</p>
+                </div>
+              </section>
             </div>
           </section>
 

--- a/protocol.html
+++ b/protocol.html
@@ -701,7 +701,7 @@ left:4.5em;
                     <li>Return an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is the target resource and the object is the Inbox.</li>
                   </ul>
 
-                  <p>Senders do the following to discover the Inbox URL in a HTTP response with a <code>4xx</code> status code:</p>
+                  <p>Senders do the following to discover the Inbox URL in an HTTP response with a <code>4xx</code> status code:</p>
 
                   <ul>
                     <li>Use the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>

--- a/protocol.html
+++ b/protocol.html
@@ -694,7 +694,7 @@ left:4.5em;
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>This section extends the LDN protocol to allow the discovery of the Inbox URL of a target resource on client errors (HTTP responses with <code>4xx</code> status codes) [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>][<cite><a class="bibref" href="#bib-ldn">LDN</a></cite>].</p>
 
-                  <p>Servers who want to advertise the Inbox URL in a HTTP response with a <code>4xx</code> status code, <code>MUST</code> do one of the following:</p>
+                  <p>Servers who want to advertise the Inbox URL in an HTTP response with a <code>4xx</code> status code, <code>MUST</code> do one of the following:</p>
 
                   <ul>
                     <li>Include the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>

--- a/protocol.html
+++ b/protocol.html
@@ -694,7 +694,7 @@ left:4.5em;
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>This section extends the LDN protocol to allow the discovery of the Inbox URL of a target resource on client errors (HTTP responses with <code>4xx</code> status codes) [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>][<cite><a class="bibref" href="#bib-ldn">LDN</a></cite>].</p>
 
-                  <p>Servers who want to advertise the Inbox URL in an HTTP response with a <code>4xx</code> status code, <code>MUST</code> do one of the following:</p>
+                  <p>Servers who want to advertise the Inbox URL in an HTTP response with a <code>4xx</code> status code, <code>MUST</code> do only one of the following:</p>
 
                   <ul>
                     <li>Include the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>

--- a/protocol.html
+++ b/protocol.html
@@ -709,6 +709,17 @@ left:4.5em;
                   </ul>
 
                   <p>These may be carried out in either order, but if the first fails to result in an Inbox the second MUST be tried.</p>
+
+                  <figure class="listing example" id="discovery-put-example-403" rel="schema:hasPart" resource="#discovery-turtle-example-webid">
+                    <p class="example-h">Discovery example: Client error</p>
+                    <pre about="#discovery-put-example-403" property="schema:description" typeof="fabio:Script"><code>PUT /article HTTP/1.1</code>
+<code>Host: example.org</code>
+<code>Content-Type: text/html;charset=utf-8</code>
+<code></code>
+<code>HTTP/1.1 403 Forbidden</code>
+<code>Link: &lt;http://example.org/inbox/&gt; rel="http://www.w3.org/ns/ldp#inbox"</code></pre>
+                    <figcaption>Discovering an Inbox in the response of a rejected request.</figcaption>
+                  </figure>
                 </div>
               </section>
             </div>

--- a/protocol.html
+++ b/protocol.html
@@ -698,14 +698,14 @@ left:4.5em;
 
                   <ul>
                     <li>include the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
-                    <li>include an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is target and the object is the Inbox.</li>
+                    <li>return an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is the target resource and the object is the Inbox.</li>
                   </ul>
 
-                  <p>Senders and consumers do the following to discover the Inbox URL in a HTTP response with a <code>4xx</code> status code:</p>
+                  <p>Senders do the following to discover the Inbox URL in a HTTP response with a <code>4xx</code> status code:</p>
 
                   <ul>
                     <li>use the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
-                    <li>parse an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is target and the object is the Inbox.</li>
+                    <li>parse an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is the target resource and the object is the Inbox.</li>
                   </ul>
 
                   <p>These may be carried out in either order, but if the first fails to result in an Inbox the second MUST be tried.</p>

--- a/protocol.html
+++ b/protocol.html
@@ -697,8 +697,8 @@ left:4.5em;
                   <p>Servers who want to advertise the Inbox URL in a HTTP response with a <code>4xx</code> status code, <code>MUST</code> do one of the following:</p>
 
                   <ul>
-                    <li>include the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
-                    <li>return an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is the target resource and the object is the Inbox.</li>
+                    <li>Include the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
+                    <li>Return an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is the target resource and the object is the Inbox.</li>
                   </ul>
 
                   <p>Senders do the following to discover the Inbox URL in a HTTP response with a <code>4xx</code> status code:</p>

--- a/protocol.html
+++ b/protocol.html
@@ -704,8 +704,8 @@ left:4.5em;
                   <p>Senders do the following to discover the Inbox URL in a HTTP response with a <code>4xx</code> status code:</p>
 
                   <ul>
-                    <li>use the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
-                    <li>parse an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is the target resource and the object is the Inbox.</li>
+                    <li>Use the <code>Link</code> header with a <code>rel</code> value of <code>http://www.w3.org/ns/ldp#inbox</code>.</li>
+                    <li>Parse an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/ldp#inbox</code>. The subject of that relation is the target resource and the object is the Inbox.</li>
                   </ul>
 
                   <p>These may be carried out in either order, but if the first fails to result in an Inbox the second MUST be tried.</p>


### PR DESCRIPTION
When a server responds with a client error (4xx), it can also enable clients to attempt to resolve the error by providing contact information. (See for example RFC 7231 https://tools.ietf.org/html/rfc7231#section-3.3 suggestion on next steps to resolve the error.)

This PR extends the LDN protocol to allow the discovery of the Inbox URL of a target resource when a client error occurs.

Not all 4xx responses are necessarily meaningful to advertise the Inbox URL. This is left to the discretion of the server. However, there are use cases that appear to be suitable for 401, 402, 403, 407, 410, 418, 423, 429, 451 (and possibly others). For instance, when clients encounter 401 or 403, the next steps to inquire the right credentials or request access to resources was previously discussed. This PR meets the Protocol needs of eg. https://github.com/solid/node-solid-server/issues/992 , https://github.com/solid/solid/issues/229 , https://github.com/solid/web-access-control-spec/issues/40 , https://github.com/solid/web-access-control-spec/issues/21 , https://github.com/solid/data-interoperability-panel/issues/13 , https://github.com/solid/authorization-panel/pull/28 .

---

Inbox discovery on client error may complement structured error messages eg. https://github.com/solid/specification/issues/28 .

---

Specifying inbox discovery on client errors could be in a different document because it is not tied to the Solid Protocol eg. LDNx spec of sorts that may cover the other items in https://github.com/solid/data-interoperability-panel/issues/13#issue-483343099 , but until a more suitable is needed, I suggest to keep it in the Solid Protocol.