### PR TITLE
Add document status to guides, templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,15 @@
+<details open="">
+  <summary>Document Status</summary>
+  <dl>
+    <dt>Modified</dt>
+    <dd>2024-01-10</dd>
+    <dt>Reason</dt>
+    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+  </dl>
+</details>
+
+---
+
 # Solid Technical Reports Contributing Guide
 
 Thank you for investing your time in contribution to the Solid project!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
     <dt>Modified</dt>
     <dd>2024-01-10</dd>
     <dt>Reason</dt>
-    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+    <dd>This document is no longer in effect and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
   </dl>
 </details>
 

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -1,3 +1,15 @@
+<details open="">
+  <summary>Document Status</summary>
+  <dl>
+    <dt>Modified</dt>
+    <dd>2024-01-10</dd>
+    <dt>Reason</dt>
+    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+  </dl>
+</details>
+
+---
+
 # W3C Solid Community Group Meeting Guidelines
 
 To reach consensus where no consensus has been reached before.

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -4,7 +4,7 @@
     <dt>Modified</dt>
     <dd>2024-01-10</dd>
     <dt>Reason</dt>
-    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+    <dd>This document is no longer in effect and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
   </dl>
 </details>
 

--- a/meetings/template.md
+++ b/meetings/template.md
@@ -1,3 +1,15 @@
+<details open="">
+  <summary>Document Status</summary>
+  <dl>
+    <dt>Modified</dt>
+    <dd>2024-01-10</dd>
+    <dt>Reason</dt>
+    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+  </dl>
+</details>
+
+---
+
 # W3C Solid Community Group: Meeting Title
 
 * Date: dateTime

--- a/meetings/template.md
+++ b/meetings/template.md
@@ -4,7 +4,7 @@
     <dt>Modified</dt>
     <dd>2024-01-10</dd>
     <dt>Reason</dt>
-    <dd>This document is no longer effective and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
+    <dd>This document is no longer in effect and is no longer being updated here. For the latest information on the <a href="https://www.w3.org/groups/cg/solid/">W3C Solid Community Group</a>, please refer to its <a href="https://github.com/w3c-cg/solid/">repository</a>, <a href="https://www.w3.org/community/solid/charter/">charter</a>, and <a href="https://github.com/w3c-cg/solid/blob/main/CONTRIBUTING.md">contributing guidelines</a>.</dd>
   </dl>
 </details>
 


### PR DESCRIPTION
This PR adds document status (modified and reason) to documents pertaining to the Solid CG. It follows a 2023-10-10 Solid CG meeting actions with the goal to clean-up / update references to CG's work. A related change was also made by https://github.com/solid/process/pull/331 .