### PR TITLE
Update to W3C Process 20230612

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -232,7 +232,7 @@ margin-top:1em;
 
           <dl id="document-modified">
             <dt>Modified</dt>
-            <dd><time content="2023-04-17T00:00:00Z" datatype="xsd:dateTime" datetime="2023-04-17T00:00:00Z" property="schema:dateModified">2023-04-17</time></dd>
+            <dd><time content="2023-06-12T00:00:00Z" datatype="xsd:dateTime" datetime="2023-06-12T00:00:00Z" property="schema:dateModified">2023-06-12</time></dd>
           </dl>
 
           <dl id="document-repository">
@@ -1411,7 +1411,7 @@ margin-top:1em;
             <div datatype="rdf:HTML" property="schema:description">
               <p><em>This section is non-normative.</em></p>
 
-              <p>The summary of <em>editorial</em> and <em>substantive</em> changes in this section are based on <cite>W3C Process Document</cite> <cite><a href="https://www.w3.org/2021/Process-20211102/#correction-classes">Classes of Changes</a></cite> [<cite><a class="bibref" href="#bib-w3c-process">W3C-PROCESS</a></cite>].</p>
+              <p>The summary of <em>editorial</em> and <em>substantive</em> changes in this section are based on <cite>W3C Process Document</cite> <cite><a href="https://www.w3.org/2023/Process-20230612/#correction-classes">Classes of Changes</a></cite> [<cite><a class="bibref" href="#bib-w3c-process">W3C-PROCESS</a></cite>].</p>
 
               <p><a about="https://solidproject.org/ED/protocol" href="https://solidproject.org/ED/protocol" rel="prov:wasRevisionOf" resource="https://solidproject.org/TR/2022/protocol-20221231">ED</a> ← <a about="https://solidproject.org/TR/2022/protocol-20221231" rel="prov:wasRevisionOf" href="https://solidproject.org/TR/2022/protocol-20221231" resource="https://solidproject.org/TR/2021/protocol-20211217">protocol-20221231</a> ← <a href="https://solidproject.org/TR/2021/protocol-20211217">protocol-20211217</a></p>
 
@@ -1566,7 +1566,7 @@ margin-top:1em;
                     <dt id="bib-ethical-web-principles">[ETHICAL-WEB-PRINCIPLES]</dt>
                     <dd><a href="https://www.w3.org/TR/ethical-web-principles/" rel="cito:citesAsPotentialSolution"><cite>W3C TAG Ethical Web Principles</cite></a>. Daniel Appelquist; Hadley Beeman; Amy Guy.  W3C. 12 May 2022. W3C Group Draft Note. URL: <a href="https://www.w3.org/TR/ethical-web-principles/">https://www.w3.org/TR/security-privacy-questionnaire/</a></dd>
                     <dt id="bib-w3c-process">[W3C-PROCESS]</dt>
-                    <dd><a href="https://www.w3.org/Consortium/Process/" rel="cito:citesAsPotentialSolution"><cite>W3C Process Document</cite></a>. Elika J. Etemad / fantasai; Florian Rivoal;  W3C Process Community Group. 2 November 2021. URL: <a href="https://www.w3.org/Consortium/Process/">https://www.w3.org/Consortium/Process/</a></dd>
+                    <dd><a href="https://www.w3.org/Consortium/Process/" rel="cito:citesAsPotentialSolution"><cite>W3C Process Document</cite></a>. Elika J. Etemad / fantasai; Florian Rivoal;  W3C Process Community Group. 12 June 2023. URL: <a href="https://www.w3.org/Consortium/Process/">https://www.w3.org/Consortium/Process/</a></dd>
                     <dt id="bib-webid-tls">[WEBID-TLS]</dt>
                     <dd><a href="https://www.w3.org/2005/Incubator/webid/spec/tls/" rel="cito:citesAsPotentialSolution"><cite>WebID Authentication over TLS</cite></a>. Henry Story; Stéphane Corlosquet; Andrei Sambra.  W3C WebID Community Group. W3C Editor's Draft. URL: <a href="https://www.w3.org/2005/Incubator/webid/spec/tls/">https://www.w3.org/2005/Incubator/webid/spec/tls/</a></dd>
                   </dl>

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -233,7 +233,7 @@ margin-top:1em;
 
           <dl id="document-modified">
             <dt>Modified</dt>
-            <dd><time content="2023-03-15T00:00:00Z" datatype="xsd:dateTime" datetime="2023-03-15T00:00:00Z" property="schema:dateModified">2023-03-15</time></dd>
+            <dd><time content="2023-06-12T00:00:00Z" datatype="xsd:dateTime" datetime="2023-06-12T00:00:00Z" property="schema:dateModified">2023-06-12</time></dd>
           </dl>
 
           <dl id="document-repository">
@@ -942,7 +942,7 @@ margin-top:1em;
             <div datatype="rdf:HTML" property="schema:description">
               <p><em>This section is non-normative.</em></p>
 
-              <p>The summary of <em>editorial</em> and <em>substantive</em> changes in this section are based on <cite>W3C Process Document</cite> <cite><a href="https://www.w3.org/2021/Process-20211102/#correction-classes">Classes of Changes</a></cite> [<cite><a class="bibref" href="#bib-w3c-process">W3C-PROCESS</a></cite>].</p>
+              <p>The summary of <em>editorial</em> and <em>substantive</em> changes in this section are based on <cite>W3C Process Document</cite> <cite><a href="https://www.w3.org/2023/Process-20230612/#correction-classes">Classes of Changes</a></cite> [<cite><a class="bibref" href="#bib-w3c-process">W3C-PROCESS</a></cite>].</p>
             </div>
           </section>
 
@@ -1006,7 +1006,7 @@ margin-top:1em;
                     <dt id="bib-solid-technical-reports">[SOLID-TECHNICAL-REPORTS]</dt>
                     <dd><a href="https://solidproject.org/TR/" rel="cito:citesAsRelated"><cite>Solid Technical Reports</cite></a>. Sarven Capadisli.  W3C Solid Community Group. 5 January 2023. Living Document. URL: <a href="https://solidproject.org/TR/">https://solidproject.org/TR/</a></dd>
                     <dt id="bib-w3c-process">[W3C-PROCESS]</dt>
-                    <dd><a href="https://www.w3.org/Consortium/Process/" rel="cito:citesAsRelated"><cite>W3C Process Document</cite></a>. Elika J. Etemad (fantasai); Florian Rivoal.  W3C. 2 November 2021. URL: <a href="https://www.w3.org/Consortium/Process/">https://www.w3.org/Consortium/Process/</a></dd>
+                    <dd><a href="https://www.w3.org/Consortium/Process/" rel="cito:citesAsRelated"><cite>W3C Process Document</cite></a>. Elika J. Etemad (fantasai); Florian Rivoal.  W3C. 12 June 2023. URL: <a href="https://www.w3.org/Consortium/Process/">https://www.w3.org/Consortium/Process/</a></dd>
                   </dl>
                 </div>
               </section>


### PR DESCRIPTION
PR'd to create some awareness that the latest W3C Process as of this writing is https://www.w3.org/2023/Process-20230612/ .

Merging as the changes only referred by a non-normative section.