### PR TITLE
Add W3C Solid CG weekly meeting to Participation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ All substantive contributors to Work Items must be members of the Solid CG. Itâ€
 
 Anyone can join the [Solid specification chat](https://gitter.im/solid/specification).
 
+Wednesdays, 14:00 UTC at https://meet.jit.si/solid/cg/weekly . Meetings are transcribed and [published](https://github.com/solid/specification/tree/main/meetings/). See also the event in the [W3C calendar](https://www.w3.org/events/meetings/0caa6ba5-5523-4e16-b514-aeec098e4d72/20221005T140000).
+
 <span id="solid-panels">Solid Panels</span> focus on certain work streams, with an aim to propose technical reports for
 the Solid ecosystem:
 


### PR DESCRIPTION
This is a proposal to have a weekly meeting for the W3C Solid Community Group (CG) as mentioned in the solid/specification Gitter chat [1] and in the W3C TPAC 2022 meeting [2].

There is an event that's drafted [3] - scheduled for Wednesdays at 14:00 UTC - for the CG calendar [4]. We will not observe daylight savings time.

Anyone may join the meeting. Participants must abide by the terms and spirit of the W3C Code of Ethics and Professional Conduct (CEPC) [5].

The Chair will propose and approve the agenda for each meeting. Participants are welcome to review and propose agenda topics.

The Solid Technical Reports Contributing Guide [6] describes different ways to contribute and follow the Solid project.

The CG Meeting Guidelines [7] describes how to participate and record meetings.

There is a minutes template [8] that can be used by scribes to transcribe the meeting.

As it stands, the CG weekly call is not intended to replace the panel meetings. Panel meetings can continue to further the development of their Work Items [9].

Bear in mind that the proposed time [3] worked reasonably well in the past for the (occasional) CG-wide meetings but unfortunately overlaps with one of the panel meetings.

Considering the current state of panels [1][2], we can revisit how Solid Panels work as per the Solid process [10]. Alternatively, Task Forces can be formed to carry out specific assignments for the CG [11], e.g., documentation similar to Panel Charters ([12][13]) but with smaller scope. Solid Panels and W3C Group Task Forces are general similar but we will need to fine tune this going forward.

[1] https://gitter.im/solid/specification?at=632c64a772ad51741ff272a3
[2] https://github.com/solid/specification/blob/main/meetings/2022-09-14.md#panels
[3] https://www.w3.org/events/meetings/0caa6ba5-5523-4e16-b514-aeec098e4d72/20221005T140000
[4] https://www.w3.org/groups/cg/solid/calendar
[5] https://www.w3.org/Consortium/cepc/
[6] https://github.com/solid/specification/blob/main/CONTRIBUTING.md
[7] https://github.com/solid/specification/blob/main/meetings/README.md
[8] https://github.com/solid/specification/blob/main/meetings/template.md
[9] https://solidproject.org/TR/
[10] https://github.com/solid/process/blob/main/README.md#solid-panels
[11] https://www.w3.org/2021/Process-20211102/#ReqsAllGroups
[12] https://github.com/solid/process/blob/main/test-suite-panel-charter.md
[13] https://github.com/solid/process/blob/main/notifications-panel-charter.md
