### PR TITLE
W3C Solid Community Group meeting minutes template

### DIFF
--- a/meetings/template.md
+++ b/meetings/template.md
@@ -1,0 +1,53 @@
+# W3C Solid Community Group: Meeting Title
+
+* Date: dateTime
+* Call: url
+* Chat: url
+* Repository: url
+
+
+## Present
+* [name](url)
+*
+
+---
+
+## Announcements
+
+### Meeting Recordings and Transcripts
+* No audio or video recording, or automated transcripts without consent. Meetings are transcribed and made public. If consent is withheld by anyone, recording/retention must not occur.
+* Use panel chat and repository. Queue in call to talk.
+
+
+### Participation and Code of Conduct
+* [Join the W3C Solid Community Group](https://www.w3.org/community/solid/join), [W3C Account Request](http://www.w3.org/accounts/request), [W3C Community Contributor License Agreement](https://www.w3.org/community/about/agreements/cla/)
+* [Solid Code of Conduct](https://github.com/solid/process/blob/master/code-of-conduct.md), [Positive Work Environment at W3C: Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/)
+* If this is your first time, welcome! please introduce yourself.
+
+
+### Scribes
+* name
+*
+
+
+### Introductions
+* name: text
+*
+
+---
+
+## Topics
+
+### Topic
+URL:
+
+* name: text
+*
+
+PROPOSAL: text
+* name: +1,0,-1
+*
+
+RESOLUTION: text
+
+ACTION: text


### PR DESCRIPTION
This is a minutes template that can be used in W3C Solid CG meetings.

* Past meeting with minor differences to PR'd: https://github.com/solid/notifications-panel/blob/main/meetings/2021-09-16.md
* Template in use, e.g., in notifications-panel: https://github.com/solid/notifications-panel/blob/main/meetings/template.md
* Upcoming meeting, e.g., in live editor: https://hackmd.io/u37sG1o3TMyahXf6iRVMeQ

The template was derived from https://gitter.im/solid/specification?at=600eda39ac653a0802df61f7 and practice in panels.