### PR TITLE
Add server Cache-Control requirement forcing revalidation

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -413,6 +413,8 @@ left:4.5em;
                   <p>A data pod MUST implement the server part of <cite>HTTP/1.1 Authentication</cite> [<cite><a class="bibref" href="#bib-rfc7235">RFC7235</a></cite>]. When a client does not provide valid credentials when requesting a resource that requires it (see <a href="#webid">WebID</a>), the data pod MUST send a response with a <code>401</code> status code (unless <code>404</code> is preferred for security reasons).</p>
 
                   <p>A Solid server MUST reject <code>PUT</code>, <code>POST</code> and <code>PATCH</code> requests without the <code>Content-Type</code> header with a status code of <code>400</code>. [<a href="https://github.com/solid/specification/issues/70#issuecomment-547924171" rel="cito:citesAsSourceDocument">Source</a>]</p>
+
+                  <p>When a server includes the <code>ETag</code> and/or <code>Last-Modified</code> headers, the server MUST include the <code>Cache-Control</code> header with the <code>no-cache</code> (alternative: <code>must-revalidate, max-age=0</code>) directive. In addition, for resources fetched with authentication, the server MUST include the <code>private</code> directive.</code>
                 </div>
               </section>
 


### PR DESCRIPTION
The requirement in this PR is a finding that was brought forward by @acoburn @Vinnl and co based on implementation experience. I hope it is captured accurately but this is why we have reviews :)

The requirement here supports browsers caching resources locally, but when re-fetching them, it will send conditional requests (If-None-Match, etc). A 304 Not Modified response allows the local browser cache to use the cached data, so the browser can avoid the network costs of re-transferring the data. If, however, the resource has changed, the new representation will be transferred, which is what an app would expect.

As per the Protocol, clients MAY implement RFC 7232. So, this is definitely something they can take advantage of -- and arguably shouldn't miss out out. The hard requirement (MUST) is set on servers so that all clients can take advantage of an intelligent caching strategy.

Feedback including direct experience with client/server behaviour can help a great detail. Some of the details involved here may be subtle and not always immediately apparent to server implementers... considering walking the fine balance between RFC7272, RFC7234.. and implementations in the wild.