### PR TITLE
Add license document

### DIFF
--- a/mit-license.html
+++ b/mit-license.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>MIT License</title>
+    <meta content="width=device-width, initial-scale=1" name="viewport" />
+  </head>
+
+  <body about="" prefix="rdfs: http://www.w3.org/2000/01/rdf-schema# xsd: http://www.w3.org/2001/XMLSchema# dcterms: http://purl.org/dc/terms/">
+    <main>
+      <article about="" typeof="dcterms:LicenseDocument">
+        <h1 property="rdfs:label">MIT License</h1>
+
+          <dl id="document-created">
+            <dt>Created</dt>
+            <dd><time content="2022-06-07T00:00:00Z" datatype="xsd:dateTime" datetime="2022-06-07T00:00:00Z" property="dcterms:created">2022-06-07</time></dd>
+          </dl>
+
+          <dl id="document-modified">
+            <dt>Modified</dt>
+            <dd><time content="2022-06-07T00:00:00Z" datatype="xsd:dateTime" datetime="2022-06-07T00:00:00Z" property="dcterms:modified">2022-06-07</time></dd>
+          </dl>
+
+          <dl id="document-rights-holder">
+            <dt>Rights Holder</dt>
+            <dd><a href="https://www.w3.org/groups/cg/solid" rel="dcterms:rightsHolder">W3C Solid Community Group</a></dd>
+          </dl>
+
+          <dl id="document-rights-statement">
+            <dt>Rights Statement</dt>
+            <dd property="dcterms:description"><p>Copyright (c) 2018-2022 W3C Solid Community Group</p>
+
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+
+<p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p></dd>
+          </dl>
+      </article>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Resolves https://github.com/solid/specification/issues/411 .

This PR proposes to publish `mit-license` so that TRs can refer to this license document that's explicit about the copyright year and rights holder (and possibly other information, TBD as part of review/discussion here or elsewhere).

I believe `mit-license` would be preferable to http://purl.org/NET/rdflicense/MIT1.0 (only the MIT license template) and https://raw.githubusercontent.com/solid/specification/main/LICENSE.md (no ties to GitHub or another authority besides the W3C Solid CG or the Solid Project).

Questions:

* What should be the license document's URL be, e.g., `https://solidproject.org/TR/mit-license` ?
* Should the document be versioned?
* Should the copyright year be "2018" (when the CG was formed) or "2022" (this year) or "2018-2022" or something else?
* What other information should be included in the license document, e.g., `odrl:Policy` details?

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/adad4ea576f795356538c503d85afb109daf307b/mit-license.html)