### PR TITLE
Feat: update HTTP refs in QA

### DIFF
--- a/ED/qa.html
+++ b/ED/qa.html
@@ -1000,12 +1000,12 @@ margin-top:1em;
                     <dd><a href="https://datatracker.ietf.org/doc/html/rfc2119" rel="cito:citesAsAuthority"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a></dd>
                     <dt id="bib-rfc3986">[RFC3986]</dt>
                     <dd><a href="https://datatracker.ietf.org/doc/html/rfc3986" rel="cito:citesAsAuthority"><cite>Uniform Resource Identifier (URI): Generic Syntax</cite></a>. T. Berners-Lee; R. Fielding; L. Masinter.  IETF. January 2005. Internet Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc3986">https://datatracker.ietf.org/doc/html/rfc3986</a></dd>
+                    <dt id="bib-rfc8174">[RFC8174]</dt>
+                    <dd><a href="https://datatracker.ietf.org/doc/html/rfc8174" rel="cito:citesAsAuthority"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8174">https://datatracker.ietf.org/doc/html/rfc8174</a></dd>
                     <dt id="bib-rfc9110">[RFC9110]</dt>
                     <dd><a href="https://www.rfc-editor.org/rfc/rfc9110" rel="cito:citesAsAuthority"><cite>HTTP Semantics</cite></a>. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed..  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a></dd>
                     <dt id="bib-rfc9113">[RFC9113]</dt>
                     <dd><a href="https://www.rfc-editor.org/rfc/rfc9113" rel="cito:citesAsAuthority"><cite>HTTP/2</cite></a>. M. Thomson, Ed.; C. Benfield, Ed..  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9113">https://www.rfc-editor.org/rfc/rfc9113</a></dd>
-                    <dt id="bib-rfc8174">[RFC8174]</dt>
-                    <dd><a href="https://datatracker.ietf.org/doc/html/rfc8174" rel="cito:citesAsAuthority"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8174">https://datatracker.ietf.org/doc/html/rfc8174</a></dd>
                     <dt id="bib-skos-reference">[skos-reference]</dt>
                     <dd><a href="https://www.w3.org/TR/skos-reference/" rel="cito:citesAsAuthority"><cite>SKOS Simple Knowledge Organization System Reference</cite></a>. Alistair Miles; Sean Bechhofer.  W3C. 18 August 2009. W3C Recommendation. URL: <a href="https://www.w3.org/TR/skos-reference/">https://www.w3.org/TR/skos-reference/</a></dd>
                     <dt id="bib-test-metadata">[test-metadata]</dt>

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -1003,9 +1003,9 @@ margin-top:1em;
                     <dt id="bib-rfc8174">[RFC8174]</dt>
                     <dd><a href="https://datatracker.ietf.org/doc/html/rfc8174" rel="cito:citesAsAuthority"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8174">https://datatracker.ietf.org/doc/html/rfc8174</a></dd>
                     <dt id="bib-rfc9110">[RFC9110]</dt>
-                    <dd><a href="https://www.rfc-editor.org/rfc/rfc9110" rel="cito:citesAsAuthority"><cite>HTTP Semantics</cite></a>. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed..  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a></dd>
+                    <dd><a href="https://www.rfc-editor.org/rfc/rfc9110" rel="cito:citesAsAuthority"><cite>HTTP Semantics</cite></a>. R. Fielding, M. Nottingham, J. Reschke, Editors.  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a></dd>
                     <dt id="bib-rfc9113">[RFC9113]</dt>
