### PR TITLE
Removed unused data-pod definition

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -488,12 +488,9 @@ margin-top:1em;
 
                   <p property="skos:definition">The Solid Protocol specification defines the following terms. These terms are referenced throughout this specification.</p>
 
-                  <span rel="skos:hasTopConcept"><span resource="#data-pod"></span><span resource="#solid-app"></span><span resource="#uniform-resource-identifier"></span><span resource="#resource"></span><span resource="#container-resource"></span><span resource="#root-container"></span><span resource="#resource-metadata"></span><span resource="#agent"></span><span resource="#owner"></span><span resource="#origin"></span><span resource="#read-operation"></span><span resource="#write-operation"></span><span resource="#append-operation"></span></span>
+                  <span rel="skos:hasTopConcept"><span resource="#solid-app"></span><span resource="#uniform-resource-identifier"></span><span resource="#resource"></span><span resource="#container-resource"></span><span resource="#root-container"></span><span resource="#resource-metadata"></span><span resource="#agent"></span><span resource="#owner"></span><span resource="#origin"></span><span resource="#read-operation"></span><span resource="#write-operation"></span><span resource="#append-operation"></span></span>
 
                   <dl>
-                    <dt about="#data-pod" property="skos:prefLabel" typeof="skos:Concept"><dfn id="data-pod">data pod</dfn></dt>
-                    <dd about="#data-pod" property="skos:definition">A data pod is a place for storing documents, with mechanisms for controlling who can access what.</dd>
-
                     <dt about="#solid-app" property="skos:prefLabel" typeof="skos:Concept"><dfn id="solid-app">Solid app</dfn></dt>
                     <dd about="#solid-app" property="skos:definition">A Solid app is an application that reads or writes data from one or more <a href="#storage">storages</a>.</dd>
 


### PR DESCRIPTION
Follows https://github.com/solid/specification/pull/365 .

Created PR for awareness. Merging with the understanding that it is editorial since the term is not used in this document or referred by other Work Items.