### PR TITLE
Editorial: update with the WAC spec as authoritative

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -154,7 +154,7 @@ left:4.5em;
     <main>
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Solid Protocol</h1>
-        <h2>Editor’s Draft, 2021-06-16</h2>
+        <h2>Editor’s Draft, 2021-07-07</h2>
 
         <dl id="document-identifier">
           <dt>This version</dt>
@@ -185,7 +185,7 @@ left:4.5em;
 
         <dl id="document-modified">
           <dt>Modified</dt>
-          <dd><time content="2021-06-16T00:00:00Z" datatype="xsd:dateTime" datetime="2021-06-16T00:00:00Z" property="schema:dateModified">2021-06-16</time></dd>
+          <dd><time content="2021-07-07T00:00:00Z" datatype="xsd:dateTime" datetime="2021-07-07T00:00:00Z" property="schema:dateModified">2021-07-07</time></dd>
         </dl>
 
         <dl id="document-repository">
@@ -487,12 +487,6 @@ left:4.5em;
                   <p class="note" role="note"><span>Note</span>: When a server supports multiple storages, there must be complete trust between its owners.</p>
 
                   <p>[<a href="https://github.com/solid/specification/issues/67" rel="cito:citesAsSourceDocument">Source</a>][<a href=" https://github.com/solid/specification/issues/132" rel="cito:citesAsSourceDocument">Source</a>][<a href="https://github.com/solid/specification/issues/153" rel="cito:citesAsSourceDocument">Source</a>][<a href="https://github.com/solid/specification/issues/197" rel="cito:citesAsSourceDocument">Source</a>]</p>
-
-                  <p>When using Web Access Control (<a href="#web-access-control">Web Access Control</a>):</p>
-
-                  <p>The root container (<code>pim:Storage</code>) MUST have an ACL auxiliary resource directly associated to it. The associated ACL document MUST include an authorization policy with <code>acl:Control</code> access privilege.</p>
-
-                  <p>[<a href="https://github.com/solid/specification/issues/197#issuecomment-699937520" rel="cito:citesAsSourceDocument">Source</a>]</p>
                 </div>
               </section>
 
@@ -510,15 +504,13 @@ left:4.5em;
               <section id="auxiliary-resources" inlist="" rel="schema:hasPart" resource="#auxiliary-resources">
                 <h3 property="schema:name">Auxiliary Resources</h3>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p>Solid has the notion of <em>auxiliary resources</em> to provide supplementary information such as descriptive metadata, authorization policies, data shape constraints, digital rights or provenance record about a given resource (hereafter referred as the <em>subject resource</em>), and affects how resources and others associated with it are processed, served or interpreted.</p>
+                  <p>Solid has the notion of <em>auxiliary resources</em> to provide supplementary information such as descriptive metadata, authorization conditions, data shape constraints, digital rights or provenance record about a given resource (hereafter referred as the <em>subject resource</em>), and affects how resources and others associated with it are processed, served or interpreted.</p>
 
-                  <p>Auxiliary resources are represented as <em>RDF document</em>s [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>].</p>
+                  <p>Server manages the association between a subject resource and auxiliary resources defined by this specification. The lifecycle of auxiliary resources defined by this specification depend on the lifeycle of the subject resource that they are associated with.</p>
+
+                  <p>Auxiliary resources are represented as <em>RDF document</em>s [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>]. HTTP interactions on auxiliary resources are subject to the requirements as per <cite><a href="#reading-writing-resources">Reading and Writing Resources</a></cite>.</p>
 
                   <p class="note" role="note"><span>Note:</span> Where applicable, to promote <a href="https://www.w3.org/2001/tag/doc/selfDescribingDocuments">self-describing resources</a>, implementations and authors are encouraged to use the subject resource instead of the associated auxiliary resource.</p>
