### PR TITLE
Fix URL label for notification subscription types

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ border-bottom: 2pt solid #000;
                     <td><time datetime="2022-12-30">2022-12-30</time></td>
                   </tr>
                   <tr>
-                    <td><a href="https://solidproject.org/TR/notification-subscription-types" rel="cito:citesForInformation">Solid Notifications Protocol</a></td>
+                    <td><a href="https://solidproject.org/TR/notification-subscription-types" rel="cito:citesForInformation">Notification Subscription Types</a></td>
                     <td><a href="https://github.com/solid/specification">https://github.com/solid/specification</a></td>
                     <td>Living Document</td>
                     <td>N/A</td>


### PR DESCRIPTION
The link to the "Notification Subscription Types" (third in the image below) currently has the "Solid Notifications Protocol" label, which is incorrect.

![image](https://user-images.githubusercontent.com/1265883/174116639-00edf33f-29e2-459c-99cc-033357927649.png)
