### PR TITLE
W3C Solid Community Group Meeting Guidelines

### DIFF
--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,0 +1,57 @@
+# W3C Solid Community Group Meeting Guidelines
+
+To reach consensus where no consensus has been reached before.
+
+It is recommended that meetings adopt the guidelines in this document as well as the [W3C Process](https://www.w3.org/Consortium/Process/) where applicable.
+
+The [Solid Code of Conduct](https://github.com/solid/process/blob/main/code-of-conduct.md) and [Positive Work Environment at W3C: Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/) must be followed by all meeting participants.
+
+## Meeting Recordings and Transcripts
+
+No audio or video recording, or automated transcripts without consent. Meetings are transcribed and made public. If consent is withheld by anyone, recording/retention must not occur.
+
+There is a [minutes template](https://github.com/solid/specification/blob/main/meetings/template.md) (Markdown) that can be used.
+
+## Roles in Meetings
+
+Below are some common roles and their descriptions as useful guidelines. It is not a complete or strict list of duties.
+
+### Participants
+
+* Includes everyone present in the meeting.
+* Participants may switch roles provided that it is clear to the other participants and there are no conflicts of interest.
+* Participants other than the moderator should add themselves to the queue to talk, remove themselves, or allow others to go ahead.
+* State name to scribe. Be concise. Stay within topic.
+* May correct or improve fields marked by scribes during meeting.
+* Makes recommendations to improve meeting minutes, e.g., PRs.
+* Can recommend meeting topics before or during the meeting.
+* Participants should first attempt to use chats and repositories to work out concerns about the minutes or group decisions before meetings. Specific responses, e.g., clarifications or objections to previous group decisions can be proposed as topics to the meeting agenda.
+* Only Solid Community Group members may vote or raise objections during the meeting.
+
+### Guests
+
+* Anyone can join a public meeting as a guest whether invited by someone or not.
+* Guests cannot vote or raise objections in discussions.
+
+### Moderator
+
+* Defines and announces meeting agenda prior to the meeting.
+* Runs the meeting agenda; announcements, topics.
+* Generally stays neutral in discussion but can participate in discussions if announces in advance their "hat" at that time.
+* Facilitate reaching consensus.
+* Asks participants to approve prior meeting minutes. If no objections, notes approval to scribe.
+* Ensures minutes are taken and posted in due time.
+
+### Scribes
+
+* Transcribes the meeting *as is*.
+* Stops transcribing on speaker's request.
+* Requests assistance to improve transcription, e.g., mark text that needs correction or improvement, ask speaker or moderator for clarification.
+* Publishes minutes "soon after" the meeting (unless an another arrangement is made - to ensure it is on the same day).
+* Announces (draft and published) minutes in chats and elsewhere.
+
+### Solid Community Group Chair
+
+* May adopt or request to take on a role before or during the meeting.
+* Provides guidance to processes, charters and the Solid ecosystem.
+* Follows up on Community Group related actions.


### PR DESCRIPTION
Some notes below. Not required reading for the PR.

Using the W3C Process as guide, the recommendation is that the minutes of distributed meetings should be available after 48 hours. As far as I can tell from documentation related to scribing and minutes - and personal experience - groups come to an agreement about what's on record - how exactly they agree on the record is not specified. W3C groups use different approaches (and tools), e.g., minutes are shortly available after the meeting, draft minutes are generated, and approved by the group, and in other ways. I've pinged people as well as W3C (on IRC) for pointers and experiences but so far it seems that there is no formal process for agreeing to what has been minuted, and corrections are rare. Will share info once I know more.

Edit: The initial feedback that I got and reconfirmed:

* CSS WG posts the text of the official minutes to their mailing list as is (single URL). They allow in-meeting corrections (on IRC). Members are invited to reply with corrections in a new thread, and apparently that rarely happens.

* Credentials CG posts a copy of the text of official minutes to their mailing list and to a separate URL (for 8 years now), and apparently corrections were made only a few times (due to confidentiality reasons).

---

Minutes committed directly to the main branch takes the position that there is one URL for the minutes, scribed content is in sufficient quality and done in good faith, and allows corrections to be PR'd.

Corrections and missing information to the minutes are raised as PRs. Verifying changes to the minutes are done by the group. Relies on group's memory (and good faith) - no audio/video recordings for additional checks.

Concerns about prior group agreements are generally raised as a topic in meetings.

It'd be ideal to use only one URL to the minutes that's available shortly after the meeting. This has the same approach as what's commonly known as the "latest published version" in specs or "original resource" in Memento. It is useful to know the publication status of any documentation. Corrections are welcome and should be transparent. I do not ultimately what branch or whether there is a PR that a human/machine needs to merge.