### PR TITLE
Add missing 'Primer' to Solid-OIDC in title/heading

### DIFF
--- a/oidc-primer.html
+++ b/oidc-primer.html
@@ -343,7 +343,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
  <body class="h-entry">
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://solidproject.org/TR/"> <img alt="Solid" src="https://solidproject.org/TR/solid.svg" width="72"> </a> </p>
-   <h1 class="p-name no-ref" id="title">Solid-OIDC</h1>
+   <h1 class="p-name no-ref" id="title">Solid-OIDC Primer</h1>
    <h2>Version 0.1.0, 2022-03-28</h2>
    <details open>
     <summary>More details about this document</summary>


### PR DESCRIPTION
Created this PR for awareness for everyone and the Editors of Solid-OIDC Primer so they can follow-up elsewhere. Merging.

@jaxoncreed @matthieubosquet @acoburn

---

[Preview](https://htmlpreview.github.io/?https://github.com/solid/specification/blob/5f12d4c734ce71d31e74c872f1b97475f11593f1/oidc-primer.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fmain%2Foidc-primer.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F5f12d4c734ce71d31e74c872f1b97475f11593f1%2Foidc-primer.html)