### PR TITLE
fix wrong heading level

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -712,7 +712,7 @@ content:counter(appendix, upper-alpha) "." counter(sub-appendix) "\00a0";
                   <p><em>This section is non-normative.</em></p>
 
                   <section id="relationship-to-ldp" inlist="" rel="schema:hasPart" resource="#relationship-to-ldp">
-                    <h3 property="schema:name">Relationship to LDP</h3>
+                    <h4 property="schema:name">Relationship to LDP</h4>
                     <div datatype="rdf:HTML" property="schema:description">
                       <p><em>This section is non-normative.</em></p>
 


### PR DESCRIPTION
wrong heading level in section 1.4.1, which makes it appear as 1.4 in the body (the ToC is correct, though).