### PR TITLE
Add definition storage

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -488,9 +488,12 @@ margin-top:1em;
 
                   <p property="skos:definition">The Solid Protocol specification defines the following terms. These terms are referenced throughout this specification.</p>
 
-                  <span rel="skos:hasTopConcept"><span resource="#solid-app"></span><span resource="#uniform-resource-identifier"></span><span resource="#resource"></span><span resource="#container-resource"></span><span resource="#root-container"></span><span resource="#resource-metadata"></span><span resource="#agent"></span><span resource="#owner"></span><span resource="#origin"></span><span resource="#read-operation"></span><span resource="#write-operation"></span><span resource="#append-operation"></span></span>
+                  <span rel="skos:hasTopConcept"><span resource="#storage"></span><span resource="#solid-app"></span><span resource="#uniform-resource-identifier"></span><span resource="#resource"></span><span resource="#container-resource"></span><span resource="#root-container"></span><span resource="#resource-metadata"></span><span resource="#agent"></span><span resource="#owner"></span><span resource="#origin"></span><span resource="#read-operation"></span><span resource="#write-operation"></span><span resource="#append-operation"></span></span>
 
                   <dl>
+                    <dt about="#storage" property="skos:prefLabel" typeof="skos:Concept"><dfn id="storage">storage</dfn></dt>
+                    <dd about="#storage" property="skos:definition">A storage is a space of URIs that affords agents controlled access to resources.</dd>
+
                     <dt about="#solid-app" property="skos:prefLabel" typeof="skos:Concept"><dfn id="solid-app">Solid app</dfn></dt>
                     <dd about="#solid-app" property="skos:definition">A Solid app is an application that reads or writes data from one or more <a href="#storage">storages</a>.</dd>
 
@@ -513,7 +516,7 @@ margin-top:1em;
                     <dd about="#agent" property="skos:definition">An agent is a person, social entity, or software identified by a URI; e.g., a WebID denotes an agent [<cite><a class="bibref" href="#bib-webid">WEBID</a></cite>].</dd>
 
                     <dt about="#owner" property="skos:prefLabel" typeof="skos:Concept"><dfn id="owner">owner</dfn></dt>
-                    <dd about="#owner" property="skos:definition">An owner is a person or a social entity that is considered to have the rights and responsibilities of a data storage. An owner is identified by a URI, and implicitly has control over all data in a storage. An owner is first set at storage provisioning time and can be changed.</dd>
+                    <dd about="#owner" property="skos:definition">An owner is a person or a social entity that is considered to have the rights and responsibilities of a storage. An owner is identified by a URI, and implicitly has control over all URIs in a storage. An owner is first set at storage provisioning time and can be changed.</dd>
 
                     <dt about="#origin" property="skos:prefLabel" typeof="skos:Concept"><dfn id="origin">origin</dfn></dt>
                     <dd about="#origin" property="skos:definition">An origin indicates where an HTTP request originates from [<cite><a class="bibref" href="#bib-rfc6454">RFC6454</a></cite>].</dd>
@@ -635,7 +638,7 @@ margin-top:1em;
               <div class="note" id="storage-owner-uri-ownership" inlist="" rel="schema:hasPart" resource="#storage-owner-uri-ownership">
                 <h3 property="schema:name"><span>Note</span>: Storage Owner and URI Ownership</h3>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p>This specification does not describe the relationship between a Solid storage <q>owner</q> and Web architecture’s <cite><a href="https://www.w3.org/TR/webarch/#uri-ownership">URI ownership</a></cite> [<cite><a class="bibref" href="#bib-webarch">WEBARCH</a></cite>].</p>
+                  <p>This specification does not describe the relationship between a storage <q>owner</q> and Web architecture’s <cite><a href="https://www.w3.org/TR/webarch/#uri-ownership">URI ownership</a></cite> [<cite><a class="bibref" href="#bib-webarch">WEBARCH</a></cite>].</p>
                 </div>
               </div>
 
@@ -672,7 +675,7 @@ margin-top:1em;
               <section id="storage-resource" inlist="" rel="schema:hasPart" resource="#storage-resource">
                 <h3 property="schema:name">Storage Resource</h3>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p><span about="" id="server-storage" rel="spec:requirement" resource="#server-storage"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> provide one or more storages (<code>pim:Storage</code>) – a space of URIs in which data can be accessed. A storage is the root container for all of its contained resources (see <a href="#resource-containment">Resource Containment</a>).</span></span></p>
+                  <p><span about="" id="server-storage" rel="spec:requirement" resource="#server-storage"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> provide one or more <a href="#storage">storages</a>. The storage resource (<code>pim:Storage</code>) is the root container for all of its contained resources (see <a href="#resource-containment">Resource Containment</a>).</span></span></p>
 
                   <p><span about="" id="server-storage-nonoverlapping" rel="spec:requirement" resource="#server-storage-nonoverlapping"><span property="spec:statement">When a <span rel="spec:requirementSubject" resource="spec:Server">server</span> supports multiple storages, the URIs <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> be allocated to non-overlapping space.</span></span></p>
 


