### PR TITLE
Require Description Resources to be supported

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -753,7 +753,8 @@ content: "";
                   <section id="auxiliary-resources-description-resource" inlist="" rel="schema:hasPart" resource="#auxiliary-resources-description-resource">
                     <h4 property="schema:name">Description Resource</h4>
                     <div datatype="rdf:HTML" property="schema:description">
-                      <p>An auxiliary resource of type <em>Description Resource</em> provides a description of a subject resource ([<cite><a class="bibref" href="#bib-ldp">LDP</a></cite>]).</p>
+                      <p>An auxiliary resource of type <em>Description Resource</em> provides a description of a subject resource ([<cite><a class="bibref" href="#bib-ldp">LDP</a></cite>]).
+			<span about="" id="server-description-required" rel="spec:requirement" resource="#server-description-required"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> support this auxiliary resource type.</span></span></p>
 
                       <p><span about="" id="server-description-resource-max" rel="spec:requirement" resource="#server-description-resource-max"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST-NOT">MUST NOT</span> directly associate more than one description resource to a subject resource.</span></span></p>
 


### PR DESCRIPTION
Currently, there is no server requirement to support `describedby` resources, only a description about how clients may discover them. I believe this to be a simple omission, it has been in Solid since the dawn of ages, and even though we want to [generalize aux resources](https://github.com/solid/specification/issues?q=is%3Aissue+is%3Aopen+label%3A%22topic%3A+auxiliary+resources%22+), this basic functionality should be required in 0.9.x.

There are also tests https://github.com/solid/specification-tests/pull/65 in this area, and I believe it is appropriate to make this a requirement rather than introduce more variability.