### PR TITLE
Add possible semaphore mechanism wording

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -713,7 +713,7 @@ left:4.5em;
 		  </p>
 
 		  <p>
-		    <span about="" id="server-patch-sparql-outside-subset" rel="spec:requirement" resource="#server-patch-sparql-outside-subset"><span property="spec:statement">If <span rel="spec:requirementSubject" resource="spec:Server">servers</span> that process <code>DELETE/INSERT</code> queries (as defined in SPARQL 1.1 Section 3.1.3, [<cite><a class="bibref" href="#bib-sparql-overview">SPARQL</a></cite>]), finds any solution that produces a triple containing an unbound variable or an illegal RDF construct, then the server <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> abort any modifications and respond with a <code>409</code> status code.</span></span>
+		    <span about="" id="server-patch-sparql-abort" rel="spec:requirement" resource="#server-patch-sparql-abort"><span property="spec:statement">If <span rel="spec:requirementSubject" resource="spec:Server">servers</span> that process SPARQL 1.1 Update’s [<cite><a class="bibref" href="#bib-sparql11-update">SPARQL11-UPDATE</a></cite>]) <code>DELETE/INSERT</code> operation finds any solution that produces a triple containing an unbound variable or an illegal RDF construct, then the server <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> abort any modifications and respond with a <code>409</code> status code.</span></span>
 		  </p>
 
 		  <p>


### PR DESCRIPTION
I'm proposing a draft of the wording I proposed in #322. I think this is the minimal change we can do to SPARQL that also legitimizes the behaviour in NSS with regards to the semaphore mechanism.