-
-                  <p>Servers exposing auxiliary resources that are defined by this specification MUST have the same "origin" for both the resource and the associated auxiliary resource [<cite><a class="bibref" href="#bib-rfc6454">RFC6454</a></cite>].</p>
-
-                  <p>As per <a href="#deleting-resources">Deleting Resources</a>, the lifecycle of auxiliary resources defined by this specification depend on the lifecycle of the subject resource.</p>
 
                   <p>This specification defines the following types of auxiliary resources:</p>
 
@@ -557,6 +549,7 @@ left:4.5em;
 
                             <ul>
                               <li><code>http://www.w3.org/ns/auth/acl#accessControl</code></li>
+                              <li><code>https://www.w3.org/ns/iana/link-relations/relation#acl</code></li>
                               <li><code>https://www.w3.org/ns/iana/link-relations/relation#describedby</code></li>
                               <li><code>https://www.w3.org/ns/iana/link-relations/relation#describes</code></li>
                             </ul>
@@ -572,8 +565,6 @@ left:4.5em;
                     <h4 property="schema:name">Web Access Control</h4>
                     <div datatype="rdf:HTML" property="schema:description">
                       <p>An auxiliary resource of type <em>Web Access Control</em> provides access control description of a subject resource (<a href="#web-access-control">Web Access Control</a>).</p>
-
-                      <p>Servers MUST NOT directly associate more than one ACL auxiliary resource to a subject resource.</p>
                     </div>
                   </section>
 
@@ -584,7 +575,7 @@ left:4.5em;
 
                       <p>Servers MUST NOT directly associate more than one description resource to a subject resource.</p>
 
-                      <p>When an HTTP request targets a description resource, the server MUST apply the authorization policy that is used for the subject resource with which the description resource is associated.</p>
+                      <p>When an HTTP request targets a description resource, the server MUST apply the authorization rule that is used for the subject resource with which the description resource is associated.</p>
 
                       <p>Clients can discover resources that are described by description resources by making an HTTP <code>HEAD</code> or <code>GET</code> request on the target URL, and checking the HTTP <code>Link</code> header with a <code>rel</code> value of <code>describes</code> (inverse of the <code>describedby</code> relation) [<cite><a class="bibref" href="#bib-rfc6892">RFC6892</a></cite>].</p>
                     </div>
@@ -649,10 +640,6 @@ left:4.5em;
                   <p>Clients MAY use the HTTP <code>If-None-Match</code> header with a value of <code>"*"</code> to prevent an unsafe request method (e.g., <code>PUT</code>, <code>PATCH</code>) from inadvertently modifying an existing representation of the target resource when the client believes that the resource does not have a current representation. [<a href="https://github.com/solid/specification/issues/108#issuecomment-567272797" rel="cito:citesAsSourceDocument">Source</a>] [<a href="https://github.com/solid/specification/issues/40#issuecomment-566995240" rel="cito:citesAsSourceDocument">Source</a>]</p>
 
                   <p>Servers MAY use the HTTP <code>ETag</code> header with a strong validator for RDF bearing representations in order to encourage clients to opt-in to using the <code>If-Match</code> header in their requests.</p>
-
-                  <p>When using Web Access Control (<a href="#web-access-control">Web Access Control</a>):</p>
-
-                  <p>To create or update an ACL resource (see <a href="#auxiliary-resources-web-access-control">Web Access Control</a>), an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the ACL inheritance algorithm on the resource directly associated with it. [<a href="https://github.com/solid/specification/issues/42#issuecomment-616688848" rel="cito:citesAsSourceDocument">Source</a>]</p>
                 </div>
               </section>
 
@@ -669,17 +656,11 @@ left:4.5em;
 
                   <p>When a <code>DELETE</code> request is made to a container, the server MUST delete the container if it contains no resources. If the container contains resources, the server MUST respond with the <code>409</code> status code and response body describing the error. [<a href="https://github.com/solid/specification/pull/187/files/b7426e95a1613e08195a853a4d0a403b7030f494#r447130915" rel="cito:citesAsSourceDocument">Source</a>]</p>
 
