### PR TITLE
Remove mention of Solid Process from SotD

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -329,7 +329,7 @@ tfoot dd + dt { margin-top:0; }
             <div datatype="rdf:HTML" property="schema:description">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/groups/cg/solid">Solid Community Group</a> as an <em>Editor’s Draft</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/specification/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/groups/cg/solid">Solid Community Group</a> as an <em>Editor’s Draft</em>. The information in this document is still subject to change. You are invited to <a href="https://github.com/solid/specification/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
               <p>Publication as an <em>Editor’s Draft</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 

--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -198,7 +198,7 @@ tfoot dd + dt { margin-top:0; }
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Solid Protocol</h1>
 
-        <p id="w3c-state">Version <span property="doap:revision">0.11.0</span> Editor’s Draft, <time>2023-07-14</time></p>
+        <p id="w3c-state">Version <span property="doap:revision">0.11.0</span> Editor’s Draft, <time>2023-10-18</time></p>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -236,7 +236,7 @@ tfoot dd + dt { margin-top:0; }
 
           <dl id="document-modified">
             <dt>Modified</dt>
-            <dd><time content="2023-07-14T00:00:00Z" datatype="xsd:dateTime" datetime="2023-07-14T00:00:00Z" property="schema:dateModified">2023-07-14</time></dd>
+            <dd><time content="2023-10-18T00:00:00Z" datatype="xsd:dateTime" datetime="2023-10-18T00:00:00Z" property="schema:dateModified">2023-10-18</time></dd>
           </dl>
 
           <dl id="document-repository">

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -327,7 +327,7 @@ margin-top:1em;
             <div datatype="rdf:HTML" property="schema:description">
               <p>This section describes the status of this document at the time of its publication.</p>
 
-              <p>This document was published by the <a href="https://www.w3.org/groups/cg/solid">Solid Community Group</a> as an <em>Editor’s Draft</em>. The sections that have been incorporated have been reviewed following the <a href="https://github.com/solid/process">Solid process</a>. However, the information in this document is still subject to change. You are invited to <a href="https://github.com/solid/specification/issues">contribute</a> any feedback, comments, or questions you might have.</p>
+              <p>This document was published by the <a href="https://www.w3.org/groups/cg/solid">Solid Community Group</a> as an <em>Editor’s Draft</em>. The information in this document is still subject to change. You are invited to <a href="https://github.com/solid/specification/issues">contribute</a> any feedback, comments, or questions you might have.</p>
 
               <p>Publication as an <em>Editor’s Draft</em> does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a draft document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress.</p>
 

--- a/ED/qa.html
+++ b/ED/qa.html
@@ -194,7 +194,7 @@ margin-top:1em;
       <article about="" typeof="schema:Article doap:Specification">
         <h1 property="schema:name">Solid QA</h1>
 
-        <p id="w3c-state">Version <span property="doap:revision">0.2.0</span> Editor’s Draft, <time>2023-07-24</time></p>
+        <p id="w3c-state">Version <span property="doap:revision">0.2.0</span> Editor’s Draft, <time>2023-10-18</time></p>
 
         <details open="">
           <summary>More details about this document</summary>
@@ -233,7 +233,7 @@ margin-top:1em;
 
           <dl id="document-modified">
             <dt>Modified</dt>
-            <dd><time content="2023-07-24T00:00:00Z" datatype="xsd:dateTime" datetime="2023-07-24T00:00:00Z" property="schema:dateModified">2023-07-24</time></dd>
+            <dd><time content="2023-10-18T00:00:00Z" datatype="xsd:dateTime" datetime="2023-10-18T00:00:00Z" property="schema:dateModified">2023-10-18</time></dd>
           </dl>
 
           <dl id="document-repository">


### PR DESCRIPTION
PR updates the SotD section given that the [Solid CG Charter](https://www.w3.org/community/solid/charter/) supersedes Solid Process.