### PR TITLE
Fix a defunct link to Shape Trees specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ border-bottom: 2pt solid #000;
                     <td><time datetime="2021-06-30">2021-06-30</time></td>
                   </tr>
                   <tr>
-                    <td><a href="https://shapetrees.github.io/specification/spec" rel="cito:citesForInformation">Shape Trees</a></td>
+                    <td><a href="https://shapetrees.org/TR/specification/" rel="cito:citesForInformation">Shape Trees</a></td>
                     <td><a href="https://github.com/shapetrees/specification">https://github.com/shapetrees/specification</a></td>
                     <td>Editor’s Draft</td>
                     <td>Ecosystem Proposal</td>


### PR DESCRIPTION
## Issue
[The link to Shape Trees Specification in Solid Spec index](https://solidproject.org/TR/#work-item-technical-reports) leads to 404.

## Fix
https://shapetrees.github.io/specification/spec --> https://shapetrees.org/TR/specification/

## Unrelated
There also seems to exist a [Shape Trees Primer](https://shapetrees.org/TR/primer/), which is not (yet) included in the same [list of specs and primers in Solid Spec](https://solidproject.org/TR/#work-item-technical-reports).