### PR TITLE
Add definitions for triples and triple patterns

### DIFF
--- a/protocol.html
+++ b/protocol.html
@@ -369,6 +369,9 @@ left:4.5em;
                     <dt about="#root-container" property="skos:prefLabel" typeof="skos:Concept"><dfn id="root-container">root container</dfn></dt>
                     <dd about="#root-container" property="skos:definition">A root container is a container resource that is at the highest level of the collection hierarchy.</dd>
 
+                    <dt about="#triple" property="skos:prefLabel" typeof="skos:Concept"><dfn id="triple">triple</dfn></dt>
+                    <dd about="#triple" property="skos:definition">A triple is an RDF triple that consists of a subject, which is an URI or a blank node; a predicate, which is an URI and an object, which is an URI, a literal or a blank node. [<cite><a class="bibref" href="#bib-rdf11-concepts">[RDF11-CONCEPTS]</cite>].</dd>
+
                     <dt about="#agent" property="skos:prefLabel" typeof="skos:Concept"><dfn id="agent">agent</dfn></dt>
                     <dd about="#agent" property="skos:definition">An agent is a person, social entity, or software identified by a URI; e.g., a WebID denotes an agent [<cite><a class="bibref" href="#bib-webid">WEBID</a></cite>].</dd>
 

--- a/protocol.html
+++ b/protocol.html
@@ -370,7 +370,11 @@ left:4.5em;
                     <dd about="#root-container" property="skos:definition">A root container is a container resource that is at the highest level of the collection hierarchy.</dd>
 
                     <dt about="#triple" property="skos:prefLabel" typeof="skos:Concept"><dfn id="triple">triple</dfn></dt>
-                    <dd about="#triple" property="skos:definition">A triple is an RDF triple that consists of a subject, which is an URI or a blank node; a predicate, which is an URI and an object, which is an URI, a literal or a blank node. [<cite><a class="bibref" href="#bib-rdf11-concepts">[RDF11-CONCEPTS]</cite>].</dd>
+                    <dd about="#triple" property="skos:definition">A triple is an RDF triple that consists of a subject, which is an URI or a blank node; a predicate, which is an URI and an object, which is an URI, a literal or a blank node. [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>].</dd>
+
+		    <dt about="#triple-pattern" property="skos:prefLabel" typeof="skos:Concept"><dfn id="triple-pattern">triple pattern</dfn></dt>
+                    <dd about="#triple-pattern" property="skos:definition">A triple pattern extends a triple with that it may contain a variable in the subject, predicate and object components. [<cite><a class="bibref" href="#bib-sparql11-query">SPARQL11-QUERY</a></cite>].</dd>
+
 
                     <dt about="#agent" property="skos:prefLabel" typeof="skos:Concept"><dfn id="agent">agent</dfn></dt>
                     <dd about="#agent" property="skos:definition">An agent is a person, social entity, or software identified by a URI; e.g., a WebID denotes an agent [<cite><a class="bibref" href="#bib-webid">WEBID</a></cite>].</dd>
@@ -1103,6 +1107,8 @@ access-mode      = "read" / "write" / "append" / "control"</pre>
                     <dd><a href="https://httpwg.org/specs/rfc8288.html" rel="cito:citesAsAuthority"><cite>Web Linking</cite></a>. M. Nottingham.  IETF. October 2017. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc8288.html">https://httpwg.org/specs/rfc8288.html</a></dd>
                     <dt id="bib-solid-oidc">[SOLID-OIDC]</dt>
                     <dd><a href="https://solid.github.io/solid-oidc/" rel="cito:citesAsAuthority"><cite>SOLID-OIDC</cite></a>. Aaron Coburn; elf Pavlik; Dmitri Zagidulin.  W3C Solid Community Group. W3C Editor's Draft. URL: <a href="https://solid.github.io/solid-oidc/">https://solid.github.io/solid-oidc/</a></dd>
+		    <dt id="bib-sparql11-query">[SPARQL11-QUERY]</dt>
+                    <dd><a href="https://www.w3.org/TR/sparql11-query/" rel="cito:citesAsAuthority"><cite>SPARQL 1.1 Query</cite></a>. Steve Harris; Andy Seaborne; Eric Prud'hommeaux.  W3C. 21 March 2013. W3C Recommendation. URL: <a href="https://www.w3.org/TR/sparql11-query/">https://www.w3.org/TR/sparql11-query/</a></dd>
                     <dt id="bib-turtle">[Turtle]</dt>
                     <dd><a href="https://www.w3.org/TR/turtle/" rel="cito:citesAsAuthority"><cite>RDF 1.1 Turtle</cite></a>. Eric Prud'hommeaux; Gavin Carothers.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/turtle/">https://www.w3.org/TR/turtle/</a></dd>
                     <dt id="bib-w3c-html">[W3C-HTML]</dt>


### PR DESCRIPTION
Addressing #348 . 

I decided to paraphrase, as the formal definitions in particular for SPARQL, did not seem appropriate to put our document. Please check that out. I also decided to constrain to URIs, as we generally have done, but see #347 . 

I'm not particularly confident this is the right thing to put in there, but the normative references are there for those who need them.