### PR TITLE
Fix: update SAI primer link

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@ border-bottom: 2pt solid #000;
                     <td><abbr title="To Be Determined">TBD</abbr></td>
                   </tr>
                   <tr>
-                    <td><a href="https://solid.github.io/data-interoperability-panel/primer/" rel="cito:citesForInformation">Solid Application Interoperability Primer</a></td>
+                    <td><a href="https://solid.github.io/data-interoperability-panel/primer/application.html" rel="cito:citesForInformation">Solid Application Interoperability: Application Primer</a></td>
                     <td><a href="https://github.com/solid/data-interoperability-panel">https://github.com/solid/data-interoperability-panel</a></td>
                     <td>Editor’s Draft</td>
                     <td><abbr title="To Be Determined">TBD</abbr></td>

--- a/index.html
+++ b/index.html
@@ -261,6 +261,12 @@ border-bottom: 2pt solid #000;
                     <td>Editor’s Draft</td>
                     <td><abbr title="To Be Determined">TBD</abbr></td>
                   </tr>
+                  <tr>
+                    <td><a href="https://solid.github.io/data-interoperability-panel/primer/authorization-agent.html" rel="cito:citesForInformation">Solid Application Interoperability: Authorization Agent Primer</a></td>
+                    <td><a href="https://github.com/solid/data-interoperability-panel">https://github.com/solid/data-interoperability-panel</a></td>
+                    <td>Editor’s Draft</td>
+                    <td><abbr title="To Be Determined">TBD</abbr></td>
+                  </tr>
                 </tbody>
 
                 <tfoot>

--- a/index.html
+++ b/index.html
@@ -258,13 +258,13 @@ border-bottom: 2pt solid #000;
                   <tr>
                     <td><a href="https://solid.github.io/data-interoperability-panel/primer/application.html" rel="cito:citesForInformation">Solid Application Interoperability: Application Primer</a></td>
                     <td><a href="https://github.com/solid/data-interoperability-panel">https://github.com/solid/data-interoperability-panel</a></td>
-                    <td>Editor’s Draft</td>
+                    <td>Unofficial Draft</td>
                     <td><abbr title="To Be Determined">TBD</abbr></td>
                   </tr>
                   <tr>
                     <td><a href="https://solid.github.io/data-interoperability-panel/primer/authorization-agent.html" rel="cito:citesForInformation">Solid Application Interoperability: Authorization Agent Primer</a></td>
                     <td><a href="https://github.com/solid/data-interoperability-panel">https://github.com/solid/data-interoperability-panel</a></td>
-                    <td>Editor’s Draft</td>
+                    <td>Unofficial Draft</td>
                     <td><abbr title="To Be Determined">TBD</abbr></td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
Going through the TRs I noticed the link to the SAI primer resulted in a 404. I believe this has not been updated since SAI split the primer into separate parts aimed at the different conformance classes. Can you confirm this, @elf-pavlik?

I also corrected the status of the primer(s), which said ED but is in fact UD according to the documents themselves.

Target | Correction class | Note
-- | -- | --
#work-item-technical-reports | [2](https://www.w3.org/2021/Process-20211102/#class-2) | update broken link
#work-item-technical-reports | [2](https://www.w3.org/2021/Process-20211102/#class-2) | correct displayed draft status

_(The TR table does not containe more finegrained IDs, so could not put more detail in correction table above.)_

[HTML Preview](https://htmlpreview.github.io/?https://github.com/solid/specification/blob/95d3904794ebef4c1f7e66d33299a899f889dd86/index.html)