-                  <p>When using Web Access Control (<a href="#web-access-control">Web Access Control</a>):</p>
-
-                  <p>To delete a resource, an <code>acl:agent</code> MUST have <code>acl:Write</code> privilege per the ACL inheritance algorithm on the resource and the containing container. [<a href="https://github.com/solid/specification/issues/197" rel="cito:citesAsSourceDocument">Source</a>]</p> <p>To delete an ACL resource (see <a href="#auxiliary-resources-web-access-control">Web Access Control</a>), an <code>acl:agent</code> MUST have <code>acl:Control</code> privileges per the ACL inheritance algorithm on the resource directly associated with it. [<a href="https://github.com/solid/specification/issues/145" rel="cito:citesAsSourceDocument">Source</a>]</p>
-
                   <p><em>This section is non-normative.</em></p>
 
                   <p>The server might perform additional actions, as described in the normative references like [<cite><a class="bibref" href="#bib-rfc7231">RFC7231</a></cite>]. For example, the server could remove membership triples referring to the deleted resource, perform additional cleanup tasks for resources it knows are no longer referenced or have not been accessed for some period of time, and so on.</p>
 
                   <p>Subsequent <code>GET</code> requests to the deleted resource usually result in a <code>404</code> or <code>410</code> status code, although HTTP allows others. [<a href="https://github.com/solid/specification/issues/72" rel="cito:citesAsSourceDocument">Source</a>] [<a href="https://github.com/solid/specification/issues/46" rel="cito:citesAsSourceDocument">Source</a>]</p>
-
-                  <p>As deleted resources can be reinstated with the same URI, access controls on the reinstated resource can change per the ACL inheritance algorithm. [<a href="https://github.com/solid/specification/issues/145#issuecomment-618918284" rel="cito:citesAsSourceDocument">Source</a>]</p>
 
                   <p class="issue">Pertaining to events and loss of control mitigation: https://github.com/solid/specification/issues/41#issuecomment-534679278</p>
                 </div>
@@ -729,9 +710,9 @@ left:4.5em;
             <div datatype="rdf:HTML" property="schema:description">
               <p><a data-link-type="dfn" href="#solid-app" id="ref-for-solid-app">Solid apps</a> typically access data from multiple sources. However, Web browsers by default prevent apps that run on one origin from accessing data on other origins. This cross-origin protection is a security mechanism that ensures malicious websites cannot simply read your profile or banking details from other websites. However, this reasonable default poses a problem even for benevolent Solid apps, which might have good reasons to access data from different places. For instance, a Solid app at <code>https://app.example/</code> would be prevented from accessing data on <code>https://guinan.example/</code> or <code>https://darmok.example/</code>, even when Guinan and Darmok have given the user of the app their permission to see some of their data.</p>
 
-              <p>For cases where the other origins have their own access protection mechanism — <a href="#web-access-control">like within Solid</a> — the browser’s built-in cross-origin protection is actually an obstacle rather than a feature. After all, <a data-link-type="dfn" href="#data-pod" id="ref-for-data-pod②">data pods</a> already ensure through access control that certain documents can only be accessed by specific people or applications. Preventively blocking apps from different origins thus introduces an unnecessary barrier.</p>
+              <p>For cases where the other origins have their own access protection mechanism — <a href="#authorization">like within Solid</a> — the browser’s built-in cross-origin protection is actually an obstacle rather than a feature. After all, <a data-link-type="dfn" href="#data-pod" id="ref-for-data-pod②">data pods</a> already ensure through access control that certain documents can only be accessed by specific people or applications. Preventively blocking apps from different origins thus introduces an unnecessary barrier.</p>
 
