### PR TITLE
Add discovery and descriptions for implementation report, test suite, test case

### DIFF
--- a/ED/qa.html
+++ b/ED/qa.html
@@ -384,6 +384,7 @@ margin-top:1em;
                     <li><a href="#test-assertion-description"><span class="secno">4.3</span> <span class="content">Test Assertion Description</span></a></li>
                     <li><a href="#test-report-notification"><span class="secno">4.4</span> <span class="content">Test Report Notification</span></a></li>
                     <li><a href="#project-maintainer-input-review"><span class="secno">4.5</span> <span class="content">Project Maintainer Input and Review</span></a></li>
+                    <li><a href="#implementation-report-description"><span class="secno">4.6</span> <span class="content">Implementation Report Description</span></a></li>
                   </ol>
                 </li>
                 <li class="tocline">
@@ -678,8 +679,6 @@ margin-top:1em;
                   </div>
 
                   <p class="issue">Should <a href="https://www.w3.org/TR/annotation-vocab/">Web Annotation Vocabulary</a> be required to convey the relationship between test criteria and reviews?</p>
-
-                  <p class="issue">The test-report-summary-description. Aggregates test-report-descriptions.</p>
                 </div>
               </section>
 
@@ -746,6 +745,24 @@ margin-top:1em;
                 <h3 property="schema:name">Project Maintainer Input and Review</h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>Project maintainer will be notified to review the publication of a report, and if no objection within a certain time (TBD), it can be approved for publication by the submitter (or test suite panel). During the review process, maintainers will be given the opportunity to provide explanatory notes to go with the report.</p>
+                </div>
+              </section>
+
+              <section id="implementation-report-description" inlist="" rel="schema:hasPart" resource="#implementation-report-description">
+                <h3 property="schema:name">Implementation Report Description</h3>
+
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The Implementation Report Description refers to the criteria and resolutions set forth by the Group publishing a Technical Report to demonstrate implementation experience; refers to test reports; provides a summary.</p>
+
+                  <p>Document metadata:</p>
+
+                  <p class="issue">Similar to Test Report Description document metadata. Reuse or redefine?</p>
+
+                  <p>Referencing individual test reports:</p>
+
+                  <ul>
+                    <li>One or more <code>spec:testReport</code>s to refer to <a href="#test-report-description">test reports</a>.</li>
+                  </ul>
                 </div>
               </section>
             </div>

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -609,7 +609,7 @@ margin-top:1em;
                     <li>One <code>spec:implementationReport</code> property to refer to an <a href="#implementation-report-description">implementation report</a>.</li>
                   </ul>
 
-                  <p class="issue">Defining URI Templates for implementation report, e.g.,<code>https://solidproject.org/test-reports/{technical-report-short-name}/summary</code>, and test report, e.g., <code>https://solidproject.org/test-reports/{technical-report-short-name}/{uuid}</code></p>
+                  <p class="issue">Defining URI Templates for implementation report, e.g., <code>https://solidproject.org/test-reports/{technical-report-short-name}/summary</code>, and test report, e.g., <code>https://solidproject.org/test-reports/{technical-report-short-name}/{uuid}</code>.</p>
                 </div>
               </section>
             </div>

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -602,7 +602,14 @@ margin-top:1em;
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>The <cite><a href="https://github.com/solid/specification/blob/main/CONTRIBUTING.md">Solid Technical Reports Contributing Guide</a></cite> provides the recommendations for publishing technical reports following the <cite><a href="https://www.w3.org/DesignIssues/LinkedData">Linked Data</a></cite> design principles, where significant units of information, such as concepts and requirements, are given an identifier, and described with a <a href="https://www.w3.org/TR/rdf11-concepts/#dfn-concrete-rdf-syntax">concrete RDF syntax</a>. The <cite><a href="http://www.w3.org/ns/spec">Spec Terms</a></cite> vocabulary provides classes and properties that can be used to describe any significant unit of information in technical reports, as well as supporting the description of test cases and test reports. The <cite><a href="https://www.w3.org/TR/skos-reference/">SKOS</a></cite> data model can be used to identify, describe, and link concepts and definitions across technical reports.</p>
 
