### PR TITLE
Add Work Items section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,32 @@ repository, create a PR.
 Congratulations :tada: Solid community thanks you :sparkles:.
 
 
+## Work items
+
+In general, all documents in scope of the group are welcome. Work items can be
+documents or software.
+
+### New work item proposal
+
+* Propose new work item as an issue in https://github.com/solid/specification
+  and propose it as an agenda topic in a group meeting.
+* Include publicly accessible link to abstract or draft.
+* List and link to owners (at least 1 person for advancing the work item and 1
+  other person).
+* Answer the following questions in order to document how you are meeting the
+  requirements for a new work item at the W3C Solid Community Group. Please
+  note if this work item supports certain programs or another government or
+  private sector project.
+  1. Explain what you are trying to do using no jargon or acronyms.
+  2. How is it done today, and what are the limits of the current practice?
+  3. What is new in your approach and why do you think it will be successful?
+  4. How are you involving participants from multiple skill sets and global
+     locations in this work item? (Skill sets: technical, design, product,
+     marketing, anthropological, and UX. Global locations: Africa, the
+     Americas, APAC, Europe, Middle East.)
+  5. What actions are you taking to make this work item accessible to a
+     non-technical audience?
+
 
 ## Publishing a technical report
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,13 +206,13 @@ documents or software.
   requirements for a new work item at the W3C Solid Community Group. Please
   note if this work item supports certain programs or another government or
   private sector project.
-  1. Explain what you are trying to do using no jargon or acronyms.
+  1. Explain what you are trying to do, using no jargon or acronyms.
   2. How is it done today, and what are the limits of the current practice?
-  3. What is new in your approach and why do you think it will be successful?
+  3. What is new in your approach, and why do you think it will be successful?
   4. How are you involving participants from multiple skill sets and global
      locations in this work item? (Skill sets: technical, design, product,
      marketing, anthropological, and UX. Global locations: Africa, the
-     Americas, APAC, Europe, Middle East.)
+     Americas, APAC, Europe, Middle East, Antarctica.)
   5. What actions are you taking to make this work item accessible to a
      non-technical audience?
 


### PR DESCRIPTION
The proposed CG charter includes a process for [new work item proposals](https://github.com/solid/process/blob/7a8cfc55edaaf9de26252976fa8365d7c884bdc7/solid-cg-charter.md#new-work-item-proposal) (NWIP).

As mentioned, "some of this information could be moved to other documents". So, this PR moves NWIP from proposed Charter to the [Contributing Guide](https://github.com/solid/specification/blob/main/CONTRIBUTING.md).

Merging this PR should follow be followed with committing suggestion to refer to NWIP in Contributing Guide: https://github.com/solid/process/pull/323/files#r1267917483
