### PR TITLE
Adjust URL for Solid-OIDC specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,8 +126,8 @@ border-bottom: 2pt solid #000;
 
                 <tbody>
                   <tr>
-                    <td><a href="https://solid.github.io/authentication-panel/solid-oidc/" rel="cito:citesForInformation">Solid OIDC</a></td>
-                    <td><a href="https://github.com/solid/authentication-panel">https://github.com/solid/authentication-panel</a></td>
+                    <td><a href="https://solid.github.io/solid-oidc/" rel="cito:citesForInformation">Solid OIDC</a></td>
+                    <td><a href="https://github.com/solid/solid-oidc">https://github.com/solid/solid-oidc</a></td>
                     <td>Editor’s Draft</td>
                     <td>Ecosystem Proposal</td>
                     <td>Community Report</td>
@@ -169,8 +169,8 @@ border-bottom: 2pt solid #000;
 
                 <tbody>
                   <tr>
-                    <td><a href="https://solid.github.io/authentication-panel/solid-oidc-primer/" rel="cito:citesForInformation">Solid OIDC Primer</a></td>
-                    <td><a href="https://github.com/solid/authentication-panel">https://github.com/solid/authentication-panel</a></td>
+                    <td><a href="https://solid.github.io/solid-oidc/primer/" rel="cito:citesForInformation">Solid OIDC Primer</a></td>
+                    <td><a href="https://github.com/solid/solid-oidc">https://github.com/solid/solid-oidc</a></td>
                     <td>Editor’s Draft</td>
                     <td>Ecosystem Proposal</td>
                     <td>Community Report</td>

--- a/protocol.html
+++ b/protocol.html
@@ -1018,7 +1018,7 @@ access-mode      = "read" / "write" / "append" / "control"</pre>
                     <dt id="bib-rfc8288">[RFC8288]</dt>
                     <dd><a href="https://httpwg.org/specs/rfc8288.html"><cite>Web Linking</cite></a>. M. Nottingham.  IETF. October 2017. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc8288.html">https://httpwg.org/specs/rfc8288.html</a></dd>
                     <dt id="bib-solid-oidc">[SOLID-OIDC]</dt>
-                    <dd><a href="https://solid.github.io/authentication-panel/solid-oidc/"><cite>Solid Protocol</cite></a>. Aaron Coburn; elf Pavlik; Dmitri Zagidulin.  W3C Solid Community Group. W3C Editor's Draft. URL: <a href="https://solid.github.io/authentication-panel/solid-oidc/">https://solid.github.io/authentication-panel/solid-oidc/</a></dd>
+                    <dd><a href="https://solid.github.io/solid-oidc/"><cite>Solid Protocol</cite></a>. Aaron Coburn; elf Pavlik; Dmitri Zagidulin.  W3C Solid Community Group. W3C Editor's Draft. URL: <a href="https://solid.github.io/solid-oidc/">https://solid.github.io/solid-oidc/</a></dd>
                     <dt id="bib-turtle">[Turtle]</dt>
                     <dd><a href="https://www.w3.org/TR/turtle/"><cite>RDF 1.1 Turtle</cite></a>. Eric Prud'hommeaux; Gavin Carothers.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/turtle/">https://www.w3.org/TR/turtle/</a></dd>
                     <dt id="bib-w3c-html">[W3C-HTML]</dt>


### PR DESCRIPTION
The Solid-OIDC specification has been split off from the Authentication Panel repository. The new URL is https://solid.github.io/solid-oidc/ and the corresponding repository is at https://github.com/solid/solid-oidc