-              <p>Fortunately, Web servers can indicate to the browser that certain documents do not require cross-origin protection. This mechanism to selectively disable that protection is called <em>Cross-Origin Resource Sharing</em> or <em>CORS</em> [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>]. By responding to browser requests with a specific combination of HTTP headers, servers can indicate which actions are allowed for a given resource. For a Solid data pod, the goal is to allow <em>all</em> actions on the CORS level, such that the deeper <a href="#web-access-control">access control layer</a> can exert full control over the app’s allowed permissions. The next section describes how to achieve this through the right HTTP header configuration.</p>
+              <p>Fortunately, Web servers can indicate to the browser that certain documents do not require cross-origin protection. This mechanism to selectively disable that protection is called <em>Cross-Origin Resource Sharing</em> or <em>CORS</em> [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>]. By responding to browser requests with a specific combination of HTTP headers, servers can indicate which actions are allowed for a given resource. For a Solid data pod, the goal is to allow <em>all</em> actions on the CORS level, such that the deeper <a href="#authorization">Authorization</a> layer can exert full control over the app’s allowed permissions. The next section describes how to achieve this through the right HTTP header configuration.</p>
 
               <section id="cors-server" inlist="" rel="schema:hasPart" resource="#cors-server">
                 <h3 property="schema:name">CORS Server</h3>
@@ -755,10 +736,6 @@ left:4.5em;
                 <h3 property="schema:name">WebID</h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>A <em>WebID</em> is an HTTP URI denoting an agent, for example a person, organisation, or software [<cite><a class="bibref" href="#bib-webid">WEBID</a></cite>]. When a WebID is dereferenced, server provides a representation of the WebID Profile in an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] which uniquely describes an agent denoted by a WebID. WebIDs are an underpinning component in the Solid ecosystem and are used as the primary identifier for users and applications.</p>
-
-                  <p>When using Web Access Control (<a href="#web-access-control">Web Access Control</a>):</p>
-
-                  <p>Agents accessing non-public Solid resources need to authenticate with a WebID.</p>
                 </div>
               </section>
             </div>
@@ -792,7 +769,7 @@ left:4.5em;
               <section id="web-access-control" inlist="" rel="schema:hasPart" resource="#web-access-control">
                 <h3 property="schema:name">Web Access Control</h3>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p>Web Access Control (<abbr title="Web Access Control">WAC</abbr>) is a decentralized cross-domain access control system. The WAC mechanism is concerned with giving access to agents denoted by a <a href="#webid">WebID</a> to perform various kinds of read-write operations on resources identified by URLs. The <cite><a href="http://www.w3.org/ns/auth/acl">Access Control List</a></cite> (<abbr title="Access Control List">ACL</abbr>) ontology is used to describe authorization policies about agents with modes of access on target resources.</p>
+                  <p>Web Access Control (<abbr title="Web Access Control">WAC</abbr>) is a decentralized cross-domain access control system providing a way for Linked Data systems to set authorization conditions on HTTP resources using the Access Control List (<abbr title="Access Control List">ACL</abbr>) model. Server manages the association between a resource and an ACL resource, and applies the authorization conditions on requested operations. Authorizations are described using the <cite><a href="http://www.w3.org/ns/auth/acl">ACL ontology</a></cite> to express and determine access privileges of a requested resource. Applications can discover authorization rules associated with a given resource, and to control such rules, as directed by an agent.</p>
 
                   <p>Servers MUST conform to the Web Access Control specification [<cite><a class="bibref" href="#bib-wac">WAC</a></cite>].</p>
 
@@ -922,7 +899,7 @@ access-mode      = "read" / "write" / "append" / "control"</pre>
 
                   <p>Servers are strongly discouraged from assuming that the user agent is a regular Web browser, even when requests contain familiar values in headers such as <code>User-Agent</code> or <code>Origin</code>. Such an assumption could lead to incorrect conclusions about the security model of the application making the request, since the request might actually come from a non-browser actor unaffected by browser security constraints.</p>
 