-                  <p>Specifications MUST link to approved Test Reports summary/index, e.g., <code>https://solidproject.org/test-reports/{technical-report-short-name}/summary</code> where it will link to individual implementation reports e.g., <code>https://solidproject.org/test-reports/{technical-report-short-name}/{uuid}</code>.</p>
+                  <p class="issue">Add other requirements from Spec Terms and SKOS.</p>
+
+                  <ul>
+                    <li>One <code>spec:testSuite</code> property to refer to a <a href="#test-suite-description">test suite</a>.</li>
+                    <li>One <code>spec:implementationReport</code> property to refer to an <a href="#implementation-report-description">implementation report</a>.</li>
+                  </ul>
+
+                  <p class="issue">Defining URI Templates for implementation report, e.g.,<code>https://solidproject.org/test-reports/{technical-report-short-name}/summary</code>, and test report, e.g., <code>https://solidproject.org/test-reports/{technical-report-short-name}/{uuid}</code></p>
                 </div>
               </section>
             </div>

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -397,8 +397,8 @@ margin-top:1em;
                 <li class="tocline">
                   <a class="tocxref" href="#test-assessment"><span class="secno">6</span> <span class="content">Test Assessment</span></a>
                   <ol>
-                    <li><a href="#test-suite-description"><span class="secno">6.1</span> <span class="content">Test Review Policy</span></a></li>
-                    <li><a href="#test-environment"><span class="secno">6.1</span> <span class="content">Test Review Criteria</span></a></li>
+                    <li><a href="#test-review-policy"><span class="secno">6.1</span> <span class="content">Test Review Policy</span></a></li>
+                    <li><a href="#test-review-criteria"><span class="secno">6.1</span> <span class="content">Test Review Criteria</span></a></li>
                   </ol>
                 </li>
                 <li class="tocline">
@@ -775,7 +775,7 @@ margin-top:1em;
             </div>
           </section>
 
-          <section id="test-suite" inlist="" rel="schema:hasPart" resource="#test-suite-description">
+          <section id="test-suite" inlist="" rel="schema:hasPart" resource="#test-suite">
             <h2 property="schema:name">Test Suite</h2>
             <div datatype="rdf:HTML" property="schema:description">
               <p>This section describes the requirements for test suite and test metadata.</p>
@@ -838,7 +838,7 @@ margin-top:1em;
                 </div>
               </section>
 
-              <section id="test-review" inlist="" rel="schema:hasPart" resource="#test-review">
+              <section id="test-review-criteria" inlist="" rel="schema:hasPart" resource="#test-review-criteria">
                 <h3 property="schema:name">Test Review Criteria</h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <ul>

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -779,6 +779,11 @@ margin-top:1em;
                 <h3 property="schema:name">Test Suite Description</h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>Description of test suites (e.g., license, date, written by, reviewed by), the software (e.g., repository, version, maintainers), setup (e.g., platform, configuration), provenance (e.g., activity, entity, agent), input about environment (e.g., combination of subject and setup). Meet the requirements of reporting (issue 5) and test review checklist (issue 7).</p>
+
+                  <ul>
+                    <li>One <code>rdf:type</code> property whose object is <code>spec:TestSuite</code> (TBD).</li>
+                    <li>One or more <code>spec:testCase</code>s to refer to <a href="#test-case-description">test cases</a>.</li>
+                  </ul>
                 </div>
               </section>
 


### PR DESCRIPTION
Follows actions of https://github.com/solid/test-suite-panel/blob/main/meetings/2023-05-16.md

* Update technical-report-description (for the discovery of implementation report and test suite)
* Update test-suite-description (for the discovery of test cases)
* Add implementation-report-description

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/bb84886d41ae9b9487c384cbc1ae2ad25b3645f5/ED/qa.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F0a14f9b6011d8db394cbd26e3a7b09037715b4d9%2FED%2Fqa.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fbb84886d41ae9b9487c384cbc1ae2ad25b3645f5%2FED%2Fqa.html)