### PR TITLE
Add notion of "owner" and requirements

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -334,6 +334,8 @@ left:4.5em;
 
                   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" id="solid-app">Solid app</dfn> is an application that reads or writes data from one or more <a data-link-type="dfn" href="#data-pod" id="ref-for-data-pod">data pods</a>.</p>
 
+                  <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" id="owner">owner</dfn> is a person or a social entity identified by a URI that has implicit control of a data pod.</p>
+
                   <p>A <dfn data-dfn-type="dfn" id="read-operation">read operation</dfn> entails that information about a resource’s existence or its description can be known. [<a href="https://github.com/solid/specification/issues/149#issue-568433265" rel="cito:citesAsSourceDocument">Source</a>]</p>
 
                   <p>A <dfn data-dfn-type="dfn" id="write-operation">write operation</dfn> entails that information about resources can be created or removed. [<a href="https://github.com/solid/specification/issues/126#issuecomment-569920473" rel="cito:citesAsSourceDocument">Source</a>]</p>
@@ -434,6 +436,8 @@ left:4.5em;
           <section id="uri" inlist="" rel="schema:hasPart" resource="#uri">
             <h2 property="schema:name">Uniform Resource Identifier</h2>
             <div datatype="rdf:HTML" property="schema:description">
+              <p class="note" role="note"><span>Note</span>: This specification does not describe the relationship between a Solid data pod <q>owner</q> and Web architecture’s <cite><a href="https://www.w3.org/TR/webarch/#uri-ownership">URI ownership</a></cite> [<cite><a class="bibref" href="#bib-webarch">WEBARCH</a></cite>].</p>
+
               <section id="uri-slash-semantics" inlist="" rel="schema:hasPart" resource="#uri-slash-semantics">
                 <h3 property="schema:name">URI Slash Semantics</h3>
                 <div datatype="rdf:HTML" property="schema:description">
@@ -475,6 +479,14 @@ left:4.5em;
                   <p>Clients can discover a storage by making an HTTP <code>GET</code> request on the target URL to retrieve an RDF representation [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>], whose encoded RDF graph contains a relation of type <code>http://www.w3.org/ns/pim/space#storage</code>. The object of the relation is the storage (<code>pim:Storage</code>).</p>
 
                   <p>[<a href="https://github.com/solid/data-interoperability-panel/issues/10#issuecomment-598694029" rel="cito:citesAsSourceDocument">Source</a>] [<a href="https://github.com/solid/specification/issues/153#issuecomment-624630022" rel="cito:citesAsSourceDocument">Source</a>]</p>
+
+                  <p>Servers MUST keep track at least one <a data-link-type="dfn" href="#owner" id="ref-for-owner">owner</a> of a storage in an implementation defined way. The owner is first set at storage provisioning time and can be changed. The owner is allowed implicit control access on every resource in a storage.</p>
+
+                  <p>When a server wants to advertise the owner of a storage, the server MUST include the <code>Link</code> header with <code>rel="http://www.w3.org/ns/solid/terms#owner"</code> targeting the URI of the owner in the response of HTTP <code>HEAD</code> or <code>GET</code> requests targeting the root container.</p>
+
+                  <p class="note" role="note"><span>Note</span>: When a server supports multiple storages, there must be complete trust between its owners.</p>
+
+                  <p>[<a href="https://github.com/solid/specification/issues/67" rel="cito:citesAsSourceDocument">Source</a>][<a href=" https://github.com/solid/specification/issues/132" rel="cito:citesAsSourceDocument">Source</a>][<a href="https://github.com/solid/specification/issues/153" rel="cito:citesAsSourceDocument">Source</a>][<a href="https://github.com/solid/specification/issues/197" rel="cito:citesAsSourceDocument">Source</a>]</p>
 
                   <p>When using Web Access Control (<a href="#web-access-control">Web Access Control</a>):</p>
 

--- a/protocol.html
+++ b/protocol.html
@@ -334,7 +334,7 @@ left:4.5em;
 
                   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" id="solid-app">Solid app</dfn> is an application that reads or writes data from one or more <a data-link-type="dfn" href="#data-pod" id="ref-for-data-pod">data pods</a>.</p>
 
-                  <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" id="owner">owner</dfn> is a person or a social entity identified by a URI that has implicit control of a data pod.</p>
+                  <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" id="owner">owner</dfn> is a person or a social entity that is considered to have the rights and responsibilities of a data storage. An owner is identified by a URI, and implicitly has control over all data in a storage. An owner is first set at storage provisioning time and can be changed.</p>
 
                   <p>A <dfn data-dfn-type="dfn" id="read-operation">read operation</dfn> entails that information about a resource’s existence or its description can be known. [<a href="https://github.com/solid/specification/issues/149#issue-568433265" rel="cito:citesAsSourceDocument">Source</a>]</p>
 
@@ -480,7 +480,7 @@ left:4.5em;
 
                   <p>[<a href="https://github.com/solid/data-interoperability-panel/issues/10#issuecomment-598694029" rel="cito:citesAsSourceDocument">Source</a>] [<a href="https://github.com/solid/specification/issues/153#issuecomment-624630022" rel="cito:citesAsSourceDocument">Source</a>]</p>
 
-                  <p>Servers MUST keep track at least one <a data-link-type="dfn" href="#owner" id="ref-for-owner">owner</a> of a storage in an implementation defined way. The owner is first set at storage provisioning time and can be changed. The owner is allowed implicit control access on every resource in a storage.</p>
+                  <p>Servers MUST keep track of at least one <a data-link-type="dfn" href="#owner" id="ref-for-owner">owner</a> of a storage in an implementation defined way.</p>
 
                   <p>When a server wants to advertise the owner of a storage, the server MUST include the <code>Link</code> header with <code>rel="http://www.w3.org/ns/solid/terms#owner"</code> targeting the URI of the owner in the response of HTTP <code>HEAD</code> or <code>GET</code> requests targeting the root container.</p>
 


### PR DESCRIPTION
Hello Reviewers,

In response to the following (and possibly other) issues on the notion of "owner":

* https://github.com/solid/specification/issues/67
* https://github.com/solid/specification/issues/132
* https://github.com/solid/specification/issues/153
* https://github.com/solid/specification/issues/197

If describing the relationship between Solid data pod / storage "owner" and AWWW's "URI ownership" is required, it can be done in another PR.

On merge of this PR, a follow-up PR will be made to the https://github.com/solid/vocab/ repository requesting to add and define the term "owner" in the Solid Terms vocabulary: `http://www.w3.org/ns/solid/terms#owner`. Proposal (derived from http://www.w3.org/ns/auth/acl#owner ):

```turtle
solid:owner
    a rdf:Property ;
    dc:issued "2021-05-19"^^xsd:date ;
    rdfs:comment "The person or other agent which owns the data storage. For example, the owner has implicit control of a data storage."@en ;
    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
    rdfs:range foaf:Agent ;
    rdfs:label "owner"@en .
```