-                    <dd><a href="https://www.rfc-editor.org/rfc/rfc9113" rel="cito:citesAsAuthority"><cite>HTTP/2</cite></a>. M. Thomson, Ed.; C. Benfield, Ed..  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9113">https://www.rfc-editor.org/rfc/rfc9113</a></dd>
+                    <dd><a href="https://www.rfc-editor.org/rfc/rfc9113" rel="cito:citesAsAuthority"><cite>HTTP/2</cite></a>. M. Thomson, C. Benfield, Editors.  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9113">https://www.rfc-editor.org/rfc/rfc9113</a></dd>
                     <dt id="bib-skos-reference">[skos-reference]</dt>
                     <dd><a href="https://www.w3.org/TR/skos-reference/" rel="cito:citesAsAuthority"><cite>SKOS Simple Knowledge Organization System Reference</cite></a>. Alistair Miles; Sean Bechhofer.  W3C. 18 August 2009. W3C Recommendation. URL: <a href="https://www.w3.org/TR/skos-reference/">https://www.w3.org/TR/skos-reference/</a></dd>
                     <dt id="bib-test-metadata">[test-metadata]</dt>

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -1000,10 +1000,10 @@ margin-top:1em;
                     <dd><a href="https://datatracker.ietf.org/doc/html/rfc2119" rel="cito:citesAsAuthority"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a></dd>
                     <dt id="bib-rfc3986">[RFC3986]</dt>
                     <dd><a href="https://datatracker.ietf.org/doc/html/rfc3986" rel="cito:citesAsAuthority"><cite>Uniform Resource Identifier (URI): Generic Syntax</cite></a>. T. Berners-Lee; R. Fielding; L. Masinter.  IETF. January 2005. Internet Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc3986">https://datatracker.ietf.org/doc/html/rfc3986</a></dd>
-                    <dt id="bib-rfc7231">[RFC7231]</dt>
-                    <dd><a href="https://httpwg.org/specs/rfc7231.html" rel="cito:citesAsAuthority"><cite>Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</cite></a>. R. Fielding, Ed.; J. Reschke, Ed..  IETF. June 2014. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc7231.html">https://httpwg.org/specs/rfc7231.html</a></dd>
-                    <dt id="bib-rfc7540">[RFC7540]</dt>
-                    <dd><a href="https://httpwg.org/specs/rfc7540.html" rel="cito:citesAsAuthority"><cite>Hypertext Transfer Protocol Version 2 (HTTP/2)</cite></a>. M. Belshe; R. Peon; M. Thomson, Ed..  IETF. May 2015. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc7540.html">https://httpwg.org/specs/rfc7540.html</a></dd>
+                    <dt id="bib-rfc9110">[RFC9110]</dt>
+                    <dd><a href="https://www.rfc-editor.org/rfc/rfc9110" rel="cito:citesAsAuthority"><cite>HTTP Semantics</cite></a>. R. Fielding, Ed.; M. Nottingham, Ed.; J. Reschke, Ed..  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a></dd>
+                    <dt id="bib-rfc9113">[RFC9113]</dt>
+                    <dd><a href="https://www.rfc-editor.org/rfc/rfc9113" rel="cito:citesAsAuthority"><cite>HTTP/2</cite></a>. M. Thomson, Ed.; C. Benfield, Ed..  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9113">https://www.rfc-editor.org/rfc/rfc9113</a></dd>
                     <dt id="bib-rfc8174">[RFC8174]</dt>
                     <dd><a href="https://datatracker.ietf.org/doc/html/rfc8174" rel="cito:citesAsAuthority"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8174">https://datatracker.ietf.org/doc/html/rfc8174</a></dd>
                     <dt id="bib-skos-reference">[skos-reference]</dt>


### PR DESCRIPTION
Following up on https://github.com/solid/specification/issues/471, this PR updates the references to HTTP RFCs from 7230/7540 to 9110/9113. While these are normative references, this has no impact, since they are not actually used in the draft.

If there still are any concerns about normative changes, you can check the changelogs here:
- [RFC7230 => RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#appendix-B.2)
- [RFC7540 => RFC9113](https://www.rfc-editor.org/rfc/rfc9113.html#name-changes-from-rfc-7540)

Target | Correction class | Note
-- | -- | --
#bib-rfc7231 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | removes (unused) reference to obsolete RFC7231
#bib-rfc7540 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | removes (unused) reference to obsolete RFC7540
#bib-rfc9110 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | inserts (unused) reference to replacing RFC9110
#bib-rfc9113 | [1](https://www.w3.org/2021/Process-20211102/#class-1) (no content change, only bibliography) | inserts (unused) reference to replacing RFC9113

[HTML Preview](https://htmlpreview.github.io/?https://github.com/woutermont/solid-specification/blob/feat/update-http-refs-qa/ED/qa.html) | [HTML Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.github.com%2Fsolid%2Fspecification%2Fmain%2FED%2Fqa.html&doc2=https%3A%2F%2Fraw.github.com%2Fwoutermont%2Fsolid-specification%2Ffeat%2Fupdate-http-refs-qa%2FED%2Fqa.html)

On a sidenote: do you all manually update the HTML here? Bikeshed or ReSpec are quite handy in keeping track of references, amongst other things.