### PR DESCRIPTION
This PR is intended to add the notion of "storage" that is commonly understood and in use. It includes other minor editorial for clarity.

Below is a non-exhaustive list of information pertaining to "storage" that I've taken into account for your reference/consideration.

```turtle
<http://www.w3.org/ns/pim/space#storage> <http://www.w3.org/2000/01/rdf-schema#comment> "The storage in which this workspace is, or the storage which\ncontains this resource, or a storage available to this agent to use." .

<http://www.w3.org/ns/auth/acl#Authorization> <http://www.w3.org/2000/01/rdf-schema#comment> "An element of access control,\n    allowing agent to agents access of some kind to resources or classes of resources" .

<http://www.w3.org/ns/auth/acl#owner> <http://www.w3.org/2000/01/rdf-schema#comment> "The person or other agent which owns this.\n    For example, the owner of a file in a filesystem.\n    There is a sense of right to control.   Typically defaults to the agent who craeted\n    something but can be changed." .

<http://www.w3.org/ns/auth/acl#delegates> <http://www.w3.org/2000/01/rdf-schema#comment> "Delegates a person or another agent to act on behalf of the agent.\n    For example, Alice delegates Bob to act on behalf of Alice for ACL purposes." .
```

https://www.w3.org/DesignIssues/CloudStorage
>There is an architecture in which a few existing or Web protocols are gathered together with some glue to make a world wide system in which applications (desktop or Web Application) can work on top of a layer of commodity read-write storage. Crucial design issues are that principals (users) and groups are identifies by URIs, and so are global in scope, and that elements of storage are access controlled using those global identifiers. The result is that storage becomes a commodity, independent of the application running on it.

>This can be called "socially-aware" storage, because the access control within the storage layer is just powerful enough to implement the social requirements of the social network applications.

https://solidproject.org/TR/2021/protocol-20211217#data-pod
>data pod
>    A data pod is a place for storing documents, with mechanisms for controlling who can access what.

https://solidproject.org/TR/2021/protocol-20211217#storage
>Servers MUST provide one or more storages (pim:Storage) – a space of URIs in which data can be accessed. A storage is the root container for all of its contained resources (see Resource Containment).

https://solidproject.org/ED/protocol#solid-app
>Solid app
>    A Solid app is an application that reads or writes data from one or more storages.

https://solidproject.org/ED/protocol#owner
>owner
>    An owner is a person or a social entity that is considered to have the rights and responsibilities of a data storage. An owner is identified by a URI, and implicitly has control over all data in a storage. An owner is first set at storage provisioning time and can be changed.

https://solid.github.io/solid-oidc/
>Hosting Client ID Document on Solid Storage

https://www.w3.org/wiki/WebAccessControl
>The design goal is that the WebAccessControl storage should be a creative medium in which

>without the intervention of administrative humans running the storage server.

https://solid.github.io/authorization-panel/acp-specification/
> Effective Policies are the Policies controlling access to a resource.

>This creates natural data boundaries that make data storage and authorization more intuitive.


https://github.com/solid/specification/issues/355#issuecomment-979503292
>we should be careful to name stuff that infringes on the authority of a storage (being roughly the same as a "pod", but I use the term storage, since that is what is specified) to control its URI space. This seems to turn into two distinct classes of things though: Those things that are within the URI space controlled by a storage and those that aren't. Those things that are within the space controlled by a storage should be discovered by interrogating the storage, but that leaves us with the requirement that storages must be really easy to discover, which they aren't now (#310). There should be a list of storages hosted by a server somewhere.

https://www.rfc-editor.org/rfc/rfc7231#section-4.3.4
>It does not define how
>   resource state is "stored", nor how such storage might change as a
>   result of a change in resource state

https://www.rfc-editor.org/rfc/rfc7231#section-4.3.5
> associated storage might or might not be reclaimed

https://www.rfc-editor.org/rfc/rfc7231#section-9.1
>Similar naming conventions might exist
   within other types of storage systems.

https://solidproject.org/
>Solid is a specification that lets people store their data securely in decentralized data stores called Pods. Pods are like secure personal web servers for data. When data is stored in someone's Pod, they control which people and applications can access it. 

https://solid.github.io/authorization-panel/authorization-ucr/#uc-inheritance
>The group uses a resource server for storing their information at https://research.example/, which Bob administers as the resource controller.

https://github.com/solid/authentication-panel/blob/main/proposals/HttpSignature.md
>Alice makes a request to a resource &lt;/comments/&gt; on her Personal Online Data Store (POD) at &lt;https://alice.name&gt;

https://solid.github.io/notifications/protocol#notification-channel-discovery
>When a server wants to enable applications to discover Notification Channels available to a storage in which a given resource is in
