### PR TITLE
Add TR/2024/wac-20240512

### DIFF
--- a/2024/wac-20240512.html
+++ b/2024/wac-20240512.html
@@ -291,12 +291,12 @@ margin-bottom:0.5rem;
 
             <dl id="document-identifier">
               <dt>This version</dt>
-              <dd><a href="https://solidproject.org/TR/2024/wac-20240512" rel="owl:sameAs mem:memento">https://solidproject.org/TR/2024/wac-20240512</a></dd>
+              <dd><a href="https://solidproject.org/TR/2024/wac-20240512" rel="owl:sameAs">https://solidproject.org/TR/2024/wac-20240512</a></dd>
             </dl>
 
             <dl id="document-latest-published-version">
               <dt>Latest published version</dt>
-              <dd><a href="https://solidproject.org/TR/wac" rel="rel:latest-version">https://solidproject.org/TR/wac</a></dd>
+              <dd><a href="https://solidproject.org/TR/wac" rel="rel:latest-version mem:original">https://solidproject.org/TR/wac</a></dd>
             </dl>
 
             <dl id="document-previous-version">
@@ -333,12 +333,12 @@ margin-bottom:0.5rem;
 
             <dl id="document-created">
               <dt>Created</dt>
-              <dd><time content="2021-03-29T00:00:00Z" datatype="xsd:dateTime" datetime="2021-03-29T00:00:00Z" property="schema:dateCreated">2021-03-29</time></dd>
+              <dd><time content="2024-05-12T00:00:00Z" datatype="xsd:dateTime" datetime="2024-05-12T00:00:00Z" property="schema:dateCreated">2024-05-12</time></dd>
             </dl>
 
             <dl id="document-published">
               <dt>Published</dt>
-              <dd><time content="2021-07-11T00:00:00Z" datatype="xsd:dateTime" datetime="2021-07-11T00:00:00Z" property="schema:datePublished">2021-07-11</time></dd>
+              <dd><time content="2024-05-12T00:00:00Z" datatype="xsd:dateTime" datetime="2024-05-12T00:00:00Z" property="schema:datePublished">2024-05-12</time></dd>
             </dl>
 
             <dl id="document-modified">

--- a/wac.timemap.html
+++ b/wac.timemap.html
@@ -27,6 +27,7 @@
               <ul>
                 <li><a rel="mem:memento" href="https://solidproject.org/TR/2021/wac-20210711">https://solidproject.org/TR/2021/wac-20210711</a> (<time about="https://solidproject.org/TR/2021/wac-20210711" datatype="xsd:dateTime" datetime="2021-07-11T00:00:00Z" property="mem:mementoDateTime">2021-07-11T00:00:00Z</time>)</li>
                 <li><a rel="mem:memento" href="https://solidproject.org/TR/2022/wac-20220705">https://solidproject.org/TR/2022/wac-20220705</a> (<time about="https://solidproject.org/TR/2022/wac-20220705" datatype="xsd:dateTime" datetime="2022-07-05T00:00:00Z" property="mem:mementoDateTime">2022-07-05T00:00:00Z</time>)</li>
+                <li><a rel="mem:memento" href="https://solidproject.org/TR/2024/wac-20240512">https://solidproject.org/TR/2024/wac-20240512</a> (<time about="https://solidproject.org/TR/2024/wac-20240512" datatype="xsd:dateTime" datetime="2022-07-05T00:00:00Z" property="mem:mementoDateTime">2024-05-12T00:00:00Z</time>)</li>
               </ul>
             </dd>
           </dl>


### PR DESCRIPTION
Add Web Access Control, Version 1.0. Publishes:

* This version: https://solidproject.org/TR/2024/wac-20240512 (add)
* Latest published version: https://solidproject.org/TR/wac (update)
* TimeMap: https://solidproject.org/TR/wac.timemap (update)

"This version" is a request to be published as a CG-DRAFT report of the Solid CG.

---

The `#changelog` section indicates changes since [TR/2022/wac-20220705](https://solidproject.org/TR/2022/wac-20220705).

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/6dfc5b77c6d6f7b37d8bc98fcd7f49c917c658ef/wac.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2Fcc42a36928a7961ecc34923fe4b375f5a95f6389/wac.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F6dfc5b77c6d6f7b37d8bc98fcd7f49c917c658ef/wac.html)