### PR TITLE
Clarify that the required predicate for creation is acl:default

### DIFF
--- a/wac.html
+++ b/wac.html
@@ -765,7 +765,7 @@ content: "";
 
                       <p id="server-read-resource">When an operation requests to read a resource, the server MUST match an Authorization allowing the <code>acl:Read</code> access privilege on the resource.</p>
 
-                      <p id="server-create-operation">When an operation requests to create a resource as a member of a container resource, the server MUST match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on the container for new members.</p>
+                      <p id="server-create-operation">When an operation requests to create a resource as a member of a container resource, the server MUST match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on the container identified via <code>acl:default</code>.</p>
 
                       <p id="server-update-operation">When an operation requests to update a resource, the server MUST match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on the resource.</p>
 


### PR DESCRIPTION
Following https://github.com/solid/web-access-control-tests/issues/41#issuecomment-898295543, I'm hereby making a suggestion to clarify the text.

When editing, however, I also stumbled upon another question:

> the server MUST match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on the container

Should we, in addition to—or instead of—mentioning those two terms, add a link to which one is appropriate?
Or is are literally any of those appropriate?

I _think_ that we mean to say:
- if you're doing `PUT` to create, you need `Write`
- you you're doing `PATCH` to create, you need `Append`
but that is not what we're saying; we say that either is fine for creation.
