### PR TITLE
Add server to support Last-Modified header field

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -747,6 +747,8 @@ content:counter(appendix, upper-alpha) "." counter(sub-appendix) "\00a0";
                   <p about="" id="server-content-type-includes" rel="spec:requirement" resource="#server-content-type-includes"><span property="spec:statement"><span rel="spec:requirementSubject" resource="#Server">Server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> generate a <code>Content-Type</code> header field in a message that contains content.</span></p>
 
                   <p about="" id="server-content-type-missing" rel="spec:requirement" resource="#server-content-type-missing"><span property="spec:statement"><span rel="spec:requirementSubject" resource="#Server">Server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> reject <code>PUT</code>, <code>POST</code>, and <code>PATCH</code> requests that contain content but lack the <code>Content-Type</code> header field, with a status code of <code>400</code>.</span> [<a href="https://github.com/solid/specification/issues/70#issuecomment-547924171" rel="cito:citesAsSourceDocument">Source</a>] [<a href="https://github.com/solid/specification/pull/660#issue-2319265317" rel="cito:citesAsSourceDocument">Source</a>]</p>
+
+                  <p about="" id="server-last-modified-includes" rel="spec:requirement" resource="#server-last-modified-includes"><span property="spec:statement"><span rel="spec:requirementSubject" resource="#Server">Server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> generate a <code>Last-Modified</code> header field in response to <code>GET</code> and <code>HEAD</code> requests.</span></p>
                 </div>
               </section>
 


### PR DESCRIPTION
This PR makes a [correction class 4 change](https://www.w3.org/2023/Process-20231103/#class-4):

* Add server requirement https://solidproject.org/ED/protocol#server-last-modified-includes to include the `Last-Modified` header field.

In an nutshell, the `Last-Modified` header field is useful for clients in a number of ways. RFC 9110 only goes as far as setting a SHOULD requirement level for servers, e.g., https://www.rfc-editor.org/rfc/rfc9110#name-last-modified , https://www.rfc-editor.org/rfc/rfc9110#section-15.3.1-5 . This PR makes it a MUST as there is already precedent of its use, and ensures that clients can rely on it where applicable:

---

I'm generally considering this PR to be a class 4 change because the `Last-Modified` header wasn't explicitly required in the Solid Protocol, hence, it can be considered as a new feature in and itself. This PR can alternatively be considered a [class 3 change](https://www.w3.org/2023/Process-20231103/#class-3) on the grounds that it:

>clears up an ambiguity or under-specified part of the specification in such a way that data, a processor, or an agent whose conformance was once unclear becomes clearly either conforming or non-conforming.

and given that the Solid Protocol already describes a number of behaviours and advisements involving the `Last-Modified` header field, e.g.:

* https://solidproject.org/ED/protocol#server-container-last-modified describes behaviour involving responses that include `Last-Modified`.
* https://solidproject.org/ED/protocol#dcterms-modified-corresponds-last-modified describes behaviour where `dcterms:modified` value under https://solidproject.org/ED/protocol#contained-resource-metadata corresponds with HTTP responses including the `Last-Modified` header field and its field value.
* https://solidproject.org/ED/protocol#container-last-modified-comparison describes how to interpret the field value in the context of containers.

---

Resolves https://github.com/solid/specification/issues/154 .

---

[Preview](http://htmlpreview.github.io/?https://github.com/solid/specification/blob/65f13c25519825d458b9898feca11dd2cc6cfd50/ED/protocol.html) | [Diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F3e8984067ad07e567cd63da4ab35676e8840f165%2FED%2Fprotocol.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fsolid%2Fspecification%2F65f13c25519825d458b9898feca11dd2cc6cfd50%2FED%2Fprotocol.html)