### PR TITLE
Add consider-webid-profile

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -1272,12 +1272,9 @@ tfoot dd + dt { margin-top:0; }
 
                   <p id="consider-authorization-resources">Servers are encouraged to use authorization techniques to prevent unwanted access to resources, rather than depending on the relative obscurity of their resource names.</p>
 
-                  <section id="identifiable-information" inlist="" rel="schema:hasPart" resource="#identifiable-information">
-                    <h4 property="schema:name">Identifiable Information</h4>
-                    <div datatype="rdf:HTML" property="schema:description">
-                      <p id="consider-identifiable-information-error-responses">In order to prevent leakage of non-resource data, servers are strongly discouraged from including identifiable information in error responses.</p>
-                    </div>
-                  </section>
+                  <p id="consider-identifiable-information-error-responses">In order to prevent leakage of non-resource data, servers are strongly discouraged from including identifiable information in error responses.</p>
+
+                  <p id="consider-webid-profile">The decision to include or exclude any information, e.g., storage, inbox, in a WebID Profile served from a Solid storage lies with the agent controlling the WebID (or the URI owner). A URI allocated to a WebID in a Solid storage does not imply that the WebID is the storage owner. Owners of a WebID hosted from Solid storage are encouraged to take into account information related to themselves that could be readable from other resources in the storage, even if that information e.g., storage, inbox, is not part of the WebID Profile itself (<a href="#storage-owner-uri-ownership">Storage Owner and URI Ownership</a> and <a href="#self-describing-resources">Self-describing Resources</a>.)</p>
                 </div>
               </section>
 


### PR DESCRIPTION
This PR is a https://www.w3.org/2023/Process-20230612/#class-2 change in the specification updating the #privacy-considerations section by adding a consideration for #consider-webid-profile . It describes that the owner of a WebID Profile (in a Solid storage) ultimately decides what to include or exclude in its description, however, there may be other resources which may directly or indirectly reveal information, so the owners of the WebID are advised to take that into account.

[Preview](https://htmlpreview.github.io/?https://github.com/solid/specification/blob/e0cd730397700953eccb6a44edc3b0a93c3d38a4/ED/protocol.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fa5e7295919f9c679d335e7e3da2388a7f63c5f93%2FED%2Fprotocol.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fe0cd730397700953eccb6a44edc3b0a93c3d38a4%2FED%2Fprotocol.html)