### PR TITLE
Add TR/2022/protocol-20221231

### DIFF
--- a/2022/protocol-20221231.html
+++ b/2022/protocol-20221231.html
@@ -199,12 +199,12 @@ margin-top:1em;
 
           <dl id="document-identifier">
             <dt>This version</dt>
-            <dd><a href="https://solidproject.org/TR/2022/protocol-20221231" rel="owl:sameAs mem:memento">https://solidproject.org/TR/2022/protocol-20221231</a></dd>
+            <dd><a href="https://solidproject.org/TR/2022/protocol-20221231" rel="owl:sameAs">https://solidproject.org/TR/2022/protocol-20221231</a></dd>
           </dl>
 
           <dl id="document-latest-published-version">
             <dt>Latest published version</dt>
-            <dd><a href="https://solidproject.org/TR/protocol" rel="rel:latest-version">https://solidproject.org/TR/protocol</a></dd>
+            <dd><a href="https://solidproject.org/TR/protocol" rel="rel:latest-version mem:original">https://solidproject.org/TR/protocol</a></dd>
           </dl>
 
           <dl id="document-previous-version">
@@ -230,7 +230,7 @@ margin-top:1em;
 
           <dl id="document-published">
             <dt>Published</dt>
-            <dd><time content="2020-12-16T00:00:00Z" datatype="xsd:dateTime" datetime="2020-12-16T00:00:00Z" property="schema:datePublished">2020-12-16</time></dd>
+            <dd><time content="2022-12-31T00:00:00Z" datatype="xsd:dateTime" datetime="2022-12-31T00:00:00Z" property="schema:datePublished">2022-12-31</time></dd>
           </dl>
 
           <dl id="document-modified">
@@ -257,6 +257,11 @@ margin-top:1em;
           <dl id="document-status">
             <dt>Document Status</dt>
             <dd prefix="pso: http://purl.org/spar/pso/" rel="pso:holdsStatusInTime" resource="#b8028e44-185c-4b71-9c9f-d6e6b7c751d8"><span rel="pso:withStatus" resource="http://purl.org/spar/pso/published" typeof="pso:PublicationStatus">Published</span></dd>
+          </dl>
+
+          <dl id="document-resource-state">
+            <dt>Resource State</dt>
+            <dd><span about="" typeof="mem:Memento">Memento</span></dd>
           </dl>
 
           <dl id="document-in-reply-to">

--- a/protocol.timemap.html
+++ b/protocol.timemap.html
@@ -26,6 +26,7 @@
             <dd about="https://solidproject.org/TR/protocol">
               <ul>
                 <li><a rel="mem:memento" href="https://solidproject.org/TR/2021/protocol-20211217">https://solidproject.org/TR/2021/protocol-20211217</a> (<time about="https://solidproject.org/TR/2021/protocol-20211217" datatype="xsd:dateTime" datetime="2021-12-17T00:00:00Z" property="mem:mementoDateTime">2021-12-17T00:00:00Z</time>)</li>
+                <li><a rel="mem:memento" href="https://solidproject.org/TR/2022/protocol-20221231">https://solidproject.org/TR/2022/protocol-20221231</a> (<time about="https://solidproject.org/TR/2022/protocol-20221231" datatype="xsd:dateTime" datetime="2022-12-31T00:00:00Z" property="mem:mementoDateTime">2022-12-31T00:00:00Z</time>)</li>
               </ul>
             </dd>
           </dl>


### PR DESCRIPTION
Add Solid Protocol, Version 0.10.0.

`#change-log` section indicates changes since [TR/2022/protocol-20211217](https://solidproject.org/TR/2021/protocol-20211217).

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/dbefa0d6bf82baaf1bd5305c38845ac6bc491afa/protocol.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F8efc7b5e67bbaf005412aec8855989f1af19067f%2Fprotocol.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fdbefa0d6bf82baaf1bd5305c38845ac6bc491afa%2Fprotocol.html)