### PR TITLE
Alternative SPARQL Update support 

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -1105,7 +1105,7 @@ access-mode      = "read" / "write" / "append" / "control"</pre>
 		<div class="note" id="sparql-variant-definition-note" inlist="" rel="schema:hasPart" resource="#sparql-variant-definition-note">
                     <h4 property="schema:name"><span>Note</span>: Definition of SPARQL Update Variant</h4>
                     <div datatype="rdf:HTML" property="schema:description">
-                      <p>This specification alters the grammar of 8 rules in the original grammar of the SPARQL 1.1 Query Language [<cite><a class="bibref" href="#bib-sparql-overview">SPARQL</a></cite>] grammar and introduces another 10 new rules to accommodate for <code>INSERT DATA</code> and <code>DELETE DATA</code>, which was defined in the language definition but not precisely defined in the grammar. This specification references the original grammar definition where no changes were made.
+                      <p>This specification alters the grammar of 8 rules in the original grammar of the SPARQL 1.1 Query Language [<cite><a class="bibref" href="#bib-sparql-overview">SPARQL</a></cite>] grammar and introduces another 11 new rules to accommodate for <code>INSERT DATA</code> and <code>REMOVE DATA</code>, as the corresponding operations were defined in the language definition but not precisely defined in the grammar. This specification references the original grammar definition where no changes were made.
 		    </div>
 		</div>
 


### PR DESCRIPTION
During the [Solid Editors call 2021-10-20](https://hackmd.io/yZ0HY0sSTJS8rcfgrppQnA),  @timbl reiterated that it might be a good idea to have different syntax for different semantics rather than the consensus of #125. I decided to explore this further, also in light of the discussion in #322 and this pull request can be thought of as an alternative to #320, but it also builds on it.

In this PR, I have replaced `DELETE` with `REMOVE` and so, `REMOVE` carries semantics that enables error reporting. This PR is actually more complete than #320, as the latter was intended to be a minimal change to SPARQL. This PR departs more significantly, but also defines a MIME Type for the result.