### PR TITLE
ED/protocol.html: remove doubled dot at the end of a sentence

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -963,7 +963,7 @@ content: "";
 
                   <p>The <cite>Solid WebSockets API</cite> (Unofficial Draft) has been the common protocol for many years. That draft does not include an authentication mechanism, and therefore the Protocol will transition to a new design. The new design is currently at <cite><a href="https://solid.github.io/notifications/protocol" rel="cito:citesAsPotentialSolution">Solid Notifications Protocol</a></cite> [<cite><a class="bibref" href="#bib-solid-notifications-protocol">SOLID-NOTIFICATIONS-PROTOCOL</a></cite>]. It is planned to include both security through authentication, and also common formats with other forms of real-time notification in the Solid ecosystem.</p>
 
-                  <p>Both client and server implementations should provide the existing protocol, and should transition to providing both protocols as the new one becomes available..</p>
+                  <p>Both client and server implementations should provide the existing protocol, and should transition to providing both protocols as the new one becomes available.</p>
 
                   <p>The future directions of the protocol include moving from a simple one-bit notification that a resource has changed, requiring the client to reload the resource, to adding <code>PATCH</code> information in the notification so the client can calculate the new state immediately.</p>
                 </div>


### PR DESCRIPTION
There is a dot doubled at the end of one sentence.

This commit removes one of the redundant dots.