### PR TITLE
TR/2022/wac-20220705

### DIFF
--- a/2022/wac-20220705.html
+++ b/2022/wac-20220705.html
@@ -136,7 +136,7 @@ content: "";
     <main>
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Web Access Control</h1>
-        <h2>Version <span property="doap:revision">1.0.0</span>, 2022-07-05</h2>
+        <h2>Version <span property="doap:revision">1.0.0</span>, Editor’s Draft, 2022-07-05</h2>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -175,12 +175,12 @@ content: "";
 
           <dl id="document-created">
             <dt>Created</dt>
-            <dd><time content="2021-07-11T00:00:00Z" datatype="xsd:dateTime" datetime="2021-07-11T00:00:00Z" property="schema:dateCreated">2021-07-11</time></dd>
+            <dd><time content="2022-07-05T00:00:00Z" datatype="xsd:dateTime" datetime="2022-07-0500:00:00Z" property="schema:dateCreated">2022-07-05</time></dd>
           </dl>
 
           <dl id="document-published">
             <dt>Published</dt>
-            <dd><time content="2021-07-11T00:00:00Z" datatype="xsd:dateTime" datetime="2021-07-11T00:00:00Z" property="schema:datePublished">2021-07-11</time></dd>
+            <dd><time content="2022-07-05T00:00:00Z" datatype="xsd:dateTime" datetime="2022-07-05T00:00:00Z" property="schema:datePublished">2022-07-05</time></dd>
           </dl>
 
           <dl id="document-modified">

--- a/2022/wac-20220705.html
+++ b/2022/wac-20220705.html
@@ -136,7 +136,7 @@ content: "";
     <main>
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Web Access Control</h1>
-        <h2>Version <span property="doap:revision">1.0.0-cr.1</span>, Editor’s Draft, 2022-07-05</h2>
+        <h2>Version <span property="doap:revision">1.0.0-cr.1</span>, Candidate Recommendation, 2022-07-05</h2>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -291,7 +291,7 @@ content: "";
 
               <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Version 1.0.0-cr.1</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
-              <p>Publication as an <em>Version 1.0.0-cr.1</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
+              <p>Publication as a <em>Version 1.0.0-cr.1</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This document is a Candidate Recommendation by the W3C Solid Community Group and we invite implementations. It will only change in response to important implementation feedback. It is inappropriate to cite this document as other than work in progress.</p>
 
               <p>This document was produced by a group operating under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.</p>
             </div>

--- a/2022/wac-20220705.html
+++ b/2022/wac-20220705.html
@@ -339,7 +339,6 @@ content: "";
                     <li><a href="#effective-acl-resource"><span class="secno">5.1</span> <span class="content">Effective ACL Resource</span></a></li>
                     <li><a class="tocxref" href="#authorization-conformance"><span class="secno">5.2</span> <span class="content">Authorization Conformance</span></a></li>
                     <li><a class="tocxref" href="#authorization-evaluation"><span class="secno">5.3</span> <span class="content">Authorization Evaluation</span></a></li>
-                    <li><a class="tocxref" href="#access-privileges"><span class="secno">5.4</span> <span class="content">Access Privileges</span></a></li>
                   </ol>
                 </li>
                 <li class="tocline">

--- a/2022/wac-20220705.html
+++ b/2022/wac-20220705.html
@@ -136,7 +136,7 @@ content: "";
     <main>
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Web Access Control</h1>
-        <h2>Version <span property="doap:revision">1.0.0</span>, Editor’s Draft, 2022-07-05</h2>
+        <h2>Version <span property="doap:revision">1.0.0-cr.1</span>, Editor’s Draft, 2022-07-05</h2>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -289,9 +289,9 @@ content: "";
             <div property="schema:description" datatype="rdf:HTML">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Version 1.0.0</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Version 1.0.0-cr.1</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
-              <p>Publication as an <em>Version 1.0.0</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
+              <p>Publication as an <em>Version 1.0.0-cr.1</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 
               <p>This document was produced by a group operating under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.</p>
             </div>