-                  <p>Servers <a href="#cors-server">disable all cross-origin protections</a> in browsers because resource access is governed explicitly by <a href="#web-access-control">Web Access Control</a>. As such, servers cannot rely on browser-based cross-origin protection mechanisms for determining the authentication status or representation of a resource. In particular, servers are strongly encouraged to ignore HTTP cookies from untrusted origins. Additional security measures can be taken to prevent metadata in error responses from leaking. For instance, a malicious application could probe multiple servers to check whether the response status code is <code>401</code> or <code>403</code>, or could try to access an error page from an intranet server within the user agent’s private network to extract company names or other data. To mitigate this, when a request from an untrusted <code>Origin</code> arrives, the server may want to set the status code of error responses to <code>404</code> and/or anonymize or censor their contents.</p>
+                  <p>Servers <a href="#cors-server">disable all cross-origin protections</a> in browsers because resource access is governed explicitly by the <a href="#authorization">Authorization</a> component. As such, servers cannot rely on browser-based cross-origin protection mechanisms for determining the authentication status or representation of a resource. In particular, servers are strongly encouraged to ignore HTTP cookies from untrusted origins. Additional security measures can be taken to prevent metadata in error responses from leaking. For instance, a malicious application could probe multiple servers to check whether the response status code is <code>401</code> or <code>403</code>, or could try to access an error page from an intranet server within the user agent’s private network to extract company names or other data. To mitigate this, when a request from an untrusted <code>Origin</code> arrives, the server may want to set the status code of error responses to <code>404</code> and/or anonymize or censor their contents.</p>
 
                   <p>Servers are encouraged to use TLS connections to protect the contents of requests and responses from eavesdropping and modification by third parties. Unsecured TCP connections without TLS may be used in testing environments or when the data pod is behind a reverse proxy that terminates a secure connection.</p>
                 </div>
@@ -1047,11 +1024,11 @@ access-mode      = "read" / "write" / "append" / "control"</pre>
                     <dt id="bib-w3c-html">[W3C-HTML]</dt>
                     <dd><a href="https://www.w3.org/TR/html/"><cite>HTML</cite></a>.  W3C. 28 January 2021. W3C Recommendation. URL: <a href="https://www.w3.org/TR/html/">https://www.w3.org/TR/html/</a></dd>
                     <dt id="bib-wac">[WAC]</dt>
-                    <dd><a href="https://solid.github.io/web-access-control-spec/"><cite>Web Access Control</cite></a>.  W3C Solid Community Group. W3C Editor's Draft. URL: <a href="https://solid.github.io/web-access-control-spec/">https://solid.github.io/web-access-control-spec/</a></dd>
+                    <dd><a href="https://solid.github.io/web-access-control-spec/"><cite>Web Access Control</cite></a>.  Sarven Capadisli.  W3C Solid Community Group. W3C Editor's Draft. URL: <a href="https://solid.github.io/web-access-control-spec/">https://solid.github.io/web-access-control-spec/</a></dd>
                     <dt id="bib-webarch">[WEBARCH]</dt>
                     <dd><a href="https://www.w3.org/TR/webarch/"><cite>Architecture of the World Wide Web, Volume One</cite></a>. Ian Jacobs; Norman Walsh.  W3C. 15 December 2004. W3C Recommendation. URL: <a href="https://www.w3.org/TR/webarch/">https://www.w3.org/TR/webarch/</a></dd>
                     <dt id="bib-webid">[WEBID]</dt>
-                    <dd><a href="https://www.w3.org/2005/Incubator/webid/spec/identity/"><cite>Web Identity and Discovery</cite></a>. W3C Editor's Draft. URL: <a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">https://www.w3.org/2005/Incubator/webid/spec/identity/</a></dd>
+                    <dd><a href="https://www.w3.org/2005/Incubator/webid/spec/identity/" rel="citesAsAuthority"><cite>WebID 1.0</cite></a>. Henry Story; Andrei Sambra; Stéphane Corlosquet.  W3C Editor’s Draft. URL: <a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">https://www.w3.org/2005/Incubator/webid/spec/identity/</a></dd>
                   </dl>
                 </div>
               </section>


### PR DESCRIPTION
Created this PR for visibility. Will merge as it is deemed to be an editorial follow-up of WAC ED: https://github.com/solid/web-access-control-spec/pull/83 .

Note: although the WAC ED includes the `acl` link relation type and the `wac-allow` header definitions, I've intentionally kept them in the Protocol. Will followup in WAC ED and specify how it uses those definitions.