### PR TITLE
Add server-content-type-payload

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -645,6 +645,8 @@ margin-top:1em;
 
                   <p><span about="" id="server-authentication" rel="spec:requirement" resource="#server-authentication"><span property="spec:statement"><span rel="spec:requirementSubject" resource="#Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> conform to <cite>HTTP/1.1 Authentication</cite> [<cite><a class="bibref" href="#bib-rfc7235">RFC7235</a></cite>].</span></span> <span about="" id="server-unauthenticated" rel="spec:requirement" resource="#server-unauthenticated"><span property="spec:statement">When a client does not provide valid credentials when requesting a resource that requires it (see <a href="#webid">WebID</a>), <span rel="spec:requirementSubject" resource="#Server">servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> send a response with a <code>401</code> status code (unless <code>404</code> is preferred for security reasons).</span></span></p>
 
+                  <p><span about="" id="server-content-type-payload" rel="spec:requirement" resource="#server-content-type-payload"><span property="spec:statement"><span rel="spec:requirementSubject" resource="#Server">Server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> generate a <code>Content-Type</code> header field in a message that contains a payload body.</span></span></p>
+
                   <p><span about="" id="server-content-type" rel="spec:requirement" resource="#server-content-type"><span property="spec:statement"><span rel="spec:requirementSubject" resource="#Server">Server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> reject <code>PUT</code>, <code>POST</code> and <code>PATCH</code> requests without the <code>Content-Type</code> header with a status code of <code>400</code>.</span></span> [<a href="https://github.com/solid/specification/issues/70#issuecomment-547924171" rel="cito:citesAsSourceDocument">Source</a>]</p>
                 </div>
               </section>
@@ -1418,6 +1420,7 @@ margin-top:1em;
                 <div datatype="rdf:HTML" property="schema:description">
                   <ul>
                     <li>Amend language, document details, and markup.</li>
+                    <li>Add requirement for server to include <code>Content-Type</code> in <a href="#server-content-type-payload">messages with payload</a>.</li>
                   </ul>
                 </div>
               </section>


### PR DESCRIPTION
This change adds a new feature as per https://www.w3.org/2021/Process-20211102/#class-4 :

Add requirement for server to include `Content-Type` in messages with payload in Solid Protocol.

Server including `Content-Type` in the response of a message including a payload is not guaranteed as per RFC 7231 since the inclusion is a SHOULD. It follows that the response may trigger the client to do MIME type sniffing. This requirement will ensure that server will have awareness of the media type of the message with a MUST, and clients to follow the provided `Content-Type`.

Moreover, the Solid Protocol requires that clients MUST include the `Content-Type` in `PUT`, `POST`, `PATCH` requests. It does not however necessarily follow that the server will preserve the media type (or its alternatives). Lastly, while a storage may potentially include resources that were not initially provided by a client - in which case the interaction is technically out of scope of Solid Protocol - this server requirement will ensure that HTTP messages will indeed include a `Content-Type` irrespective to however resources became available from a storage.

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/dd639ef5be43f02a6aee231f8d6185b80e2bd487/ED/protocol.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F9af6f69286a12a12aebb1bc633e99eb17cfa2c61%2FED%2Fprotocol.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fdd639ef5be43f02a6aee231f8d6185b80e2bd487%2FED%2Fprotocol.html)