--- a/wac.html
+++ b/wac.html
@@ -339,7 +339,6 @@ content: "";
                     <li><a href="#effective-acl-resource"><span class="secno">5.1</span> <span class="content">Effective ACL Resource</span></a></li>
                     <li><a class="tocxref" href="#authorization-conformance"><span class="secno">5.2</span> <span class="content">Authorization Conformance</span></a></li>
                     <li><a class="tocxref" href="#authorization-evaluation"><span class="secno">5.3</span> <span class="content">Authorization Evaluation</span></a></li>
-                    <li><a class="tocxref" href="#access-privileges"><span class="secno">5.4</span> <span class="content">Access Privileges</span></a></li>
                   </ol>
                 </li>
                 <li class="tocline">

--- a/wac.html
+++ b/wac.html
@@ -136,7 +136,7 @@ content: "";
     <main>
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Web Access Control</h1>
-        <h2>Version <span property="doap:revision">1.0.0</span>, 2022-07-05</h2>
+        <h2>Version <span property="doap:revision">1.0.0-cr.1</span>, 2022-07-05</h2>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -289,9 +289,9 @@ content: "";
             <div property="schema:description" datatype="rdf:HTML">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Version 1.0.0</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Version 1.0.0-cr.1</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
-              <p>Publication as an <em>Version 1.0.0</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
+              <p>Publication as an <em>Version 1.0.0-cr.1</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 
               <p>This document was produced by a group operating under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.</p>
             </div>

--- a/wac.html
+++ b/wac.html
@@ -136,7 +136,7 @@ content: "";
     <main>
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Web Access Control</h1>
-        <h2>Version <span property="doap:revision">1.0.0-cr.1</span>, 2022-07-05</h2>
+        <h2>Version <span property="doap:revision">1.0.0-cr.1</span>, Candidate Recommendation, 2022-07-05</h2>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -291,7 +291,7 @@ content: "";
 
               <p>This document was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> as an <em>Version 1.0.0-cr.1</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/web-access-control-spec/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
-              <p>Publication as an <em>Version 1.0.0-cr.1</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
+              <p>Publication as a <em>Version 1.0.0-cr.1</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This document is a Candidate Recommendation by the W3C Solid Community Group and we invite implementations. It will only change in response to important implementation feedback. It is inappropriate to cite this document as other than work in progress.</p>
 
               <p>This document was produced by a group operating under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.</p>
             </div>

--- a/wac.timemap.html
+++ b/wac.timemap.html
@@ -26,6 +26,7 @@
             <dd about="https://solidproject.org/TR/wac">
               <ul>
                 <li><a rel="mem:memento" href="https://solidproject.org/TR/2021/wac-20210711">https://solidproject.org/TR/2021/wac-20210711</a> (<time about="https://solidproject.org/TR/2021/wac-20210711" datatype="xsd:dateTime" datetime="2021-07-11T00:00:00Z" property="mem:mementoDateTime">2021-07-11T00:00:00Z</time>)</li>
+                <li><a rel="mem:memento" href="https://solidproject.org/TR/2022/wac-20220705">https://solidproject.org/TR/2022/wac-20220705</a> (<time about="https://solidproject.org/TR/2022/wac-20220705" datatype="xsd:dateTime" datetime="2022-07-05T00:00:00Z" property="mem:mementoDateTime">2022-07-05T00:00:00Z</time>)</li>
               </ul>
             </dd>
           </dl>


### PR DESCRIPTION
The #change-log section includes a summary of all changes.

The key change from the previous version is that the `acl` link relation definition is updated based on the IANA process for registering a link relation type ( https://github.com/protocol-registries/link-relations/issues/32 ).

This PR follows based on agreement by the Editor's Team:
* https://github.com/solid/specification/blob/main/meetings/2022-03-30.md#add-solid-oidc-draft-specification-and-primer-to-solid-project
* https://github.com/solid/specification/blob/main/meetings/2022-04-27.md#solid-oidc-and-solid-oidc-primer
* https://github.com/solid/specification/blob/main/meetings/2022-08-17.md#add-tr2022wac-20220705

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/1dca4d5bb72247d4eeb1ed7bd92bc8bda909b80f/wac.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F1dca4d5bb72247d4eeb1ed7bd92bc8bda909b80f%2Fwac.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fa447b21b58c50f716267615f601077acd1172dda%2Fwac.html)