### PR TITLE
Add WebID Profile as work item

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,14 @@ border-bottom: 2pt solid #000;
 
                 <tbody>
                   <tr>
+                    <td><a href="https://github.com/solid/webid-profile/blob/main/notes/pre-final-draft.md" rel="cito:citesForInformation">WebID Profile</a></td>
+                    <td><a href="https://github.com/solid/webid-profile">https://github.com/solid/webid-profile</a></td>
+                    <td>Unofficial Draft</td>
+                    <td>Ecosystem Proposal</td> 
+                    <td>Community Report</td>
+                    <td>TBD</td>
+                  </tr>
+                  <tr>
                     <td><a href="https://solidproject.org/TR/oidc" rel="cito:citesForInformation">Solid OIDC</a></td>
                     <td><a href="https://github.com/solid/solid-oidc">https://github.com/solid/solid-oidc</a></td>
                     <td>Community Group Draft</td>

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ border-bottom: 2pt solid #000;
                     <td>Unofficial Draft</td>
                     <td>Ecosystem Proposal</td> 
                     <td>Community Report</td>
-                    <td>TBD</td>
+                    <td>2023-06-30</td>
                   </tr>
                   <tr>
                     <td><a href="https://solidproject.org/TR/oidc" rel="cito:citesForInformation">Solid OIDC</a></td>

--- a/index.html
+++ b/index.html
@@ -126,9 +126,9 @@ border-bottom: 2pt solid #000;
 
                 <tbody>
                   <tr>
-                    <td><a href="https://github.com/solid/webid-profile/blob/main/notes/pre-final-draft.md" rel="cito:citesForInformation">WebID Profile</a></td>
+                    <td><a href="https://solid.github.io/webid-profile/" rel="cito:citesForInformation">Solid WebID Profile</a></td>
                     <td><a href="https://github.com/solid/webid-profile">https://github.com/solid/webid-profile</a></td>
-                    <td>Unofficial Draft</td>
+                    <td>Version 1.0.0, Editor's Draft</td>
                     <td>Ecosystem Proposal</td> 
                     <td>Community Report</td>
                     <td>2023-06-30</td>


### PR DESCRIPTION
This PR's purpose is to introduce WebID Profile as a work item. 

See: https://github.com/solid/webid-profile/issues/15

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/e4f738436cbcd22bdf9c6f6e267978b2781efc39/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fmain%2Findex.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fe4f738436cbcd22bdf9c6f6e267978b2781efc39%2Findex.html)