### PR TITLE
publish SAI v0.1

### DIFF
--- a/sai-primer-application.html
+++ b/sai-primer-application.html
@@ -1,0 +1,1066 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Solid Application Interoperability - Application Primer</title>
+  <meta content="CG-DRAFT" name="w3c-status">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
+  <link href="https://solidproject.org/TR/sai-primer-application" rel="canonical">
+  <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
+  <meta content="b1aa5b6d33d362cab931e0fa7c3674b51f45950b" name="revision">
+  <meta content="dark light" name="color-scheme">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
+<style>/* Boilerplate: style-autolinks */
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
+</style>
+<style>/* Boilerplate: style-colors */
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+</style>
+<style>/* Boilerplate: style-counters */
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}
+</style>
+<style>/* Boilerplate: style-issues */
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* Boilerplate: style-line-highlighting */
+:root {
+    --highlight-hover-bg: rgba(0, 0, 0, .05);
+}
+.line-numbered {
+    display: grid !important;
+    grid-template-columns: min-content 1fr;
+    grid-auto-flow: rows;
+}
+.line-numbered > *,
+.line-numbered::before,
+.line-numbered::after {
+    grid-column: 1/-1;
+}
+.line-no {
+    grid-column: 1;
+    color: gray;
+}
+.line {
+    grid-column: 2;
+}
+.line.highlight-line {
+    background: var(--highlight-hover-bg);
+}
+.line-no.highlight-line {
+    background: var(--highlight-hover-bg);
+    color: #444;
+    font-weight: bold;
+}
+.line-no.highlight-line[data-line]::before {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line);
+}
+.line-no.highlight-line[data-line-end]::after {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line-end);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --highlight-hover-bg: rgba(255, 255, 255, .05);
+    }
+}
+</style>
+<style>/* Boilerplate: style-md-lists */
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}
+</style>
+<style>/* Boilerplate: style-selflinks */
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">Solid Application Interoperability - Application Primer</h1>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2025-09-16">16 September 2025</time></p>
+   <details open>
+    <summary>More details about this document</summary>
+    <div data-fill-with="spec-metadata">
+     <dl>
+      <dt>This version:
+      <dd><a class="u-url" href="https://solidproject.org/TR/tag/sai-primer-application-v0.1">https://solidproject.org/TR/tag/sai-primer-application-v0.1</a>
+      <dt>Latest published version:
+      <dd><a href="https://solidproject.org/TR/sai-primer-application">https://solidproject.org/TR/sai-primer-application</a>
+      <dt>Feedback:
+      <dd><a href="https://github.com/solid/data-interoperability-panel/issues/">GitHub</a>
+      <dt class="editor">Editor:
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">elf Pavlik</span>
+      <dt>Version:
+      <dd>0.1
+     </dl>
+    </div>
+   </details>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">Copyright © 2025 the Contributors to the Solid Application Interoperability - Application Primer,
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This report was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+  Learn more about <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#shape-tree"><span class="secno">2</span> <span class="content">Shape Tree</span></a>
+    <li><a href="#appliction"><span class="secno">3</span> <span class="content">Application</span></a>
+    <li>
+     <a href="#authorization-flow"><span class="secno">4</span> <span class="content">Authorization Flow</span></a>
+     <ol class="toc">
+      <li><a href="#authorization-agent-discovery"><span class="secno">4.1</span> <span class="content">Authorization Agent Discovery</span></a>
+      <li><a href="#application-registration-discovery"><span class="secno">4.2</span> <span class="content">Application Registration Discovery</span></a>
+      <li><a href="#user-consent"><span class="secno">4.3</span> <span class="content">User Consent</span></a>
+      <li><a href="#resource-indication"><span class="secno">4.4</span> <span class="content">Resource Indication</span></a>
+     </ol>
+    <li>
+     <a href="#application-registration"><span class="secno">5</span> <span class="content">Application Registration</span></a>
+     <ol class="toc">
+      <li><a href="#access-grant"><span class="secno">5.1</span> <span class="content">Access Grant</span></a>
+      <li>
+       <a href="#data-grant"><span class="secno">5.2</span> <span class="content">Data Grant</span></a>
+       <ol class="toc">
+        <li><a href="#data-grant-scopes"><span class="secno">5.2.1</span> <span class="content">Scopes</span></a>
+        <li><a href="#data-grant-inheritance"><span class="secno">5.2.2</span> <span class="content">Inheritance</span></a>
+        <li><a href="#data-grant-delegation"><span class="secno">5.2.3</span> <span class="content">Delegation</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#data-registration"><span class="secno">6</span> <span class="content">Data Registration</span></a>
+     <ol class="toc">
+      <li><a href="#data-instance"><span class="secno">6.1</span> <span class="content">Data Instance</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+   </ol>
+  </nav>
+  <main>
+<script type="application/ld+json">
+{
+  "@context": {
+    "spec": "http://www.w3.org/ns/spec#",
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "author": { "@id": "schema:author", "@type": "@id" },
+    "editor": { "@id": "schema:editor", "@type": "@id" }
+  },
+  "@id": "https://solidproject.org/TR/sai-primer-application",
+  "@type": "spec:Primer",
+  "name": "SAI Application Primer",
+  "author": [
+    "https://elf-pavlik.hackers4peace.net"
+  ],
+  "editor": [
+    "https://elf-pavlik.hackers4peace.net"
+  ]
+}
+</script>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p>This primer is intended to accompany <a data-link-type="biblio" href="#biblio-sai" title="Solid Application Interoperability">[SAI]</a>.
+It is focused on providing a friendly introduction for developers of libraries intended
+for solid applications.</p>
+   <p>This document was developed alongside the open-source TypeScript implementation <a data-link-type="biblio" href="#biblio-sai-js" title="Solid Application Interoperability - TypeScript implementation">[SAI-JS]</a></p>
+   <p>We will follow example of an application called <em>Projectron</em>,
+which manages projects and tasks.
+End user, named <em>Alice</em>, collaborates on projects
+with other Individuals and Organizations.</p>
+   <h2 class="heading settled" data-level="2" id="shape-tree"><span class="secno">2. </span><span class="content">Shape Tree</span><a class="self-link" href="#shape-tree"></a></h2>
+   <p>Shape Trees <a data-link-type="biblio" href="#biblio-shapetrees" title="Shape Trees">[SHAPETREES]</a> allow  for the definition and validation of data hierarchies
+including which shapes <a data-link-type="biblio" href="#biblio-shex" title="Shape Expressions Language 2.1">[SHEX]</a> should be used to validate data.
+In our examples, we are going to use the following Shapes and Shape Trees.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>references</c-> <c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c-> <c- p>.</c->
+
+<c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>viaShapePath</c->
+    <c- s>"@&lt;https://solidshapes.example/shapes/Project>~&lt;https://vocab.example/project-management/hasTask>"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Project shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c-> <c- k>IRI</c-> <c- o>*</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Project shape (ShEx)</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>.</c->
+</pre>
+    <figcaption>Task shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Task</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Task shape (ShEx)</figcaption>
+   </figure>
+   <p class="issue" id="issue-f026f3dd"><a class="self-link" href="#issue-f026f3dd"></a> Reference shape path documentation</p>
+   <h2 class="heading settled" data-level="3" id="appliction"><span class="secno">3. </span><span class="content">Application</span><a class="self-link" href="#appliction"></a></h2>
+   <p>In this primer we will consider the use-case of a project management application
+identified by <code>https://projectron.example/#app</code> Every application has public WebID Document providing information about it.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Application</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationName</c-> <c- s>"Projectron"</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationDescription</c-> <c- s>"Manage projects with ease"</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationAuthor</c-> <c- nn>acme</c-><c- p>:</c-><c- f>\#corp</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationThumbnail</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>thumb.svg</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-group-pm</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#need-group-pm</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessScenario</c-> <c- nn>interop</c-><c- p>:</c-><c- f>PersonalAccess</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>authenticatesAs</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Pilot</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessDecoratorIndex</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>index</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-project</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#need-project</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>write</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#need-issue</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Issue</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>write</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-project</c-> <c- p>.</c-></span></pre>
+    <figcaption>Projectron WebID document</figcaption>
+   </figure>
+   <p>Access Needs explain what kind of data application works with.
+They use combination of <a href="#shape-tree">§ 2 Shape Tree</a> and access modes to
+convey how the application can work with data.</p>
+   <p class="issue" id="issue-e982e541"><a class="self-link" href="#issue-e982e541"></a> Details can change based on experience from implementing Authorization Agent role</p>
+   <h2 class="heading settled" data-level="4" id="authorization-flow"><span class="secno">4. </span><span class="content">Authorization Flow</span><a class="self-link" href="#authorization-flow"></a></h2>
+   <p>User always needs to authenticate first.
+For the rest of this primer we’ll be assuming that user has already authenticated,
+and that applicaction know WebID of the authenticated user.</p>
+   <h3 class="heading settled" data-level="4.1" id="authorization-agent-discovery"><span class="secno">4.1. </span><span class="content">Authorization Agent Discovery</span><a class="self-link" href="#authorization-agent-discovery"></a></h3>
+   <p>Every user has an Authorization Agent which can be discovered from
+their WebID Document via <code>interop:hasAuthorizationAgent</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="4"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>13e60d32-77a6-4239-864d-cfe2c90807c8</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- g>&lt;https://auth.alice.example/></c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s WebID document</figcaption>
+   </figure>
+   <p>Here we see that Alice designates <code>https://auth.alice.example/</code> as their Authorization Agent.</p>
+   <h3 class="heading settled" data-level="4.2" id="application-registration-discovery"><span class="secno">4.2. </span><span class="content">Application Registration Discovery</span><a class="self-link" href="#application-registration-discovery"></a></h3>
+   <p>Application can discover Application Registration created for it by the user,
+by performing <code>HEAD</code> or <code>GET</code> request on IRI denoting
+user’s Authorization Agent. Response will include HTTP Link header relating
+Application Registration to the application making the request using <code>http://www.w3.org/ns/solid/interop#registeredAgent</code> as link relation.</p>
+   <figure>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>auth.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://projectron.example/#app>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://auth.alice.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+    <figcaption>HEAD request to and response from Authorization Agent</figcaption>
+   </figure>
+   <p>Details in <a href="https://solid.github.io/data-interoperability-panel/specification/#authorization">7. Data Authorization</a> (<a data-link-type="biblio" href="#biblio-sai" title="Solid Application Interoperability">[SAI]</a>)</p>
+   <h3 class="heading settled" data-level="4.3" id="user-consent"><span class="secno">4.3. </span><span class="content">User Consent</span><a class="self-link" href="#user-consent"></a></h3>
+   <p>In cases where an application hasn’t been registered yet, it needs to initiate the flow with the Authorization Agent.</p>
+   <p>After successful flow, the application will be able to discover its registration.</p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice finds an Application called Projectron that she’d like
+            to use to manage her Projects and Tasks.
+      <tr>
+       <td><b>2</b>
+       <td>Alice authenticates to Projectron with her WebID.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron dereferences her WebID and retrieves Authorization Agent from her WebID Profile Document.
+      <tr>
+       <td><b>4</b>
+       <td>Projectron asks Alice’s Authorization Agent whether Alice already has an Application Registration for Projectron.
+      <tr>
+       <td><b>5</b>
+       <td>Alice’s Authorization Agent checks the Agent Registry in Alice’s Pod for a Projectron Application Registration.
+      <tr>
+       <td><b>6</b>
+       <td>No Application Registration for Projectron is found.
+          Projectron now knows that Alice hasn’t given it permission to access her data, so it must ask.
+      <tr>
+       <td><b>7</b>
+       <td>Projectron redirects Alice to her Authorization Agent, supplying its identifier for context.
+      <tr>
+       <td><b>8</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron identifier, retrieving Projectron’s
+          Application profile graph and corresponding Access Need Groups from the WebID Profile Document,
+          as well as <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>9</b>
+       <td>Alice’s Authorization Agent presents the Access Need Groups from Projectron’s Application
+          profile graph, so that Alice understands what kind of data is being requested, and why.
+      <tr>
+       <td><b>10</b>
+       <td>Alice’s chooses the scope of access that Projectron will receive, to the data to 
+          which it has asked for access via the presented Access Needs.
+      <tr>
+       <td><b>11-13</b>
+       <td>Alice’s Authorization Agent records her decision as an Access Authorization in Alice’s
+            Authorization Registry. An Application Registration is created for Projectron in
+            Alice’s Agent Registry. An Access Grant and corresponding Data Grants are generated
+            from the Access Authorization and stored in the Projectron Application Registration. 
+      <tr>
+       <td><b>14</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the appropriate access has been granted.
+      <tr>
+       <td><b>15</b>
+       <td>Projectron again asks Alice’s Authorization Agent for a Projectron Application Registration.
+      <tr>
+       <td><b>16</b>
+       <td>Alice’s Authorization Agent finds the newly created Projectron Application Registration in the Agent Registry in Alice’s Pod.
+      <tr>
+       <td><b>17</b>
+       <td>Alice’s Authorization Agent provides the URI of the Application Registration to Projectron.
+      <tr>
+       <td><b>18</b>
+       <td>Projectron learns what access it received through the Access Grant in Alice’s Projectron Application Registration.
+      <tr>
+       <td><b>19</b>
+       <td>Projectron may now function as intended, within the scope of authorization it was given by Alice.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/application-requests-access-flow.seq.mmd.svg"></p>
+   <h3 class="heading settled" data-level="4.4" id="resource-indication"><span class="secno">4.4. </span><span class="content">Resource Indication</span><a class="self-link" href="#resource-indication"></a></h3>
+   <p>When the application has already been registered, and the user wants to
+initiate a sharing-specific <a href="#data-instance">§ 6.1 Data Instance</a>, an authorization flow with resource
+indication is available.</p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice’s is authenticated with Projectron.
+      <tr>
+       <td><b>2</b>
+       <td>Alice has already authorized Projectron.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron has read its Access Grant and displayed projects.
+      <tr>
+       <td><b>4</b>
+       <td>Alice initiates sharing of a specific project.
+      <tr>
+       <td><b>5</b>
+       <td>Projectron redirects Alice to her Authorization Agent, indicating the selected project.
+      <tr>
+       <td><b>6-8</b>
+       <td>Alice’s Authorization Agent fetches the indicated project and checks who already has access to it.
+          It also fetches list of all registered social agents to present it to Alice.
+      <tr>
+       <td><b>9</b>
+       <td>Alice chooses all the social agents with which she wants to share the selected project,
+          as well as modes of access for all selected agents. If the shape tree has references (e.g., tasks) she can
+          also select modes of access for each inherited shape tree.
+      <tr>
+       <td><b>10-11</b>
+       <td>Alice’s Authorization Agent records new access authorizations for all the selected agents
+          and regenerates access grants provided in their agent registrations.
+      <tr>
+       <td><b>12</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron WebID, retrieving Projection’s
+          Application profile graph from the WebID Profile Document,
+          to discover the <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>13</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the project has been shared.
+      <tr>
+       <td><b>14</b>
+       <td>Alice continues using Projectron.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/resource-indication.seq.mmd.svg"></p>
+   <h2 class="heading settled" data-level="5" id="application-registration"><span class="secno">5. </span><span class="content">Application Registration</span><a class="self-link" href="#application-registration"></a></h2>
+   <p>Application Registration can be considered an entry point to all the data
+that the user authorized it to access. The next step in the discovery of that data
+is the Access Grant linked via <code>interop:hasAccessGrant</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-auth</c-><c- p>:</c-><c- f>bcf22534-0187-4ae4-b88f-fe0f9fa96659</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>ApplicationRegistration</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- g>&lt;https://jarvis.alice.example/#agent></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredAgent</c-> <c- g>&lt;https://projectron.example/#app></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="8"></span><span class="line highlight-line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrant</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe</c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s application registration for Projectron</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="5.1" id="access-grant"><span class="secno">5.1. </span><span class="content">Access Grant</span><a class="self-link" href="#access-grant"></a></h3>
+   <p>Access Grant links to all the Data Grants issued to the application
+via <code>interop:hasDataGrant</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-auth</c-><c- p>:</c-><c- f>dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- g>&lt;https://jarvis.alice.example/#agent></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>providedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>fromAgent</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>viaAgent</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrantSubject</c-></span><span class="line-no"></span><span class="line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>3fcef0f6-5807-4f1b-b77a-63d64df25a69\#grant-subject</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- g>&lt;#need-group-pm></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="13"></span><span class="line highlight-line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataGrant</c-></span><span class="line-no highlight-line" data-line="14"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="15"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>9827ae00-2778-4655-9f22-08bb9daaee26</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>7b2bc4ff-b4b8-47b8-96f6-06695f4c5126</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="17"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>54b1a123-23ca-4733-9371-700b52b9c567</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>12daf870-a343-4684-b828-c67c5c9c997a</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>7be5a39f-583d-4464-8ad8-a39e24b99fce</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>c205e9da-2dc5-4d1f-8be9-a3f90c13eedc</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>68dd1212-b0f3-4611-aae2-f9f5ea30ee07</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>92328851-ffb0-427d-847e-f6d9c8417648</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice-auth</c-><c- p>:</c-><c- f>3fcef0f6-5807-4f1b-b77a-63d64df25a69\#grant-subject</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessGrantSubject</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>accessByAgent</c->  <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>accessByApplication</c-> <c- g>&lt;https://projectron.example/#app></c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s access grant for Projectron</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="5.2" id="data-grant"><span class="secno">5.2. </span><span class="content">Data Grant</span><a class="self-link" href="#data-grant"></a></h3>
+   <p>Each Data grant represents access granted by specific Social Agent, to all or selected
+Data Instances in specific Data Registration.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Write</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c->
+      <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c->
+
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>9827ae00-2778-4655-9f22-08bb9daaee26</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c->
+      <c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c-> <c- p>.</c->
+
+<c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s data grant for Projectron - Pro Projects</figcaption>
+   </figure>
+   <p>A Data Grant is immutable, it never gets updated, instead it can be only replaced
+with a newer Data Grant.</p>
+   <p>Data Grant can be consider as the most important data structure, it provides following information:</p>
+   <dl>
+    <dt data-md>dataOwner
+    <dd data-md>
+     <p>Social Agent who owns the data</p>
+    <dt data-md>grantedBy
+    <dd data-md>
+     <p>Social Agent who granted the access</p>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by related Data Registration</p>
+    <dt data-md>hasDataRegistration
+    <dd data-md>
+     <p>Data Registration that this Data Grant applies to. As well as <code>iriPrefix</code> of that Data Registration (see <a href="#data-registration">§ 6 Data Registration</a>)</p>
+    <dt data-md>accessMode
+    <dd data-md>
+     <p>List of access modes defining what application can do with the data</p>
+    <dt data-md>scopeOfGrant
+    <dd data-md>
+     <p>Defines which instances can be accessed (see <a href="#data-grant-scopes">§ 5.2.1 Scopes</a>)</p>
+    <dt data-md>inheritsFromGrant
+    <dd data-md>
+     <p>If grant has <code>InheritInstances</code> scope, it will be the Data Grant for Data Registraion with parent Data Instances (see <a href="#data-grant-inheritance">§ 5.2.2 Inheritance</a>)</p>
+    <dt data-md>hasDataInstance
+    <dd data-md>
+     <p>If grant has <code>SelectedInstances</code> scope, it will be all the Data Instances that application can access in the Data Registration</p>
+    <dt data-md>delegationOfGrant
+    <dd data-md>
+     <p>If Data Grant is issued by Social Agent other than data owner, it will be the original Data Grant issued by the data owner (see <a href="#data-grant-delegation">§ 5.2.3 Delegation</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="5.2.1" id="data-grant-scopes"><span class="secno">5.2.1. </span><span class="content">Scopes</span><a class="self-link" href="#data-grant-scopes"></a></h4>
+   <p>Data Grant can have one of three scopes:</p>
+   <dl>
+    <dt data-md>AllFromRegistry
+    <dd data-md>
+     <p>All the Data Instances in the Data Registration. Application will be able to access the Data Registration and see the list of all contained instances (see <a href="#data-registration">§ 6 Data Registration</a>)</p>
+    <dt data-md>SelectedFromRegistry
+    <dd data-md>
+     <p>Only specific Data Instances in the Data Registration. Application will not be able to access the Data Registration, so it will not see the list al all contained instances. Instad list of selected Data Instances is available via <code>hasDataInstance</code></p>
+    <dt data-md>Inherited
+    <dd data-md>
+     <p>Only those Data Instances in the Data Registration, which are related to parent kData Instances in Data Registration of the Data Grant referenced with <code>inheritsFromGrant</code> (see <a href="#data-grant-inheritance">§ 5.2.2 Inheritance</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="5.2.2" id="data-grant-inheritance"><span class="secno">5.2.2. </span><span class="content">Inheritance</span><a class="self-link" href="#data-grant-inheritance"></a></h4>
+   <p><code>InheritInstances</code> Data Grant doesn’t provide access to the Data Registration, so
+application can’t get the list of all the Data Instances. Neither it provides a list of specific
+Data Instances in the Data Registration.</p>
+   <p>To find Data Instances from that Data Registration, application first needs to access parent
+Data Instances from Data Registration which Data Grant referenced by <code>inheritsFromGrant</code> makes accessible. Based on shape tree definition, each parent Data Instance will reference all its
+child Data Instances.</p>
+   <p>Both parent and child Data Registrations have to be in the same Data Registry. Since only one
+Data Registration for specific shape tree can be created in any given Data Registry.
+All parent Data Instances are from one Data Registration and all child Data Instances are from
+one Data Registration.</p>
+   <h4 class="heading settled" data-level="5.2.3" id="data-grant-delegation"><span class="secno">5.2.3. </span><span class="content">Delegation</span><a class="self-link" href="#data-grant-delegation"></a></h4>
+   <p>Application doesn’t need to handle delegated Data Grants in any special way.
+To know if Data Grant was issued by currently logged in user or someone else,
+application should rely on <code>dataOwner</code> information in the Data Grant.</p>
+   <div class="issue no-marker" id="issue-d41d8cd9"><a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a></div>
+   <h2 class="heading settled" data-level="6" id="data-registration"><span class="secno">6. </span><span class="content">Data Registration</span><a class="self-link" href="#data-registration"></a></h2>
+   <p><img class="flowchart-diagram" src="diagrams/pro.alice.example.flow.mmd.png"></p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-10-17T11:42:35.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="6"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- g>&lt;https://solidmin.example/#app></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="7"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="8"></span><span class="line highlight-line">  <c- nn>ldp</c-><c- p>:</c-><c- f>contains</c-></span><span class="line-no highlight-line" data-line="9"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>ccbd77ae-f769-4e07-b41f-5136501e13e7\#project</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="10"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s data registration for <strong>pro</strong> projects</figcaption>
+   </figure>
+   <dl>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by this Data Registration</p>
+    <dt data-md>iriPrefix
+    <dd data-md>
+     <p>String that should be used as base for creating IRIs for new Data Instances in this registration, by appending a unique string to the <code>iriPrefix</code></p>
+   </dl>
+   <h3 class="heading settled" data-level="6.1" id="data-instance"><span class="secno">6.1. </span><span class="content">Data Instance</span><a class="self-link" href="#data-instance"></a></h3>
+   <p>Data Instances are domain specific data records. They don’t use <code>interop:</code> vocabulary,
+instead they use some domain specific vocabularies.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-pro</c-><c- p>:</c-><c- f>ccbd77ae-f769-4e07-b41f-5136501e13e7\#project</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- s>"P-Ap-1"</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="4"></span><span class="line highlight-line">  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c-></span><span class="line-no highlight-line" data-line="5"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>576520a6-af5a-4cf9-8b40-8b1512b59c73\#task</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="6"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>106a82aa-6911-4a7e-a49b-383cbaa9da66\#task</c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s <strong>pro</strong> project 1</figcaption>
+   </figure>
+   <p>As we discussed in <a href="#data-grant-inheritance">§ 5.2.2 Inheritance</a> a Shape Tree will specify how parent data instances
+relate to child data instances. For Project shape three the predicate is <code>pm:hasTask</code>,
+links to child Task data instances.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>alice-pro</c-><c- p>:</c-><c- f>576520a6-af5a-4cf9-8b40-8b1512b59c73\#task</c->
+  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Task</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- s>"T-Ap-1"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s <strong>pro</strong> task 1</figcaption>
+   </figure>
+   <p>When creating or updating data instance with HTTP PUT method. Application should include
+link header linking Data Instance to Data Registration using link relation <code>http://www.w3.org/ns/solid/interop#targetDataRegistration</code></p>
+   <p>Update should include <code>If-Match</code> HTTP header with value of ETag from
+HTTP response when the representation was retreived.</p>
+   <figure>
+<pre class="highlight"><c- nf>PUT</c-> <c- nn>/ccbd77ae-f769-4e07-b41f-5136501e13e7</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>pro.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+<c- e>If-Match</c-><c- o>:</c-> <c- l>"..."</c->
+<c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://pro.alice.example/773605f0-b5bf-4d46-878d-5c167eac8b5d>;</c->
+  <c- l>rel="http://www.w3.org/ns/solid/interop#targetDataRegistration"</c->
+
+</pre>
+    <figcaption>Updating Data Instance with PUT</figcaption>
+   </figure>
+   <p>When creating new data instance client should also include <code>If-None-Match: *</code> header in HTTP request.</p>
+   <figure>
+<pre class="highlight"><c- nf>PUT</c-> <c- nn>/d046dd43-b619-46c8-91f6-a0713d967c0d</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>pro.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+<c- e>If-None-Match</c-><c- o>:</c-> <c- l>*</c->
+<c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://pro.alice.example/773605f0-b5bf-4d46-878d-5c167eac8b5d>;</c->
+  <c- l>rel="http://www.w3.org/ns/solid/interop#targetDataRegistration"</c->
+
+</pre>
+    <figcaption>Creating new Data Instance with PUT</figcaption>
+   </figure>
+  </main>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-sai">[SAI]
+   <dd>Justin Bingham; Eric Prud'hommeaux; elf Pavlik. <a href="https://solid.github.io/data-interoperability-panel/specification/"><cite>Solid Application Interoperability</cite></a>. URL: <a href="https://solid.github.io/data-interoperability-panel/specification/">https://solid.github.io/data-interoperability-panel/specification/</a>
+   <dt id="biblio-sai-js">[SAI-JS]
+   <dd>elf Pavlik; Maciej Samoraj; Ángel Araya. <a href="https://github.com/janeirodigital/sai-js"><cite>Solid Application Interoperability - TypeScript implementation</cite></a>. URL: <a href="https://github.com/janeirodigital/sai-js">https://github.com/janeirodigital/sai-js</a>
+   <dt id="biblio-shapetrees">[SHAPETREES]
+   <dd>Justin Bingham; et al. <a href="https://shapetrees.org/TR/specification/"><cite>Shape Trees</cite></a>. URL: <a href="https://shapetrees.org/TR/specification/">https://shapetrees.org/TR/specification/</a>
+   <dt id="biblio-shex">[SHEX]
+   <dd>Eric Prud'hommeaux; et al. <a href="http://shex.io/shex-semantics/index.html"><cite>Shape Expressions Language 2.1</cite></a>. URL: <a href="http://shex.io/shex-semantics/index.html">http://shex.io/shex-semantics/index.html</a>
+  </dl>

--- a/sai-primer-authorization-agent.html
+++ b/sai-primer-authorization-agent.html
@@ -1,0 +1,1190 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Solid Application Interoperability - Authorization Agent Primer</title>
+  <meta content="CG-DRAFT" name="w3c-status">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
+  <link href="https://solidproject.org/TR/sai-primer-authorization-agent" rel="canonical">
+  <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
+  <meta content="b1aa5b6d33d362cab931e0fa7c3674b51f45950b" name="revision">
+  <meta content="dark light" name="color-scheme">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
+<style>/* Boilerplate: style-autolinks */
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
+</style>
+<style>/* Boilerplate: style-colors */
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+</style>
+<style>/* Boilerplate: style-counters */
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}
+</style>
+<style>/* Boilerplate: style-issues */
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* Boilerplate: style-line-highlighting */
+:root {
+    --highlight-hover-bg: rgba(0, 0, 0, .05);
+}
+.line-numbered {
+    display: grid !important;
+    grid-template-columns: min-content 1fr;
+    grid-auto-flow: rows;
+}
+.line-numbered > *,
+.line-numbered::before,
+.line-numbered::after {
+    grid-column: 1/-1;
+}
+.line-no {
+    grid-column: 1;
+    color: gray;
+}
+.line {
+    grid-column: 2;
+}
+.line.highlight-line {
+    background: var(--highlight-hover-bg);
+}
+.line-no.highlight-line {
+    background: var(--highlight-hover-bg);
+    color: #444;
+    font-weight: bold;
+}
+.line-no.highlight-line[data-line]::before {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line);
+}
+.line-no.highlight-line[data-line-end]::after {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line-end);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --highlight-hover-bg: rgba(255, 255, 255, .05);
+    }
+}
+</style>
+<style>/* Boilerplate: style-md-lists */
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}
+</style>
+<style>/* Boilerplate: style-selflinks */
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">Solid Application Interoperability - Authorization Agent Primer</h1>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2025-09-16">16 September 2025</time></p>
+   <details open>
+    <summary>More details about this document</summary>
+    <div data-fill-with="spec-metadata">
+     <dl>
+      <dt>This version:
+      <dd><a class="u-url" href="https://solidproject.org/TR/tag/sai-primer-authorization-agent-v0.1">https://solidproject.org/TR/tag/sai-primer-authorization-agent-v0.1</a>
+      <dt>Latest published version:
+      <dd><a href="https://solidproject.org/TR/sai-primer-authorization-agent">https://solidproject.org/TR/sai-primer-authorization-agent</a>
+      <dt>Feedback:
+      <dd><a href="https://github.com/solid/data-interoperability-panel/issues/">GitHub</a>
+      <dt class="editor">Editor:
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">elf Pavlik</span>
+      <dt>Version:
+      <dd>0.1
+     </dl>
+    </div>
+   </details>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">Copyright © 2025 the Contributors to the Solid Application Interoperability - Authorization Agent Primer,
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This report was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+  Learn more about <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#shape-tree"><span class="secno">2</span> <span class="content">Shape Tree</span></a>
+    <li><a href="#registry-set"><span class="secno">3</span> <span class="content">Registry Set</span></a>
+    <li>
+     <a href="#data-registry"><span class="secno">4</span> <span class="content">Data Registry</span></a>
+     <ol class="toc">
+      <li><a href="#data-registration"><span class="secno">4.1</span> <span class="content">Data Registration</span></a>
+      <li><a href="#data-instance"><span class="secno">4.2</span> <span class="content">Data Instance</span></a>
+     </ol>
+    <li>
+     <a href="#authorization-registry"><span class="secno">5</span> <span class="content">Authorization Registry</span></a>
+     <ol class="toc">
+      <li><a href="#access-authorization"><span class="secno">5.1</span> <span class="content">Access Authorization</span></a>
+      <li>
+       <a href="#data-authorization"><span class="secno">5.2</span> <span class="content">Data Authorization</span></a>
+       <ol class="toc">
+        <li><a href="#data-authorization-scopes"><span class="secno">5.2.1</span> <span class="content">Scopes</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#agent-registry"><span class="secno">6</span> <span class="content">Agent Registry</span></a>
+     <ol class="toc">
+      <li><a href="#agent-registration"><span class="secno">6.1</span> <span class="content">Agent Registration</span></a>
+      <li>
+       <a href="#social-agent-registration"><span class="secno">6.2</span> <span class="content">Social Agent Registration</span></a>
+       <ol class="toc">
+        <li><a href="#reciprocal-registration"><span class="secno">6.2.1</span> <span class="content">Reciprocal Registration</span></a>
+       </ol>
+      <li><a href="#social-agent-invitation"><span class="secno">6.3</span> <span class="content">Social Agent Invitation</span></a>
+      <li><a href="#application-registration"><span class="secno">6.4</span> <span class="content">Application Registration</span></a>
+      <li><a href="#agent-registration-discovery"><span class="secno">6.5</span> <span class="content">Agent Registration Discovery</span></a>
+      <li><a href="#access-grant"><span class="secno">6.6</span> <span class="content">Access Grant</span></a>
+      <li>
+       <a href="#data-grant"><span class="secno">6.7</span> <span class="content">Data Grant</span></a>
+       <ol class="toc">
+        <li><a href="#data-grant-scopes"><span class="secno">6.7.1</span> <span class="content">Scopes</span></a>
+        <li><a href="#data-grant-inheritance"><span class="secno">6.7.2</span> <span class="content">Inheritance</span></a>
+        <li><a href="#data-grant-delegation"><span class="secno">6.7.3</span> <span class="content">Delegation</span></a>
+       </ol>
+      <li><a href="#access-receipt"><span class="secno">6.8</span> <span class="content">Access Receipt</span></a>
+      <li><a href="#access-need-group"><span class="secno">6.9</span> <span class="content">Access Need Group</span></a>
+      <li><a href="#access-need"><span class="secno">6.10</span> <span class="content">Access Need</span></a>
+     </ol>
+    <li><a href="#gathering-authorizations"><span class="secno">7</span> <span class="content">Gathering Authorizations from the user</span></a>
+    <li><a href="#resource-indication"><span class="secno">8</span> <span class="content">Sharing resources indicated by the application</span></a>
+    <li><a href="#generating-grants-from-authorizations"><span class="secno">9</span> <span class="content">Generating Access Grant from Access Authorization</span></a>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+   </ol>
+  </nav>
+  <main>
+<script type="application/ld+json">
+{
+  "@context": {
+    "spec": "http://www.w3.org/ns/spec#",
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "author": { "@id": "schema:author", "@type": "@id" },
+    "editor": { "@id": "schema:editor", "@type": "@id" }
+  },
+  "@id": "https://solidproject.org/TR/sai-primer-authorization-agent",
+  "@type": "spec:Primer",
+  "name": "SAI Authorization Agent Primer",
+  "author": [
+    "https://elf-pavlik.hackers4peace.net"
+  ],
+  "editor": [
+    "https://elf-pavlik.hackers4peace.net"
+  ]
+}
+</script>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p>This primer is intended to accompany <a data-link-type="biblio" href="#biblio-sai" title="Solid Application Interoperability">[SAI]</a>.
+It is focused on providing a friendly introduction for developers of libraries intended
+for solid authorization agents.</p>
+   <p>This document was developed alongside the open-source TypeScript implementation <a data-link-type="biblio" href="#biblio-sai-js" title="Solid Application Interoperability - TypeScript implementation">[SAI-JS]</a> and open-source Java implementation <a data-link-type="biblio" href="#biblio-sai-java" title="Solid Application Interoperability - Java implementation">[SAI-JAVA]</a>.</p>
+   <h2 class="heading settled" data-level="2" id="shape-tree"><span class="secno">2. </span><span class="content">Shape Tree</span><a class="self-link" href="#shape-tree"></a></h2>
+   <p>Shape Trees <a data-link-type="biblio" href="#biblio-shapetrees" title="Shape Trees">[SHAPETREES]</a> allow  for the definition and validation of data hierarchies
+including which shapes <a data-link-type="biblio" href="#biblio-shex" title="Shape Expressions Language 2.1">[SHEX]</a> should be used to validate data.
+In our examples, we are going to use the following Shapes and Shape Trees.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>references</c-> <c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c-> <c- p>.</c->
+
+<c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>viaShapePath</c->
+    <c- s>"@&lt;https://solidshapes.example/shapes/Project>~&lt;https://vocab.example/project-management/hasTask>"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Project shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c-> <c- k>IRI</c-> <c- o>*</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Project shape (ShEx)</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>.</c->
+</pre>
+    <figcaption>Task shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Task</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Task shape (ShEx)</figcaption>
+   </figure>
+   <p class="issue" id="issue-f026f3dd"><a class="self-link" href="#issue-f026f3dd"></a> Reference shape path documentation</p>
+   <h2 class="heading settled" data-level="3" id="registry-set"><span class="secno">3. </span><span class="content">Registry Set</span><a class="self-link" href="#registry-set"></a></h2>
+   <p>Authorization Agent uses a set of different registries to perform its dutes. Specificaly,</p>
+   <ul>
+    <li data-md>
+     <p>one or more <a href="#data-registry">§ 4 Data Registry</a>,</p>
+    <li data-md>
+     <p>one <a href="#authorization-registry">§ 5 Authorization Registry</a>,</p>
+    <li data-md>
+     <p>one <a href="#agent-registry">§ 6 Agent Registry</a>,</p>
+   </ul>
+   <p>each one of them is described in a dedicated section.</p>
+   <p>The Registry Set can be discovered from a social agent’s WebID Profile using <code>interop:hasRegistrySet</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>13e60d32-77a6-4239-864d-cfe2c90807c8</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- g>&lt;https://auth.alice.example/></c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s WebID document</figcaption>
+   </figure>
+   <p>While WebID Profile is readable to the public, Registry Set should only be readable by its owner
+and their Authorization Agent.</p>
+   <p><img class="flowchart-diagram" src="diagrams/registry-set.flow.mmd.png"></p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>13e60d32-77a6-4239-864d-cfe2c90807c8</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>RegistrySet</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAgentRegistry</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>1cf3e08b-ffe2-465a-ac5b-94ce165cb8f0</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessConsentRegistry</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>96feb105-063e-4996-ab74-5e504c6ceae5</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistry</c->
+    <c- nn>alice-pro</c-><c- p>:</c-><c- f>71e96aaa-f3dc-4263-97d6-a5b4c83524cb</c-> <c- p>,</c->
+    <c- nn>alice-home</c-><c- p>:</c-><c- f>2d3d97b4-a26d-434e-afa2-e3bc8e8e2b56</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s Registry Set</figcaption>
+   </figure>
+   <h2 class="heading settled" data-level="4" id="data-registry"><span class="secno">4. </span><span class="content">Data Registry</span><a class="self-link" href="#data-registry"></a></h2>
+   <p>A Data Registry is a collection of Data Registrations, each of which represents a unique type of data,
+identified by a shape tree.</p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-pro</c-><c- p>:</c-><c- f>71e96aaa-f3dc-4263-97d6-a5b4c83524cb</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistration</c->
+    <c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-> <c- p>,</c->
+    <c- nn>alice-pro</c-><c- p>:</c-><c- f>4d594c61-7cff-484a-a1d2-1f353ee4e1e7</c-> <c- p>.</c->
+</pre>
+    <figcaption>one of Alice’s Data Registries</figcaption>
+   </figure>
+   <p>In a Data Registry, there can be at most one Data Registration for any given shape tree.</p>
+   <h3 class="heading settled" data-level="4.1" id="data-registration"><span class="secno">4.1. </span><span class="content">Data Registration</span><a class="self-link" href="#data-registration"></a></h3>
+   <p>Data Registration is a container, which contains Data Instances. Each of those Data Instances conforms to one specific
+shape tree assigned to the Data Registration.</p>
+   <p><img class="flowchart-diagram" src="diagrams/pro.alice.example.flow.mmd.png"></p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-10-17T11:42:35.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- g>&lt;https://solidmin.example/#app></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>ldp</c-><c- p>:</c-><c- f>contains</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>ccbd77ae-f769-4e07-b41f-5136501e13e7\#project</c-> <c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c-></span></pre>
+    <figcaption>Data Registration for projects in one of Alice’s Data Registries</figcaption>
+   </figure>
+   <dl>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by this Data Registration</p>
+   </dl>
+   <h3 class="heading settled" data-level="4.2" id="data-instance"><span class="secno">4.2. </span><span class="content">Data Instance</span><a class="self-link" href="#data-instance"></a></h3>
+   <p>Data Instance is a resource representing something specific, for example, a project or a task.
+An Authorization Agent is not responsible for modifying data instances. Sometimes it still needs to access them
+during <a href="#gathering-authorizations">§ 7 Gathering Authorizations from the user</a> if the user wants to select specific data instances.</p>
+   <h2 class="heading settled" data-level="5" id="authorization-registry"><span class="secno">5. </span><span class="content">Authorization Registry</span><a class="self-link" href="#authorization-registry"></a></h2>
+   <p>Authorization Registry is a container, which contains Access Authorizations.
+Each of those Access Authorizations is created for a specific grantee,
+and groups together one or more Data Authorizations.</p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>96feb105-063e-4996-ab74-5e504c6ceae5</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessConsentRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessConsent</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>eac2c39c-c8b3-4880-8b9f-a3e12f7f6372</c-> <c- p>,</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>75a2ef88-d4d4-4f05-af1e-c2a63af08cab</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s Authorization Registry</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="5.1" id="access-authorization"><span class="secno">5.1. </span><span class="content">Access Authorization</span><a class="self-link" href="#access-authorization"></a></h3>
+   <p>Access Authorization groups one or more <a href="#data-authorization"> data authorizations</a>.
+Together they represent the whole access granted by a social agent to another agent.
+One of the primary responsibilities of the authorization agent is <a href="#generating-grants-from-authorizations">§ 9 Generating Access Grant from Access Authorization</a>.</p>
+   <p>An Access Authorization is immutable, it never gets updated, instead it can be only replaced
+with a newer Access Authorization.</p>
+   <h3 class="heading settled" data-level="5.2" id="data-authorization"><span class="secno">5.2. </span><span class="content">Data Authorization</span><a class="self-link" href="#data-authorization"></a></h3>
+   <p>Data Authorization, similar to <a href="#data-grant">§ 6.7 Data Grant</a>, represents access granted by a specific Social Agent.
+It is always associated with a specific <a href="#shape-tree">§ 2 Shape Tree</a>. Depending on its scope it can apply to all the
+Data Instances in any number of Data Registrations. In that case, <code>interop:hasDataRegistration</code> will not be specified.</p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>e2765d6c-848a-4fc0-9092-556903730263</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataConsent</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- g>&lt;https://jarvis.alice.example/#agent></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- g>&lt;https://projectron.example/#app></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- g>&lt;https://acme.example/#corp></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Write</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfConsent</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromAgent</c-> <c- p>.</c->
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>6a9feb57-252b-43b2-8470-5a938888b2fa</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromConsent</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>e2765d6c-848a-4fc0-9092-556903730263</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s data authorization for Projectron to ACME’s Projects</figcaption>
+   </figure>
+   <p>A Data Authorization is immutable, it never gets updated, instead it can be only replaced
+with a newer Data Authorization.</p>
+   <h4 class="heading settled" data-level="5.2.1" id="data-authorization-scopes"><span class="secno">5.2.1. </span><span class="content">Scopes</span><a class="self-link" href="#data-authorization-scopes"></a></h4>
+   <p>Data Authorization can have one of five scopes:</p>
+   <dl>
+    <dt data-md>All
+    <dd data-md>
+     <p>All the Data Instances in all the Data Registration the End-user has access to.
+This includes ones owned by the End-user as well as ones owned by others, where End-user has been granted access.</p>
+    <dt data-md>AllFromAgent
+    <dd data-md>
+     <p>All the Data Instances in all the Data Registrations, owned by a specific social agent.
+This could be the End-user themselves or any other social agent who granted access to the End-user.</p>
+   </dl>
+   <p>Plus all the <a href="#data-grant-scopes"> Data Grant Scopes</a></p>
+   <h2 class="heading settled" data-level="6" id="agent-registry"><span class="secno">6. </span><span class="content">Agent Registry</span><a class="self-link" href="#agent-registry"></a></h2>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>1cf3e08b-ffe2-465a-ac5b-94ce165cb8f0</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AgentRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasSocialAgentRegistration</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>b1f69979-dd47-4709-b2ed-a7119f29b135</c-> <c- p>,</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>5dc3c14e-7830-475f-b8e3-4748d6c0bccb</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasApplicationRegistration</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>bcf22534-0187-4ae4-b88f-fe0f9fa96659</c-> <c- p>,</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>170c12ac-7d4f-47fe-b36d-7a9944c429d9</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s Authorization Registry</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="6.1" id="agent-registration"><span class="secno">6.1. </span><span class="content">Agent Registration</span><a class="self-link" href="#agent-registration"></a></h3>
+   <p>There can be only one Agent Registration for any given agent in Agent Registry.
+Its main purpose is to make <a href="#access-grant">§ 6.6 Access Grant</a> available to the registered agent.</p>
+   <h3 class="heading settled" data-level="6.2" id="social-agent-registration"><span class="secno">6.2. </span><span class="content">Social Agent Registration</span><a class="self-link" href="#social-agent-registration"></a></h3>
+   <p>Social Agent Registration is created for a Social Agent. Besides <a href="#access-grant">§ 6.6 Access Grant</a> it can also reference a <a href="#reciprocal-registration">§ 6.2.1 Reciprocal Registration</a>.</p>
+   <h4 class="heading settled" data-level="6.2.1" id="reciprocal-registration"><span class="secno">6.2.1. </span><span class="content">Reciprocal Registration</span><a class="self-link" href="#reciprocal-registration"></a></h4>
+   <p>The reference to reciprocal registration can be created after receiving an <a href="#access-receipt">§ 6.8 Access Receipt</a> from another Social Agent and performing <a href="#agent-registration-discovery">§ 6.5 Agent Registration Discovery</a></p>
+   <p>In the case of Social Agent Registration for ACME, created in Alice’s Agent Registry. The reciprocal registration
+will be the Social Agent Reigstration for Alice, created in ACME’s Agent Registry.</p>
+   <p><img class="flowchart-diagram" src="diagrams/reciprocal-registration.flow.mmd.png"></p>
+   <h3 class="heading settled" data-level="6.3" id="social-agent-invitation"><span class="secno">6.3. </span><span class="content">Social Agent Invitation</span><a class="self-link" href="#social-agent-invitation"></a></h3>
+   <p>Social Agent Invitation represents an invitation for a Social Agent. It takes advantage of an existing and secure
+communication channel between two agents to pass a secret link that allows accepting the invitation.
+This flow results in both agents establishing a pair of <a href="#reciprocal-registration">Reciprocal Registrations</a>.
+If the platform supports it, the Authorization Agent of the sender can use <a data-link-type="biblio" href="#biblio-web-share" title="Web Share API">[WEB-SHARE]</a> to pass the secret
+link to the user’s messaging app. On the other side, the Authorization Agent of the recipient can use <a data-link-type="biblio" href="#biblio-web-share-target" title="Web Share Target API">[WEB-SHARE-TARGET]</a> to register with the platform and receive a secret link from the user’s messaging app.
+Independent of the platform, Authorization Agents should always allow a simple copy of the link by the sender
+(e.g., <code>navigator.clipboard.writeText</code>) and paste it by the recipient.</p>
+   <h3 class="heading settled" data-level="6.4" id="application-registration"><span class="secno">6.4. </span><span class="content">Application Registration</span><a class="self-link" href="#application-registration"></a></h3>
+   <p>Application Registrations are created by the End-user for applications they use.
+Since applications do not own or share data, they will never have a [#reciprocal-registration].</p>
+   <h3 class="heading settled" data-level="6.5" id="agent-registration-discovery"><span class="secno">6.5. </span><span class="content">Agent Registration Discovery</span><a class="self-link" href="#agent-registration-discovery"></a></h3>
+   <p>Both Social Agent and Application can discover Agent Registration created for them,
+by performing <code>HEAD</code> or <code>GET</code> request on IRI denoting
+the Authorization Agent. Response will include HTTP Link header relating
+Agent Registration to the agent making the request using <code>http://www.w3.org/ns/solid/interop#registeredAgent</code> as link relation.</p>
+   <p>In a case where End-user using an application performs the discovery on their
+own Authorization Agent. The response will include a link to the Application registration.</p>
+   <figure>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>auth.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://projectron.example/#app>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://auth.alice.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+    <figcaption>HEAD request to and response from End-user’s Authorization Agent</figcaption>
+   </figure>
+   <p>In the case where the client acting on behalf of one social agent, performs the discovery on
+another’s social agent Authorization Agent. The response will include a link to Social Agent Registration.</p>
+   <figure>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>auth.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://bob.example/#id>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://auth.alice.example/92868ad4-a9e6-42df-9cb0-883350c62769";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+    <figcaption>HEAD request to and response from someone else’s Authorization Agent</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="6.6" id="access-grant"><span class="secno">6.6. </span><span class="content">Access Grant</span><a class="self-link" href="#access-grant"></a></h3>
+   <p>An Access Grant groups together all the Data Grants provided for a specific agent.</p>
+   <p>An Access Grant is immutable — it never gets updated; it can only be replaced, by a newer Access Grant.</p>
+   <h3 class="heading settled" data-level="6.7" id="data-grant"><span class="secno">6.7. </span><span class="content">Data Grant</span><a class="self-link" href="#data-grant"></a></h3>
+   <p>Each Data grant represents access granted by specific Social Agent, to all or selected
+Data Instances in specific Data Registration.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Write</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c->
+      <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c->
+
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>9827ae00-2778-4655-9f22-08bb9daaee26</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c->
+      <c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c-> <c- p>.</c->
+
+<c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s data grant for Projectron - Pro Projects</figcaption>
+   </figure>
+   <p>A Data Grant is immutable, it never gets updated, instead it can be only replaced
+with a newer Data Grant.</p>
+   <p>Data Grant can be consider as the most important data structure, it provides following information:</p>
+   <dl>
+    <dt data-md>dataOwner
+    <dd data-md>
+     <p>Social Agent who owns the data</p>
+    <dt data-md>grantedBy
+    <dd data-md>
+     <p>Social Agent who granted the access</p>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by related Data Registration</p>
+    <dt data-md>hasDataRegistration
+    <dd data-md>
+     <p>Data Registration that this Data Grant applies to. As well as <code>iriPrefix</code> of that Data Registration (see <a href="#data-registration">§ 4.1 Data Registration</a>)</p>
+    <dt data-md>accessMode
+    <dd data-md>
+     <p>List of access modes defining what application can do with the data</p>
+    <dt data-md>scopeOfGrant
+    <dd data-md>
+     <p>Defines which instances can be accessed (see <a href="#data-grant-scopes">§ 6.7.1 Scopes</a>)</p>
+    <dt data-md>inheritsFromGrant
+    <dd data-md>
+     <p>If grant has <code>InheritInstances</code> scope, it will be the Data Grant for Data Registraion with parent Data Instances (see <a href="#data-grant-inheritance">§ 6.7.2 Inheritance</a>)</p>
+    <dt data-md>hasDataInstance
+    <dd data-md>
+     <p>If grant has <code>SelectedInstances</code> scope, it will be all the Data Instances that application can access in the Data Registration</p>
+    <dt data-md>delegationOfGrant
+    <dd data-md>
+     <p>If Data Grant is issued by Social Agent other than data owner, it will be the original Data Grant issued by the data owner (see <a href="#data-grant-delegation">§ 6.7.3 Delegation</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="6.7.1" id="data-grant-scopes"><span class="secno">6.7.1. </span><span class="content">Scopes</span><a class="self-link" href="#data-grant-scopes"></a></h4>
+   <p>Data Grant can have one of three scopes:</p>
+   <dl>
+    <dt data-md>AllFromRegistry
+    <dd data-md>
+     <p>All the Data Instances in the Data Registration. Application will be able to access the Data Registration and see the list of all contained instances (see <a href="#data-registration">§ 4.1 Data Registration</a>)</p>
+    <dt data-md>SelectedFromRegistry
+    <dd data-md>
+     <p>Only specific Data Instances in the Data Registration. Application will not be able to access the Data Registration, so it will not see the list al all contained instances. Instad list of selected Data Instances is available via <code>hasDataInstance</code></p>
+    <dt data-md>Inherited
+    <dd data-md>
+     <p>Only those Data Instances in the Data Registration, which are related to parent kData Instances in Data Registration of the Data Grant referenced with <code>inheritsFromGrant</code> (see <a href="#data-grant-inheritance">§ 6.7.2 Inheritance</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="6.7.2" id="data-grant-inheritance"><span class="secno">6.7.2. </span><span class="content">Inheritance</span><a class="self-link" href="#data-grant-inheritance"></a></h4>
+   <p><code>InheritInstances</code> Data Grant doesn’t provide access to the Data Registration, so
+application can’t get the list of all the Data Instances. Neither it provides a list of specific
+Data Instances in the Data Registration.</p>
+   <p>To find Data Instances from that Data Registration, application first needs to access parent
+Data Instances from Data Registration which Data Grant referenced by <code>inheritsFromGrant</code> makes accessible. Based on shape tree definition, each parent Data Instance will reference all its
+child Data Instances.</p>
+   <p>Both parent and child Data Registrations have to be in the same Data Registry. Since only one
+Data Registration for specific shape tree can be created in any given Data Registry.
+All parent Data Instances are from one Data Registration and all child Data Instances are from
+one Data Registration.</p>
+   <h4 class="heading settled" data-level="6.7.3" id="data-grant-delegation"><span class="secno">6.7.3. </span><span class="content">Delegation</span><a class="self-link" href="#data-grant-delegation"></a></h4>
+   <p>Application doesn’t need to handle delegated Data Grants in any special way.
+To know if Data Grant was issued by currently logged in user or someone else,
+application should rely on <code>dataOwner</code> information in the Data Grant.</p>
+   <div class="issue no-marker" id="issue-d41d8cd9"><a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a></div>
+   <h3 class="heading settled" data-level="6.8" id="access-receipt"><span class="secno">6.8. </span><span class="content">Access Receipt</span><a class="self-link" href="#access-receipt"></a></h3>
+   <p>Access Receipt helps to establish data sharing between two social agents. Once received the authorization agent
+should prompt the user to approve creating <a href="#social-agent-registration">§ 6.2 Social Agent Registration</a> for that data owner.
+If user approves <a href="#reciprocal-registration">§ 6.2.1 Reciprocal Registration</a> can be associated and subscription for notifications established
+to keep track on the latest <a href="#access-grant">§ 6.6 Access Grant</a>. Once reciprocal registration gets associated there is no
+further need for its data owner to send access receipts to the agent registered in that reciprocal registration.</p>
+   <div class="issue no-marker" id="issue-d41d8cd9①"><a class="self-link" href="#issue-d41d8cd9①"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/238" style="text-transform:none">solid/data-interoperability-panel/238</a><a href="https://github.com/solid/data-interoperability-panel/issues/238">Sharing access between social agents</a></div>
+   <h3 class="heading settled" data-level="6.9" id="access-need-group"><span class="secno">6.9. </span><span class="content">Access Need Group</span><a class="self-link" href="#access-need-group"></a></h3>
+   <p>An Access Need Group is a collection of Access Needs used to communicate an access request to Social Agents.</p>
+   <p>An Authorization Agent uses them during <a href="#gathering-authorizations">§ 7 Gathering Authorizations from the user</a>.</p>
+   <h3 class="heading settled" data-level="6.10" id="access-need"><span class="secno">6.10. </span><span class="content">Access Need</span><a class="self-link" href="#access-need"></a></h3>
+   <p>An Access Need represents the requirement of one specific type of data represented by a shape tree,
+as part of an Access Need Group.</p>
+   <p class="issue" id="issue-a0664d99"><a class="self-link" href="#issue-a0664d99"></a> Complete this section based on implementation of UI for Authorization Agent Service</p>
+   <h2 class="heading settled" data-level="7" id="gathering-authorizations"><span class="secno">7. </span><span class="content">Gathering Authorizations from the user</span><a class="self-link" href="#gathering-authorizations"></a></h2>
+   <p>The most common case is authorizing an application based on its <a href="#access-need">§ 6.10 Access Need</a>.
+The authorization screen should combine those Access Needs with existing <a href="#access-authorization">§ 5.1 Access Authorization</a> if one exists.
+It should also assist the user in composing new Access Authorization, taking into account all their:</p>
+   <ul>
+    <li data-md>
+     <p>Data Registries with Data Registrations and Data Instances</p>
+    <li data-md>
+     <p><a href="#access-grant">§ 6.6 Access Grant</a> with <a href="#data-grant">§ 6.7 Data Grant</a> others issued to them (available via all the <a href="#reciprocal-registration">§ 6.2.1 Reciprocal Registration</a>)</p>
+   </ul>
+   <p><img src="images/authorization-screen.svg" width="100%"></p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice finds an Application called Projectron that she’d like
+            to use to manage her Projects and Tasks.
+      <tr>
+       <td><b>2</b>
+       <td>Alice authenticates to Projectron with her WebID.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron dereferences her WebID and retrieves Authorization Agent from her WebID Profile Document.
+      <tr>
+       <td><b>4</b>
+       <td>Projectron asks Alice’s Authorization Agent whether Alice already has an Application Registration for Projectron.
+      <tr>
+       <td><b>5</b>
+       <td>Alice’s Authorization Agent checks the Agent Registry in Alice’s Pod for a Projectron Application Registration.
+      <tr>
+       <td><b>6</b>
+       <td>No Application Registration for Projectron is found.
+          Projectron now knows that Alice hasn’t given it permission to access her data, so it must ask.
+      <tr>
+       <td><b>7</b>
+       <td>Projectron redirects Alice to her Authorization Agent, supplying its identifier for context.
+      <tr>
+       <td><b>8</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron identifier, retrieving Projectron’s
+          Application profile graph and corresponding Access Need Groups from the WebID Profile Document,
+          as well as <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>9</b>
+       <td>Alice’s Authorization Agent presents the Access Need Groups from Projectron’s Application
+          profile graph, so that Alice understands what kind of data is being requested, and why.
+      <tr>
+       <td><b>10</b>
+       <td>Alice’s chooses the scope of access that Projectron will receive, to the data to 
+          which it has asked for access via the presented Access Needs.
+      <tr>
+       <td><b>11-13</b>
+       <td>Alice’s Authorization Agent records her decision as an Access Authorization in Alice’s
+            Authorization Registry. An Application Registration is created for Projectron in
+            Alice’s Agent Registry. An Access Grant and corresponding Data Grants are generated
+            from the Access Authorization and stored in the Projectron Application Registration. 
+      <tr>
+       <td><b>14</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the appropriate access has been granted.
+      <tr>
+       <td><b>15</b>
+       <td>Projectron again asks Alice’s Authorization Agent for a Projectron Application Registration.
+      <tr>
+       <td><b>16</b>
+       <td>Alice’s Authorization Agent finds the newly created Projectron Application Registration in the Agent Registry in Alice’s Pod.
+      <tr>
+       <td><b>17</b>
+       <td>Alice’s Authorization Agent provides the URI of the Application Registration to Projectron.
+      <tr>
+       <td><b>18</b>
+       <td>Projectron learns what access it received through the Access Grant in Alice’s Projectron Application Registration.
+      <tr>
+       <td><b>19</b>
+       <td>Projectron may now function as intended, within the scope of authorization it was given by Alice.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/application-requests-access-flow.seq.mmd.svg"></p>
+   <h2 class="heading settled" data-level="8" id="resource-indication"><span class="secno">8. </span><span class="content">Sharing resources indicated by the application</span><a class="self-link" href="#resource-indication"></a></h2>
+   <p>When the application has already been registered, and the user wants to
+initiate a sharing-specific <a href="#data-instance">§ 4.2 Data Instance</a>, an authorization flow with resource
+indication is available.</p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice’s is authenticated with Projectron.
+      <tr>
+       <td><b>2</b>
+       <td>Alice has already authorized Projectron.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron has read its Access Grant and displayed projects.
+      <tr>
+       <td><b>4</b>
+       <td>Alice initiates sharing of a specific project.
+      <tr>
+       <td><b>5</b>
+       <td>Projectron redirects Alice to her Authorization Agent, indicating the selected project.
+      <tr>
+       <td><b>6-8</b>
+       <td>Alice’s Authorization Agent fetches the indicated project and checks who already has access to it.
+          It also fetches list of all registered social agents to present it to Alice.
+      <tr>
+       <td><b>9</b>
+       <td>Alice chooses all the social agents with which she wants to share the selected project,
+          as well as modes of access for all selected agents. If the shape tree has references (e.g., tasks) she can
+          also select modes of access for each inherited shape tree.
+      <tr>
+       <td><b>10-11</b>
+       <td>Alice’s Authorization Agent records new access authorizations for all the selected agents
+          and regenerates access grants provided in their agent registrations.
+      <tr>
+       <td><b>12</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron WebID, retrieving Projection’s
+          Application profile graph from the WebID Profile Document,
+          to discover the <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>13</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the project has been shared.
+      <tr>
+       <td><b>14</b>
+       <td>Alice continues using Projectron.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/resource-indication.seq.mmd.svg"></p>
+   <h2 class="heading settled" data-level="9" id="generating-grants-from-authorizations"><span class="secno">9. </span><span class="content">Generating Access Grant from Access Authorization</span><a class="self-link" href="#generating-grants-from-authorizations"></a></h2>
+   <p>Based on an <a href="#access-authorization">§ 5.1 Access Authorization</a>, authorization agent can generate an <a href="#access-grant">§ 6.6 Access Grant</a>.
+For <a href="#data-authorization">§ 5.2 Data Authorization</a> using <code>AllFromRegistry</code>, <code>SelectedFromRegistry</code> scope,
+a single <a href="#data-grant">§ 6.7 Data Grant</a> gets generated. Similar for data authorization using <code>Inherited</code> scope and
+inheriting from data authorization with one of those two scopes. Here a data authorization gets directly
+translated into a data grant, only changing type and all authorization specific properties to grant specific properties.</p>
+   <p>For data authorization using <code>All</code> or <code>AllFromAgent</code>, zero or more data grant gets generated.
+This number depends on a number of Data Registries owned by the social agent giving the authorization,
+as well as number of data grants given to them by other social agents. Data authorization with <code>Inherited</code> scope
+will also have zero or more data grants if it is inheriting from data authorization using one of those two scopes.</p>
+   <p>Example of an implementation can be found in <a data-link-type="biblio" href="#biblio-sai-js" title="Solid Application Interoperability - TypeScript implementation">[SAI-JS]</a> and <a data-link-type="biblio" href="#biblio-sai-java" title="Solid Application Interoperability - Java implementation">[SAI-JAVA]</a></p>
+  </main>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-sai">[SAI]
+   <dd>Justin Bingham; Eric Prud'hommeaux; elf Pavlik. <a href="https://solid.github.io/data-interoperability-panel/specification/"><cite>Solid Application Interoperability</cite></a>. URL: <a href="https://solid.github.io/data-interoperability-panel/specification/">https://solid.github.io/data-interoperability-panel/specification/</a>
+   <dt id="biblio-sai-java">[SAI-JAVA]
+   <dd>Justin Bingham. <a href="https://github.com/janeirodigital/sai-java"><cite>Solid Application Interoperability - Java implementation</cite></a>. URL: <a href="https://github.com/janeirodigital/sai-java">https://github.com/janeirodigital/sai-java</a>
+   <dt id="biblio-sai-js">[SAI-JS]
+   <dd>elf Pavlik; Maciej Samoraj; Ángel Araya. <a href="https://github.com/janeirodigital/sai-js"><cite>Solid Application Interoperability - TypeScript implementation</cite></a>. URL: <a href="https://github.com/janeirodigital/sai-js">https://github.com/janeirodigital/sai-js</a>
+   <dt id="biblio-shapetrees">[SHAPETREES]
+   <dd>Justin Bingham; et al. <a href="https://shapetrees.org/TR/specification/"><cite>Shape Trees</cite></a>. URL: <a href="https://shapetrees.org/TR/specification/">https://shapetrees.org/TR/specification/</a>
+   <dt id="biblio-shex">[SHEX]
+   <dd>Eric Prud'hommeaux; et al. <a href="http://shex.io/shex-semantics/index.html"><cite>Shape Expressions Language 2.1</cite></a>. URL: <a href="http://shex.io/shex-semantics/index.html">http://shex.io/shex-semantics/index.html</a>
+   <dt id="biblio-web-share">[WEB-SHARE]
+   <dd>Marcos Caceres; Eric Willigers; Matt Giuca. <a href="https://w3c.github.io/web-share/"><cite>Web Share API</cite></a>. URL: <a href="https://w3c.github.io/web-share/">https://w3c.github.io/web-share/</a>
+   <dt id="biblio-web-share-target">[WEB-SHARE-TARGET]
+   <dd>Matt Giuca; Eric Willigers. <a href="https://w3c.github.io/web-share-target/"><cite>Web Share Target API</cite></a>. ED. URL: <a href="https://w3c.github.io/web-share-target/">https://w3c.github.io/web-share-target/</a>
+  </dl>

--- a/sai.html
+++ b/sai.html
@@ -1,0 +1,4127 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Solid Application Interoperability</title>
+  <meta content="CG-DRAFT" name="w3c-status">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
+  <link href="https://solidproject.org/TR/sai" rel="canonical">
+  <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
+  <meta content="b1aa5b6d33d362cab931e0fa7c3674b51f45950b" name="revision">
+<style>
+table.permissions thead tr {
+  font-size: 12px;
+  text-align: left;
+}
+
+table.permissions th {
+  text-align: left;
+}
+
+table.permissions tbody tr:nth-child(even) {
+  background-color: lightgray;
+  font-size: 10px;
+}
+
+table.permissions tbody td {
+  font-size: 10px;
+  text-align: left;
+}
+
+table.classinfo thead tr th[colspan] {
+  text-align: left;
+  font-size: 15px;
+}
+
+table.classinfo thead tr th {
+  text-align: left;
+  font-size: 14px;
+}
+
+table.classinfo tbody tr:nth-child(odd) {
+  background-color: lightgray;
+  font-size: 12px;
+}
+
+table.classinfo tbody tr td {
+  font-size: 12px;
+}
+
+table.tree thead tr {
+  font-size: 14px;
+}
+
+table.tree tbody tr:nth-child(even) {
+  background-color: lightgray;
+  font-size: 14px;
+}
+
+table.tree tbody td {
+  font-size: 12px;
+}
+
+table.intersecting thead tr {
+  font-size: 14px ;
+}
+
+table.intersecting tbody tr:nth-child(odd) {
+  background-color: lightgray;
+  font-size: 14px;
+}
+
+table.intersecting tbody td {
+  font-size: 13px;
+  vertical-align: top ;
+  text-align: left;
+}
+
+table.intersecting td[colspan] {
+  text-align: left;
+}
+
+pre {
+  font-size: .8em;
+}
+
+figcaption {
+  text-align: left;
+}
+
+a[data-link-type=dfn] {
+  color: #000000;
+}
+
+a[href*=".ttl"] {
+  color: #339966;
+  border-bottom: 1px solid #339966;
+}
+
+a[href*="snippets"] {
+  color: #5a3399;
+  border-bottom: 1px solid #5a3399;
+}
+
+a[href^="#class"] {
+  color: #339966;
+  border-bottom: 1px solid #339966;
+}
+
+a.vocab {
+  color: #339966;
+  border-bottom: 1px solid #339966;
+}
+
+a[href*=".shex"] {
+  color: #cc2900;
+  border-bottom: 1px solid #cc2900;
+}
+
+a[href*=".tree"] {
+  color: #e68a00;
+  border-bottom: 1px solid #e68a00;
+}
+
+.sequence-diagram {
+    max-width: 100%;
+}
+
+.flow-pattern {
+  font-size: 14px;
+}
+
+em.rfc2119 {
+  text-transform: lowercase;
+  font-variant: small-caps;
+  font-style: normal;
+  font-size: 18px;
+  color: #900;
+}
+
+</style>
+<style>/* Boilerplate: style-autolinks */
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}
+
+</style>
+<style>/* Boilerplate: style-colors */
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+</style>
+<style>/* Boilerplate: style-counters */
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}
+</style>
+<style>/* Boilerplate: style-dfn-panel */
+:root {
+    --dfnpanel-bg: #ddd;
+    --dfnpanel-text: var(--text);
+    --dfnpanel-target-bg: #ffc;
+    --dfnpanel-target-outline: orange;
+}
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    width: 20em;
+    width: 300px;
+    height: auto;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--dfnpanel-bg);
+    color: var(--dfnpanel-text);
+    border: outset 0.2em;
+    white-space: normal; /* in case it's moved into a pre */
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: var(--dfnpanel-text); }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel a:focus {
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
+}
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0 0 0 1em; list-style: none; }
+.dfn-panel li a {
+    max-width: calc(300px - 1.5em - 1em);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: 8px;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+    transition: left 1s ease-out, bottom 1s ease-out;
+}
+
+.dfn-panel .link-item:hover {
+    text-decoration: underline;
+}
+.dfn-panel .link-item .copy-icon {
+    opacity: 0;
+}
+.dfn-panel .link-item:hover .copy-icon,
+.dfn-panel .link-item .copy-icon:focus {
+    opacity: 1;
+}
+
+.dfn-panel .copy-icon {
+    display: inline-block;
+    margin-right: 0.5em;
+    width: 0.85em;
+    height: 1em;
+    border-radius: 3px;
+    background-color: #ccc;
+    cursor: pointer;
+}
+
+.dfn-panel .copy-icon .icon {
+    width: 100%;
+    height: 100%;
+    background-color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.dfn-panel .copy-icon .icon::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 1px solid black;
+    background-color: #ccc;
+    opacity: 0.25;
+    transform: translate(3px, -3px);
+}
+
+.dfn-panel .copy-icon:active .icon::before {
+    opacity: 1;
+}
+
+.dfn-paneled[role="button"] { cursor: help; }
+
+.highlighted {
+    animation: target-fade 3s;
+}
+
+@keyframes target-fade {
+    from {
+        background-color: var(--dfnpanel-target-bg);
+        outline: 5px solid var(--dfnpanel-target-outline);
+    }
+    to {
+        color: var(--a-normal-text);
+        background-color: transparent;
+        outline: transparent;
+    }
+}
+</style>
+<style>/* Boilerplate: style-issues */
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* Boilerplate: style-line-highlighting */
+:root {
+    --highlight-hover-bg: rgba(0, 0, 0, .05);
+}
+.line-numbered {
+    display: grid !important;
+    grid-template-columns: min-content 1fr;
+    grid-auto-flow: rows;
+}
+.line-numbered > *,
+.line-numbered::before,
+.line-numbered::after {
+    grid-column: 1/-1;
+}
+.line-no {
+    grid-column: 1;
+    color: gray;
+}
+.line {
+    grid-column: 2;
+}
+.line.highlight-line {
+    background: var(--highlight-hover-bg);
+}
+.line-no.highlight-line {
+    background: var(--highlight-hover-bg);
+    color: #444;
+    font-weight: bold;
+}
+.line-no.highlight-line[data-line]::before {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line);
+}
+.line-no.highlight-line[data-line-end]::after {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line-end);
+}
+
+</style>
+<style>/* Boilerplate: style-md-lists */
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}
+</style>
+<style>/* Boilerplate: style-ref-hints */
+:root {
+    --ref-hint-bg: #ddd;
+    --ref-hint-text: var(--text);
+}
+
+.ref-hint {
+    display: inline-block;
+    position: absolute;
+    z-index: 35;
+    width: 20em;
+    width: 300px;
+    height: auto;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.5em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--ref-hint-bg);
+    color: var(--ref-hint-text);
+    border: outset 0.2em;
+    white-space: normal; /* in case it's moved into a pre */
+}
+
+.ref-hint * { margin: 0; padding: 0; text-indent: 0; }
+
+.ref-hint ul { padding: 0 0 0 1em; list-style: none; }
+</style>
+<style>/* Boilerplate: style-selflinks */
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">Solid Application Interoperability</h1>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2025-09-16">16 September 2025</time></p>
+   <details open>
+    <summary>More details about this document</summary>
+    <div data-fill-with="spec-metadata">
+     <dl>
+      <dt>This version:
+      <dd><a class="u-url" href="https://solidproject.org/TR/tag/sai-v0.1">https://solidproject.org/TR/tag/sai-v0.1</a>
+      <dt>Latest published version:
+      <dd><a href="https://solidproject.org/TR/sai">https://solidproject.org/TR/sai</a>
+      <dt>Feedback:
+      <dd><a href="https://github.com/solid/data-interoperability-panel/issues/">GitHub</a>
+      <dd><a href="#issues-index">Inline In Spec</a>
+      <dt class="editor">Editors:
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">Justin Bingham</span>
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">Eric Prud'hommeaux</span>
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">elf Pavlik</span>
+      <dt>Version:
+      <dd>0.1
+     </dl>
+    </div>
+   </details>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">Copyright © 2025 the Contributors to the Solid Application Interoperability,
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+   <p>This specification details how Social Agents and Applications
+can safely share and interoperate over data in Solid Pods.</p>
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This report was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+  Learn more about <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#agents"><span class="secno">2</span> <span class="content">Agents</span></a>
+    <li>
+     <a href="#social-agents"><span class="secno">3</span> <span class="content">Social Agents</span></a>
+     <ol class="toc">
+      <li><a href="#datamodel-registry-set"><span class="secno">3.1</span> <span class="content">Registry Set</span></a>
+     </ol>
+    <li><a href="#app"><span class="secno">4</span> <span class="content">Applications</span></a>
+    <li>
+     <a href="#ar"><span class="secno">5</span> <span class="content">Agent Registrations</span></a>
+     <ol class="toc">
+      <li><a href="#application-registration"><span class="secno">5.1</span> <span class="content">Application Registration</span></a>
+      <li><a href="#social-agent-registration"><span class="secno">5.2</span> <span class="content">Social Agent Registration</span></a>
+      <li><a href="#social-agent-invitation"><span class="secno">5.3</span> <span class="content">Social Agent Invitation</span></a>
+      <li><a href="#ar-registry"><span class="secno">5.4</span> <span class="content">Agent Registry</span></a>
+     </ol>
+    <li>
+     <a href="#dr"><span class="secno">6</span> <span class="content">Data Registrations</span></a>
+     <ol class="toc">
+      <li><a href="#data-registration"><span class="secno">6.1</span> <span class="content">Data Registration</span></a>
+      <li><a href="#data-registry"><span class="secno">6.2</span> <span class="content">Data Registry</span></a>
+     </ol>
+    <li>
+     <a href="#authorization"><span class="secno">7</span> <span class="content">Authorization Flows</span></a>
+     <ol class="toc">
+      <li><a href="#authorization-agent"><span class="secno">7.1</span> <span class="content">Authorization Agent</span></a>
+     </ol>
+    <li>
+     <a href="#needs"><span class="secno">8</span> <span class="content">Access Needs</span></a>
+     <ol class="toc">
+      <li><a href="#access-need-group"><span class="secno">8.1</span> <span class="content">Access Need Group</span></a>
+      <li><a href="#needs-access-need"><span class="secno">8.2</span> <span class="content">Access Need</span></a>
+      <li><a href="#access-descriptions"><span class="secno">8.3</span> <span class="content">Access Descriptions</span></a>
+      <li><a href="#access-request"><span class="secno">8.4</span> <span class="content">Access Request</span></a>
+     </ol>
+    <li>
+     <a href="#authorizations"><span class="secno">9</span> <span class="content">Access Authorizations</span></a>
+     <ol class="toc">
+      <li><a href="#access-authorization"><span class="secno">9.1</span> <span class="content">Access Authorization</span></a>
+      <li><a href="#data-authorization"><span class="secno">9.2</span> <span class="content">Data Authorization</span></a>
+      <li><a href="#access-grant"><span class="secno">9.3</span> <span class="content">Access Grant</span></a>
+      <li><a href="#data-grant"><span class="secno">9.4</span> <span class="content">Data Grant</span></a>
+      <li><a href="#delegated-data-grant"><span class="secno">9.5</span> <span class="content">Delegated Data Grant</span></a>
+      <li><a href="#access-scopes"><span class="secno">9.6</span> <span class="content">Data Access Scopes</span></a>
+      <li><a href="#access-receipt"><span class="secno">9.7</span> <span class="content">Access Receipt</span></a>
+      <li><a href="#access-registry"><span class="secno">9.8</span> <span class="content">Authorization Registry</span></a>
+     </ol>
+    <li>
+     <a href="#security"><span class="secno">10</span> <span class="content">Security</span></a>
+     <ol class="toc">
+      <li><a href="#security-appauthz"><span class="secno">10.1</span> <span class="content">Application Authorization</span></a>
+     </ol>
+    <li><a href="#definitions"><span class="secno">11</span> <span class="content">Definitions</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
+   </ol>
+  </nav>
+  <main>
+<script type="application/ld+json">
+{
+  "@context": {
+    "doap": "http://usefulinc.com/ns/doap#",
+    "spec": "http://www.w3.org/ns/spec#",
+    "schema": "http://schema.org/",
+    "sai": "https://solidproject.org/TR/sai#",
+    "name": "schema:name",
+    "author": { "@id": "schema:author", "@type": "@id" },
+    "editor": { "@id": "schema:editor", "@type": "@id" },
+    "definesConformanceFor": { "@id": "spec:definesConformanceFor", "@type": "@id" },
+    "ClassOfProduct": { "@id": "spec:ClassOfProduct", "@type": "@id" }
+  },
+  "@id": "https://solidproject.org/TR/sai",
+  "@type": "doap:Specification",
+  "name": "Solid Application Interoperability",
+  "author": [
+    "https://elf-pavlik.hackers4peace.net",
+    "urn:uuid:3b05c17c-f44a-470e-8031-408abee6e2ca",
+    "https://justin.inrupt.net/profile/card#me"
+  ],
+  "editor": [
+    "https://elf-pavlik.hackers4peace.net",
+    "urn:uuid:3b05c17c-f44a-470e-8031-408abee6e2ca",
+    "https://justin.inrupt.net/profile/card#me"
+  ],
+  "definesConformanceFor": [
+    { 
+      "@id": "sai:Application",
+      "@type": "ClassOfProduct",
+      "name": "SAI Application"
+    },
+    { 
+      "@id": "sai:AuthorizationAgent",
+      "@type": "ClassOfProduct",
+      "name": "SAI Authorization Agent"
+    }
+  ]
+}
+</script>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p>Solid affords us the opportunity to create a valuable and
+powerful ecosystem where people and organizations retain control
+of their data, but are also able to put it to work and use it
+to its full potential. The fundamentals of Solid make this possible,
+but further definition of standard methods and mechanisms 
+must be established
+to make it practical, intuitive, and secure.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> See <a data-link-type="biblio" href="#biblio-problems-and-goals" title="Problems and Goals for Interoperability, Collaboration, and Security in a Solid Pod">Problems and Goals for Interoperability in Solid</a> for an explanation of the problem space.</p>
+   <p>This specification details how <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent">Social Agents</a> in the Solid ecosystem
+can read, write, and manage data stored in a Solid pod using
+disparate <a data-link-type="dfn" href="#application" id="ref-for-application">Applications</a>.</p>
+   <p><a href="#ar">§ 5 Agent Registrations</a> details how <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①">Social Agents</a> track and manage the other <a data-link-type="dfn" href="#agents①" id="ref-for-agents①">Agents</a> they interact with.</p>
+   <p><a href="#dr">§ 6 Data Registrations</a> details how <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②">Social Agents</a> register, organize, and
+lookup their data. Data is stored uniformly, avoiding complex 
+physical hierarchies. <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree">Shape trees</a> and <a data-link-type="dfn" href="#shape" id="ref-for-shape">shapes</a> provide strong data validation and
+intuitive data boundaries.</p>
+   <p><a href="#authorization">§ 7 Authorization Flows</a> provides the means for a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③">Social Agent</a> to grant other <a data-link-type="dfn" href="#application" id="ref-for-application①">Applications</a> and <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④">Social Agents</a> access to data in their control.</p>
+   <ul>
+    <li data-md>
+     <p><a href="#needs">§ 8 Access Needs</a> let <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application②">Applications</a> express which data they
+need access to, and patterns to request those needs.</p>
+    <li data-md>
+     <p><a href="#authorizations">§ 9 Access Authorizations</a> let <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥">Social Agents</a> manage and track access they’ve granted
+to other <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①">Agents</a>.</p>
+   </ul>
+   <h2 class="heading settled" data-level="2" id="agents"><span class="secno">2. </span><span class="content">Agents</span><a class="self-link" href="#agents"></a></h2>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="agents①">Agents</dfn> are the primary actors in an interoperable Solid <a data-link-type="dfn" href="#ecosystem" id="ref-for-ecosystem">ecosystem</a>.</p>
+   <p>An <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②">Agent</a> is denoted by an <a data-link-type="dfn" href="#identity" id="ref-for-identity">identity</a>. Dereferencing that <a data-link-type="dfn" href="#identity" id="ref-for-identity①">identity</a> leads to <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document">identity profile document</a>, where a graph of useful information
+about the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③">Agent</a> can be found. This graph is used by the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①④">Agent</a> as a starting point to look up their own data, as well as data that has
+been shared with them.</p>
+   <p>The <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑤">Agent</a> graph in an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document①">identity profile document</a> is designed to be
+publicly accessible, but many of the things the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑥">Agent</a> links to are
+designed to be private, or accessible only by others they have authorized.</p>
+   <p>An <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑦">Agent</a> can dereference the <a data-link-type="dfn" href="#identity" id="ref-for-identity②">identity</a> of another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑧">Agent</a> to obtain
+the public information they need to interact with them.</p>
+   <p><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application③">Applications</a> are specific types of <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑨">Agents</a> denoted by this specification.</p>
+   <div id="classAgent"></div>
+   <div class="issue no-marker" id="issue-d41d8cd9"><a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/210" style="text-transform:none">solid/data-interoperability-panel/210</a><a href="https://github.com/solid/data-interoperability-panel/issues/210">Incorporate profile requirements from solid-oidc for Social Agents and Applications.</a></div>
+   <h2 class="heading settled" data-level="3" id="social-agents"><span class="secno">3. </span><span class="content">Social Agents</span><a class="self-link" href="#social-agents"></a></h2>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="social-agent">Social Agent</dfn> is a strongly identifiable individual, group, or
+organization that can own or be responsible for data, and provide authorization to the
+access of that data by other <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⓪">Agents</a>.</p>
+   <p>Most of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧">Social Agent’s</a> information is stored in <a data-link-type="dfn" href="#registry" id="ref-for-registry">Registries</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="registry">Registry</dfn> is a place where a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨">Social Agent</a> can store and find
+different types of data, often for particular purposes. Each type
+of <a data-link-type="dfn" href="#registry" id="ref-for-registry①">Registry</a> serves a specific purpose or function.</p>
+   <p>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪">Social Agent</a> stores a list of its <a data-link-type="dfn" href="#registry" id="ref-for-registry②">Registries</a> in a <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set">Registry Set</a>,
+which must be a separate resource from the <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document②">identity profile document</a> that the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①">Social Agent</a> graph resides in so that it can be given more
+restrictive (i.e. non-public) permissions.</p>
+   <p>The <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document③">identity profile document</a> <em class="rfc2119">MUST</em> be readable by the public. It <em class="rfc2119">MAY</em> use any resource or subject names.</p>
+   <p><a href="interop.ttl#SocialAgent">Class Definition</a> - <a href="interop.shex#SocialAgentShape">Shape Definition</a> - <a href="interop.tree#SocialAgentTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classSocialAgent">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasRegistrySet
+      <td><a href="#classRegistrySet">RegistrySet</a>
+      <td><a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set①">Registry Set</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①②">Social Agent</a>
+     <tr>
+      <td>hasAuthorizationAgent
+      <td><a href="#classApplication">Application</a>
+      <td>The software used by the Agent to manage access to their data
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①③">Social Agent</a> at https://alice.example/#id - <a href="snippets/alice.example/alice.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- k>PREFIX</c-> <c- nn>rdf:</c-> <c- g>&lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#></c->
+<c- k>PREFIX</c-> <c- nn>rdfs:</c-> <c- g>&lt;http://www.w3.org/2000/01/rdf-schema#></c->
+<c- k>PREFIX</c-> <c- nn>interop:</c-> <c- g>&lt;http://www.w3.org/ns/solid/interop#></c->
+<c- k>PREFIX</c-> <c- nn>alice:</c-> <c- g>&lt;https://alice.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-jarvis:</c-> <c- g>&lt;https://alice.jarvis.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-auth:</c-> <c- g>&lt;https://auth.alice.example/></c->
+
+<c- nn>alice</c-><c- p>:</c-><c- f>\#id</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c->
+  <c- c>######## Registry Sets ########</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice</c-><c- p>:</c-><c- f>registries</c-> <c- p>;</c->
+  <c- c>######## Authorization Agent ########</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- nn>alice-jarvis</c-><c- p>:</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="3.1" id="datamodel-registry-set"><span class="secno">3.1. </span><span class="content">Registry Set</span><a class="self-link" href="#datamodel-registry-set"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="registry-set">Registry Set</dfn> links to all of the <a data-link-type="dfn" href="#registry" id="ref-for-registry③">Registries</a> owned
+by a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①④">Social Agent</a>. A non-public document, it is accessed by or
+on behalf of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑤">Social Agent</a> or their <a data-link-type="dfn">Trusted Agents</a> via trusted <a data-link-type="dfn" href="#application" id="ref-for-application④">Applications</a>.</p>
+   <p>The <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set②">Registry Set</a> <em class="rfc2119">MAY</em> use any resource or
+subject names. It <em class="rfc2119">SHOULD NOT</em> be readable
+by the public. It <em class="rfc2119">SHOULD</em> be accessible
+and manageable by the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑥">Social Agent</a> that owns it, or other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑦">Social Agents</a> that have received appropriate authorization, via
+authorized <a data-link-type="dfn" href="#application" id="ref-for-application⑤">Applications</a>.</p>
+   <p><a href="interop.ttl#RegistrySet">Class Definition</a> - <a href="interop.shex#RegistrySetShape">Shape Definition</a> - <a href="interop.tree#RegistrySetTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classRegistrySet">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAgentRegistry
+      <td><a href="#classAgentRegistry">AgentRegistry</a>
+      <td><a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry">Agent Registry</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑧">Social Agent</a>
+     <tr>
+      <td>hasAuthorizationRegistry
+      <td><a href="#classAuthorizationRegistry">AuthorizationRegistry</a>
+      <td><a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry">Authorization Registry</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑨">Social Agent</a>
+     <tr>
+      <td>hasDataRegistry
+      <td><a href="#classDataRegistry">DataRegistry</a>
+      <td><a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①">Data Registry</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⓪">Social Agent</a>
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set③">Registry Set</a> at https://alice.example/registries - <a href="snippets/alice.example/registries.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- k>PREFIX</c-> <c- nn>interop:</c-> <c- g>&lt;http://www.w3.org/ns/solid/interop#></c->
+<c- k>PREFIX</c-> <c- nn>alice:</c-> <c- g>&lt;https://alice.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-work:</c-> <c- g>&lt;https://work.alice.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-personal:</c-> <c- g>&lt;https://personal.alice.example/></c->
+
+<c- nn>alice</c-><c- p>:</c-><c- f>registries</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>RegistrySet</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAgentRegistry</c-> <c- nn>alice</c-><c- p>:</c-><c- f>agents\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationRegistry</c-> <c- nn>alice</c-><c- p>:</c-><c- f>authorization\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistry</c->
+    <c- nn>alice-work</c-><c- p>:</c-><c- f>data\/</c-> <c- p>,</c->
+    <c- nn>alice-personal</c-><c- p>:</c-><c- f>data\/</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h2 class="heading settled" data-level="4" id="app"><span class="secno">4. </span><span class="content">Applications</span><a class="self-link" href="#app"></a></h2>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application">Application</dfn> is a software-based <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①①">Agent</a> that a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②①">Social Agent</a> uses to access, manipulate, and manage the data in 
+their control, as well as the data they’ve been granted access to.</p>
+   <p>The information in the <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document④">identity profile document</a> of an <a data-link-type="dfn" href="#application" id="ref-for-application⑥">Application</a> is used during <a href="#authorization">§ 7 Authorization Flows</a> to help <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②②">Social Agents</a> determine whether 
+they want to use that <a data-link-type="dfn" href="#application" id="ref-for-application⑦">Application</a>. It lets them know what kind of 
+data the <a data-link-type="dfn" href="#application" id="ref-for-application⑧">Application</a> needs access to and why. This lets the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②③">Social Agent</a> make an informed choice.</p>
+   <p>An <a data-link-type="dfn" href="#application" id="ref-for-application⑨">Application</a> identifies the types of data it requires access to
+by linking to <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①">Access Need Groups</a>.</p>
+   <p>The <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑤">identity profile document</a> of an <a data-link-type="dfn" href="#application" id="ref-for-application①⓪">Application</a> <em class="rfc2119">MUST</em> be readable by the public, along with
+its thumbnail and any identified <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①">Access Need Groups</a>. 
+They <em class="rfc2119">MAY</em> use any resource or subject names.</p>
+   <p><a href="interop.ttl#Application">Class Definition</a> - <a href="interop.shex#ApplicationShape">Shape Definition</a> - <a href="interop.tree#ApplicationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classApplication">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>applicationName
+      <td>xsd:string
+      <td>Name of the <a data-link-type="dfn" href="#application" id="ref-for-application①①">Application</a>
+     <tr>
+      <td>applicationDescription
+      <td>xsd:string
+      <td>Description of the <a data-link-type="dfn" href="#application" id="ref-for-application①②">Application</a>
+     <tr>
+      <td>applicationAuthor
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②④">Social Agent</a> that authored the <a data-link-type="dfn" href="#application" id="ref-for-application①③">Application</a>
+     <tr>
+      <td>applicationThumbnail
+      <td>binary image
+      <td>Thumbnail for the <a data-link-type="dfn" href="#application" id="ref-for-application①④">Application</a>
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②">Access Need Group</a> representing types of data the <a data-link-type="dfn" href="#application" id="ref-for-application①⑤">Application</a> needs to operate
+     <tr>
+      <td>hasAuthorizationCallbackEndpoint
+      <td>IRI
+      <td>URI used to redirect back from <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①">Authorization Agent</a> to the application, after completing authorization
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#application" id="ref-for-application①⑥">Application</a> at https://projectron.example/#id - <a href="snippets/projectron.example/projectron.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Application</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationName</c-> <c- s>"Projectron"</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationDescription</c-> <c- s>"Manage projects with ease"</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationAuthor</c-> <c- nn>acme</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationThumbnail</c-> <c- nn>acme</c-><c- p>:</c-><c- f>thumb.svg</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>needs</c-><c- p>:</c-><c- f>need-group-pm</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationCallbackEndpoint</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>redirect</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h2 class="heading settled" data-level="5" id="ar"><span class="secno">5. </span><span class="content">Agent Registrations</span><a class="self-link" href="#ar"></a></h2>
+   <p><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑤">Social Agents</a> manage the other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑥">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application①⑦">Applications</a> they interact with
+by registering these <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①②">Agents</a> in their <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①">Agent Registry</a>.</p>
+   <p>When a given <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①③">Agent</a> is the subject of an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①">Access Authorization</a>,
+an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①">Access Grant</a> is generated and <a href="#ar-hierarchy">stored</a> in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations">Agent Registration</a> for that <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①④">Agent</a>.</p>
+   <h3 class="heading settled" data-level="5.1" id="application-registration"><span class="secno">5.1. </span><span class="content">Application Registration</span><a class="self-link" href="#application-registration"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application-registration①">Application Registration</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑦">Social Agent</a> with a place to maintain metadata, state, preferences, and
+other application-specific data associated with a given <a data-link-type="dfn" href="#application" id="ref-for-application①⑧">Application</a> they
+have elected to use.</p>
+   <p><a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①">Application Registrations</a> are stored in an <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry②">Agent Registry</a>.</p>
+   <p><a href="interop.ttl#ApplicationRegistration">Class Definition</a> - <a href="interop.shex#ApplicationRegistrationShape">Shape Definition</a> - <a href="interop.tree#ApplicationRegistrationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classApplicationRegistration">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑧">Social Agent</a> that registered the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①①">Application Registration</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application①⑨">Application</a> used to create the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①②">Application Registration</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①③">Application Registration</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①④">Application Registration</a> was updated
+     <tr>
+      <td>registeredAgent
+      <td><a href="#classApplication">Application</a>
+      <td>The <a data-link-type="dfn" href="#application" id="ref-for-application②⓪">Application</a> that was registered
+     <tr>
+      <td>hasAccessGrant
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①">Access Grant</a> describing the access that has been
+      granted to the <code>registeredAgent</code>
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①⑤">Application Registration</a> for Projectron at
+  https://alice.pod.example/agents/2f2f3628/ - <a href="snippets/alice.example/2f2f3628.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c-><c- f>2f2f3628\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>ApplicationRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAgent</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrant</c-> <c- nn>alice-agents</c-><c- p>:</c-><c- f>2f2f3628\/27eae14b</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="5.2" id="social-agent-registration"><span class="secno">5.2. </span><span class="content">Social Agent Registration</span><a class="self-link" href="#social-agent-registration"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="social-agent-registration①">Social Agent Registration</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑨">Social Agent</a> with a place to track and manage other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⓪">Social Agents</a> they
+interact with.</p>
+   <p><a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①">Social Agent Registrations</a> are stored in an <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry③">Agent Registry</a>.</p>
+   <p><a href="interop.ttl#SocialAgentRegistration">Class Definition</a> - <a href="interop.shex#SocialAgentRegistrationShape">Shape Definition</a> - <a href="interop.tree#SocialAgentRegistrationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classSocialAgentRegistration">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③①">Social Agent</a> that registered the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①">Social Agent Registration</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application②①">Application</a> used to create the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①②">Social Agent Registration</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①③">Social Agent Registration</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①④">Social Agent Registration</a> was updated
+     <tr>
+      <td>registeredAgent
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③②">Social Agent</a> that was registered
+     <tr>
+      <td>reciprocalRegistration
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td>The <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑤">Social Agent Registration</a> that <code>registeredAgent</code> maintains
+      for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③③">Social Agent</a> that owns this <a data-link-type="dfn" href="#registry" id="ref-for-registry④">Registry</a>
+     <tr>
+      <td>hasAccessGrant
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①②">Access Grant</a> describing the access that has been
+      granted to the <code>registeredAgent</code>
+     <tr>
+      <td>skos:prefLabel
+      <td>xsd:string
+      <td>Human readable label assigned by the user creating the registration
+     <tr>
+      <td>skos:note
+      <td>xsd:string
+      <td>Optional note which can further help with recognising the agent
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑥">Social Agent Registration</a> for Bob at
+  https://alice.pod.example/agents/c4562da9/ - <a href="snippets/alice.example/c4562da9.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c-><c- f>c4562da9\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SocialAgentRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAgent</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>reciprocalRegistration</c-> <c- nn>bob-agents</c-><c- p>:</c-><c- f>255aa181\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrant</c-> <c- nn>alice-agents</c-><c- p>:</c-><c- f>c4562da9\/b6e125b8</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="5.3" id="social-agent-invitation"><span class="secno">5.3. </span><span class="content">Social Agent Invitation</span><a class="self-link" href="#social-agent-invitation"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="social-agent-invitation①">Social Agent Invitation</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③④">Social Agent</a> with a simple and secure way to establish data sharing with other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑤">Social Agents</a>.</p>
+   <p><a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①">Social Agent Invitations</a> are stored in an <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry④">Agent Registry</a>.</p>
+   <p><a href="interop.ttl#SocialAgentInvitation">Class Definition</a> - <a href="interop.shex#SocialAgentInvitationShape">Shape Definition</a> - <a href="interop.tree#SocialAgentInvitationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classSocialAgentInvitation">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑥">Social Agent</a> that registered the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①①">Social Agent Invitation</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application②②">Application</a> used to create the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①②">Social Agent Invitation</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①③">Social Agent Invitation</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①④">Social Agent Invitation</a> was updated
+     <tr>
+      <td>capabilityUrl
+      <td><a data-link-type="biblio" href="#biblio-capability-urls" title="Good Practices for Capability URLs">Capability URL</a>
+      <td>Secure link used to accept the invitation
+     <tr>
+      <td>skos:prefLabel
+      <td>xsd:string
+      <td>Human readable label assigned by the user creating the invitation
+     <tr>
+      <td>skos:note
+      <td>xsd:string
+      <td>Optional note which can further help with understanding who is being invited
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑤">Social Agent Invitation</a> for Yori at
+  https://alice.pod.example/agents/a1umr5yx/ - <a href="snippets/alice.example/a1umr5yx.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c-><c- f>a1umr5yx\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SocialAgentInvitation</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>capabilityUrl</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>invitations\/z8tms2zzq3d9vfpo1a6yk5jkgn5y4aem</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Yori"</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>note</c-> <c- s>"A friend from my D&amp;D club"</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <p><a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①">Authorization Agent</a> accepting an authenticated request, targeting the <code>capabilityUrl</code> from a <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑥">Social Agent Invitation</a></p>
+   <ul>
+    <li data-md>
+     <p>MUST respond with the <a data-link-type="biblio" href="#biblio-webid" title="WebID 1.0">[WEBID]</a> of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑦">Social Agent</a> who created the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑦">Social Agent Invitation</a>, using <code>Content-Type: text/plain</code></p>
+    <li data-md>
+     <p>MUST use the identity of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑧">Social Agent</a>, from the incoming request,
+as the <code>registeredAgent</code> for newly created <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑦">Social Agent Registration</a>.</p>
+    <li data-md>
+     <p>SHOULD use the <code>skos:prefLabel</code> from the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑧">Social Agent Invitation</a> for the new <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑧">Social Agent Registration</a>.</p>
+    <li data-md>
+     <p>SHOULD use the <code>skos:note</code> from the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑨">Social Agent Invitation</a> for the new <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑨">Social Agent Registration</a>.</p>
+    <li data-md>
+     <p>SHOULD schedule <a href="#agent-registration-discovery">§ 7.1.4 Agent Registration Discovery</a> on the <code>registeredAgent</code> from the new <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①⓪">Social Agent Registration</a>.
+After the successful discovery, add it as <code>reciprocalRegistration</code></p>
+   </ul>
+   <p class="note" role="note"><span class="marker">Note:</span> Commonly the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①②">Authorization Agent</a>, making the request on behalf of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑨">Social Agent</a> accepting the invitation,
+    will create corresponding <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①①">Social Agent Registration</a> after receiving the <a data-link-type="biblio" href="#biblio-webid" title="WebID 1.0">[WEBID]</a> in the response,
+    which means that it is not available before receiving the response.</p>
+   <h3 class="heading settled" data-level="5.4" id="ar-registry"><span class="secno">5.4. </span><span class="content">Agent Registry</span><a class="self-link" href="#ar-registry"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="agent-registry">Agent Registry</dfn> is a collection of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="agent-registrations">Agent Registrations</dfn>.</p>
+   <p>Each <a data-link-type="dfn" href="#application" id="ref-for-application②③">Application</a> a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⓪">Social Agent</a> interacts with has an <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①⑥">Application Registration</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④①">Social Agent</a> a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④②">Social Agent</a> interacts with has a <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①②">Social Agent Registration</a>.</p>
+   <p>The <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑤">Agent Registry</a> is linked to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④③">Social Agent</a> via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set④">Registry Set</a>.</p>
+   <p><a href="interop.ttl#AgentRegistry">Class Definition</a> - <a href="interop.shex#AgentRegistryShape">Shape Definition</a> - <a href="interop.tree#AgentRegistryTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAgentRegistry">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasSocialAgentRegistration
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td>Link to an associated <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①③">Social Agent Registration</a> for 
+      a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④④">Social Agent</a>
+     <tr>
+      <td>hasApplicationRegistration
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td>Link to an associated <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①⑦">Application Registration</a> for 
+      a given <a data-link-type="dfn" href="#application" id="ref-for-application②④">Application</a>
+   </table>
+   <figure>
+    <figcaption>An <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑥">Agent Registry</a> at https://alice.example/agents/ - <a href="snippets/alice.example/agents.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AgentRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasSocialAgentRegistration</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>c4562da9\/</c-> <c- p>,</c->         <c- c># Bob</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>b49afcdf\/</c-> <c- p>,</c->         <c- c># Sarah</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>4ae3abf8\/</c-> <c- p>;</c->         <c- c># Jose</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasApplicationRegistration</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>2f2f3628\/</c-> <c- p>,</c->         <c- c># Projectron</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>b5eea7bb\/</c-> <c- p>,</c->         <c- c># Jarvis</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="5.4.1" id="ar-hierarchy"><span class="secno">5.4.1. </span><span class="content">Resource Hierarchy</span><a class="self-link" href="#ar-hierarchy"></a></h4>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Resource
+      <th>Class
+      <th>Shape
+      <th>Shape Tree
+    <tbody>
+     <tr>
+      <td><code><a href="snippets/alice.example/agents.ttl">agents/</a></code>
+      <td><a href="#classAgentRegistry">AgentRegistry</a>
+      <td><a href="interop.shex#AgentRegistryShape">AgentRegistryShape</a>
+      <td><a href="interop.tree#AgentRegistryTree">AgentRegistryTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/c4562da9.ttl">c4562da9/</a></code>
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td><a href="interop.shex#SocialAgentRegistrationShape">SocialAgentRegistrationShape</a>
+      <td><a href="interop.tree#SocialAgentRegistrationTree">SocialAgentRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/b6e125b8.ttl">b6e125b8/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/b42228af.ttl">b42228af/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/95ff7580.ttl">95ff7580/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/b49afcdf.ttl">b49afcdf/</a></code>
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td><a href="interop.shex#SocialAgentRegistrationShape">SocialAgentRegistrationShape</a>
+      <td><a href="interop.tree#SocialAgentRegistrationTree">SocialAgentRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/731b43ec.ttl">731b43ec/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/d85fd1f5.ttl">d85fd1f5/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/8fac3576.ttl">8fac3576/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/4ae3abf8.ttl">4ae3abf8/</a></code>
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td><a href="interop.shex#SocialAgentRegistrationShape">SocialAgentRegistrationShape</a>
+      <td><a href="interop.tree#SocialAgentRegistrationTree">SocialAgentRegistrationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/2f2f3628.ttl">2f2f3628/</a></code>
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td><a href="interop.shex#ApplicationRegistrationShape">ApplicationRegistrationShape</a>
+      <td><a href="interop.tree#ApplicationRegistrationTree">ApplicationRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/27eae14b.ttl">27eae14b/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/40d038ea.ttl">40d038ea/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/0945218b.ttl">0945218b/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/fe818190.ttl">fe818190/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/017d6a07.ttl">017d6a07/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/90b0f5ad.ttl">90b0f5ad/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/1912239c.ttl">1912239c/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/b5eea7bb.ttl">b5eea7bb/</a></code>
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td><a href="interop.shex#ApplicationRegistrationShape">ApplicationRegistrationShape</a>
+      <td><a href="interop.tree#ApplicationRegistrationTree">ApplicationRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/5ad22737.ttl">5ad22737/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/b0dc6c78.ttl">b0dc6c78/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/6ef722af.ttl">6ef722af/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/c2328cdd.ttl">c2328cdd/</a></code>
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td><a href="interop.shex#ApplicationRegistrationShape">ApplicationRegistrationShape</a>
+      <td><a href="interop.tree#ApplicationRegistrationTree">ApplicationRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/2ae35a57.ttl">2ae35a57/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/a8a224e6.ttl">a8a224e6/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/244dfe3e.ttl">244dfe3e/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/efc426c9.ttl">efc426c9/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/391f526b.ttl">391f526b/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/cc8f2f69.ttl">cc8f2f69/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/6da10e5b.ttl">6da10e5b/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+   </table>
+   <p>The <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑦">Agent Registry</a> MAY use any resource or subject name.</p>
+   <p>The resource name for an <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations①">Agent Registration</a> <em class="rfc2119">SHOULD</em> be unpredictable.</p>
+   <p>The <code>interop:registeredAgent</code> of a given <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations②">Agent Registration</a> <em class="rfc2119">SHOULD</em> have <code>acl:Read</code> access to that <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations③">Agent Registration</a>.</p>
+   <h2 class="heading settled" data-level="6" id="dr"><span class="secno">6. </span><span class="content">Data Registrations</span><a class="self-link" href="#dr"></a></h2>
+   <p>Data Registrations let <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑤">Social Agents</a> store and manage the
+data they control. Data of various types is organized and stored in a 
+uniform way to aid validation, authorization, 
+discovery, and more.</p>
+   <p>Complex hierarchies that hinder interoperability are avoided
+by storing data in a relatively flat hierarchy. This creates natural
+data boundaries that make data storage and authorization more intuitive.</p>
+   <h3 class="heading settled" data-level="6.1" id="data-registration"><span class="secno">6.1. </span><span class="content">Data Registration</span><a class="self-link" href="#data-registration"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-registration①">Data Registration</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑥">Social Agent</a> with a place to store <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance">Data Instances</a> that conform to the
+registered <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①">shape tree</a> of that registration. <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①">Data Registrations</a> are 
+stored in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①">Data Registry</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-instance">Data Instance</dfn> is a unique, stored instance of data
+in a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①">Data Registration</a> that conforms to it’s <code>interop:registeredShapeTree</code>.</p>
+   <p>Each <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①">Data Instance</a> is linked to the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②">Data Registration</a> via the <a class="vocab" href="https://www.w3.org/ns/ldp#contains">ldp:contains</a> property.</p>
+   <p><a href="interop.ttl#DataRegistration">Class Definition</a> - <a href="interop.shex#DataRegistrationShape">Shape Definition</a> - <a href="interop.tree#DataRegistrationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataRegistration">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑦">Social Agent</a> that registered the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③">Data Registration</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application②⑤">Application</a> used to create the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①④">Data Registration</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑤">Data Registration</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑥">Data Registration</a> was updated
+     <tr>
+      <td>registeredShapeTree
+      <td><a class="vocab" href="https://www.w3.org/ns/shapetrees#ShapeTree">st:ShapeTree</a>
+      <td>The <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②">Shape Tree</a> that was registered
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑦">Data Registration</a> for Projects at https://work.alice.example/data/8501f084/ - <a href="snippets/work.alice.example/8501f084.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetree</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="6.2" id="data-registry"><span class="secno">6.2. </span><span class="content">Data Registry</span><a class="self-link" href="#data-registry"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-registry①">Data Registry</dfn> is a collection of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑧">Data Registrations</a>, each
+of which represents a unique type of data, identified by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree③">shape tree</a>.</p>
+   <p>A <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②">Data Registry</a> can be used for basic discovery, but it is not
+designed nor intended to be an efficient means to query or index data.
+However, it is <em>intended</em> to be used as reliable source data for different
+query engines or indexing schemes.</p>
+   <p>A <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①③">Data Registry</a> is linked to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑧">Social Agent</a> via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑤">Registry Set</a>.</p>
+   <p><a href="interop.ttl#DataRegistry">Class Definition</a> - <a href="interop.shex#DataRegistryShape">Shape Definition</a> - <a href="interop.tree#DataRegistryTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataRegistry">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasDataRegistration
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td>Link to an associated <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑨">Data Registration</a>
+   </table>
+   <figure>
+    <figcaption>A <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①④">Data Registry</a> at https://work.alice.example/data/ 
+  linking to <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⓪">Data Registrations</a> for Projects and Tasks - <a href="snippets/work.alice.example/data-registry.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-work-data</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistry</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c->
+    <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>,</c->
+    <c- nn>alice-work-data</c-><c- p>:</c-><c- f>df4ab227\/</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="6.2.1" id="dr-hierarchy"><span class="secno">6.2.1. </span><span class="content">Resource Hierarchy</span><a class="self-link" href="#dr-hierarchy"></a></h4>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Resource
+      <th>Class
+      <th>Shape
+      <th>Shape Tree
+    <tbody>
+     <tr>
+      <td><code><a href="snippets/work.alice.example/data-registry.ttl">data/</a></code>
+      <td><a href="#classDataRegistry">DataRegistry</a>
+      <td><a href="interop.shex#DataRegistry">DataRegistryShape</a>
+      <td><a href="interop.tree#DataRegistry">DataRegistryTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/work.alice.example/8501f084.ttl">8501f084/</a></code>
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td><a href="interop.shex#DataRegistration">DataRegistrationShape</a>
+      <td><a href="interop.tree#DataRegistration">DataRegistrationTree</a>, <a href="snippets/data.example/pm-shapetrees.tree#ProjectRegistrationTree">ProjectRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/16e1eae9.ttl">16e1eae9</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Project">Project</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#ProjectShape">ProjectShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a>
+     <tr>
+      <td><code>------ 886785d2</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Project">Project</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#ProjectShape">ProjectShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a>
+     <tr>
+      <td><code>------ dae5015c</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Project">Project</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#ProjectShape">ProjectShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/work.alice.example/df4ab227.ttl">df4ab227/</a></code>
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td><a href="interop.shex#DataRegistration">DataRegistrationShape</a>
+      <td><a href="interop.tree#DataRegistration">DataRegistrationTree</a>, <a href="snippets/data.example/pm-shapetrees.tree#TaskRegistrationTree">TaskRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/9b60a354.ttl">9b60a354</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/6e545b74.ttl">6e545b74</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/d33e01c8.ttl">d33e01c8</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ 927108fa</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ 180dda0b</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+   </table>
+   <p>The <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑤">Data Registry</a> resource <em class="rfc2119">MAY</em> use any
+resource or subject name.</p>
+   <p>The resource names for <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①①">Data Registrations</a> and <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②">Data Instances</a> <em class="rfc2119">SHOULD</em> be unpredictable.</p>
+   <p>A <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①②">Data Registration</a> container <em class="rfc2119">MUST</em> contain conformant instances of the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree④">shape tree</a> associated with the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①③">Data Registration</a> via <a href="#classDataRegistration">interop:registeredShapeTree</a>.</p>
+   <p>Two complementary <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑤">shape trees</a> <em class="rfc2119">MUST</em> be assigned
+to the same <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①④">Data Registration</a> container to ensure that it conforms
+to general validation requirements, and to ensure
+that it only contains <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③">Data Instances</a> of the registered <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑥">shape tree</a> identified by <a href="#classDataRegistration">interop:registeredShapeTree</a>.</p>
+   <p>In the <a href="#fig-datareg-intersecting">figure below</a>, the
+combination of a <a href="interop.tree#DataRegistration">DataRegistrationTree</a> and <a href="snippets/data.example/pm-shapetrees.tree#ProjectRegistrationTree">ProjectRegistrationTree</a> on the
+same <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑤">Data Registration</a> can be observed. Furthermore, an example of
+a contained <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④">Data Instance</a> is provided, which conforms
+to <a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a> per the directive in <a href="snippets/data.example/pm-shapetrees.tree#ProjectRegistrationTree">ProjectRegistrationTree</a>.</p>
+   <figure id="fig-datareg-intersecting">
+    <figcaption>Intersecting <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑦">shape trees</a> for a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑥">Data Registration</a> and the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑧">shape tree</a> registered with it </figcaption>
+    <table align="left" class="data intersecting">
+     <colgroup>
+      <col>
+      <col>
+     <tbody>
+      <tr>
+       <td colspan="2"> <code>-- 8501f084/</code> 
+      <tr>
+       <td>
+         Contents of the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑦">Data Registration</a> 
+<pre class="include-code highlight"><c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetree</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>.</c->
+</pre>
+       <td>
+         Ensure the container resource for the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑧">Data Registration</a> conforms to <code>interops#DataRegistrationShape</code>. 
+<pre class="include-code highlight">  <c- nn>st</c-><c- p>:</c-><c- f>shape</c->          <c- nn>interops</c-><c- p>:</c-><c- f>DataGrantShape</c-> <c- p>.</c->
+
+<c- c># Data Registry</c->
+<c- c>##########################################################</c->
+</pre>
+        <p>And also ensure the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑨">Data Registration</a> only
+          contains resources that conform to <code>pm:ProjectTree</code>.</p>
+<pre class="include-code highlight"><c- g>&lt;#ProjectRegistrationTree></c->
+  <c- b>a</c-> <c- nn>st</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>st</c-><c- p>:</c-><c- f>Container</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>contains</c-> <c- g>&lt;#ProjectTree></c-> <c- p>.</c->
+</pre>
+      <tr>
+       <td colspan="2"> <code>------ 16e1eae9</code> 
+      <tr>
+       <td>
+         Contents of the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑤">Data Instance</a> 
+<pre class="include-code highlight">
+<c- nn>alice-work-projects</c-><c- p>:</c-><c- f>16e1eae9</c->
+  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>id</c-> <c- mi>6</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>name</c-> <c- s>"Solid Project"</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>created_at</c-> <c- s>"2021-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>9b60a354</c-> <c- p>,</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>6e545b74</c-> <c- p>,</c->
+</pre>
+       <td>
+         Ensure the resource for the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑥">Data Instance</a> conforms to <code>pm:ProjectTree</code>. 
+<pre class="include-code highlight"><c- g>&lt;#ProjectTree></c->
+  <c- b>a</c-> <c- nn>st</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>st</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>shape</c-> <c- nn>pm-shex</c-><c- p>:</c-><c- f>ProjectShape</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>references</c-> <c- p>[</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- g>&lt;#TaskTree></c-> <c- p>;</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>viaPredicate</c-> <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+  <c- p>]</c-> <c- p>.</c->
+</pre>
+    </table>
+   </figure>
+   <h2 class="heading settled" data-level="7" id="authorization"><span class="secno">7. </span><span class="content">Authorization Flows</span><a class="self-link" href="#authorization"></a></h2>
+   <p>Authorization represents several key elements that
+work together to grant, adjust, and rescind access to data controlled
+by a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑨">Social Agent</a>.</p>
+   <p>Key authorization flows are facilitated by an <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①③">Authorization Agent</a> on behalf of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⓪">Social Agent</a>.</p>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Flow
+      <th>Scenario
+    <tbody>
+     <tr>
+      <td><b>Application Requests Access</b>
+      <td>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤①">Social Agent</a> elects to use a new <a data-link-type="dfn" href="#application" id="ref-for-application②⑥">Application</a>. The <a data-link-type="dfn" href="#application" id="ref-for-application②⑦">Application</a> prompts the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤②">Social Agent</a> for access to data in their control. <a data-link-type="dfn" href="#access-need" id="ref-for-access-need">Access Needs</a> are provided by the <a data-link-type="dfn" href="#application" id="ref-for-application②⑧">Application</a>. 
+     <tr>
+      <td><b>Another Social Agent Requests Access</b>
+      <td>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤③">Social Agent</a> requests access to data owned
+        by another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤④">Social Agent</a>. <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①">Access Needs</a> are provided
+        in an <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①">Access Request</a>. Resultant notification is
+        provided through an <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①">Access Receipt</a>.
+     <tr>
+      <td><b>Social Agent Shares Access</b>
+      <td>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑤">Social Agent</a> using an <a data-link-type="dfn" href="#application" id="ref-for-application②⑨">Application</a> elects to share
+        access to data in their control with another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑥">Social Agent</a> that did not request it. <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②">Access Needs</a> are provided by <a data-link-type="dfn" href="#application" id="ref-for-application③⓪">Application</a>. Notification that access was shared is provided
+        through an <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①①">Access Receipt</a>.
+   </table>
+   <div class="assertion">
+    <p><b>Each authorization flow listed above uses the following pattern:</b></p>
+    <ol>
+     <li data-md>
+      <p>A requesting <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑤">Agent</a> expresses
+their <a href="#needs">Access Needs</a> to a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑦">Social Agent</a> for data in their control.</p>
+     <li data-md>
+      <p><a href="#needs">Access Needs</a> are processed and presented to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑧">Social Agent</a> by their <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①④">Authorization Agent</a>.</p>
+     <li data-md>
+      <p>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑨">Social Agent’s</a> access decisions are captured and enacted
+through <a href="#authorizations">§ 9 Access Authorizations</a>.</p>
+     <li data-md>
+      <p>The requesting <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑥">Agent</a> looks for an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①③">Access Grant</a> stored in a corresponding <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations④">Agent Registration</a> in the <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑧">Agent Registry</a> of the
+data owner. This <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①④">Access Grant</a> tells them exactly what they have access to.</p>
+    </ol>
+   </div>
+   <p>Slight variations concerning where <a data-link-type="dfn" href="#access-need" id="ref-for-access-need③">Access Needs</a> are sourced from, and
+how notification of access is provided, are the only differences from
+one flow to another.</p>
+   <h3 class="heading settled" data-level="7.1" id="authorization-agent"><span class="secno">7.1. </span><span class="content">Authorization Agent</span><a class="self-link" href="#authorization-agent"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-agent①">Authorization Agent</dfn> is an <a data-link-type="dfn" href="#application" id="ref-for-application③①">Application</a> designated by
+a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⓪">Social Agent</a> to be responsible for managing the access to data
+under their control, linked via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑥">Registry Set</a>.</p>
+   <p>Any requests for access to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥①">Social Agent</a> are processed by the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑤">Authorization Agent</a>.
+Similarly, any decisions by the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥②">Social Agent</a> to share data with another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑦">Agent</a> are processed by the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑥">Authorization Agent</a>.</p>
+   <table align="left" class="classinfo data" id="classAuthorizationAgent">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAuthorizationRedirectEndpoint
+      <td>IRI
+      <td>URI used to redirect to the Authorization Agent
+      from an <a data-link-type="dfn" href="#application" id="ref-for-application③②">Application</a> for authorization
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑦">Authorization Agent</a> at https://auth.alice.example/ - <a href="snippets/alice.jarvis.example/alice.jarvis.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-jarvis</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AuthorizationAgent</c-> <c- p>;</c->
+  <c- c>######## Authorization Redirect Endpoint ########</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationRedirectEndpoint</c-> <c- nn>alice-jarvis</c-><c- p>:</c-><c- f>redirect</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="7.1.1" id="authorization-redirect-endpoint"><span class="secno">7.1.1. </span><span class="content">Authorization Redirect Endpoint</span><a class="self-link" href="#authorization-redirect-endpoint"></a></h4>
+   <p>An <a data-link-type="dfn" href="#application" id="ref-for-application③③">Application</a> capable of redirecting, should redirect the user to the
+Authorization Redirect Endpoint advertised by the user’s <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑧">Authorization Agent</a>.</p>
+   <p>The following query parameters are defined:</p>
+   <table align="left" class="classinfo data">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Parameter
+      <th>Required
+      <th>Description
+    <tbody>
+     <tr>
+      <td>client_id
+      <td>Yes
+      <td>URI used to identify the <a data-link-type="dfn" href="#application" id="ref-for-application③④">Application</a> requesting the authorization
+     <tr>
+      <td>resource
+      <td>No
+      <td>URI used to indicate the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑦">Data Instance</a>.
+      Used for <a href="#resource-indication">§ 7.1.2 Resource Indication</a>
+   </table>
+   <figure>
+    <figcaption>Example redirect</figcaption>
+<pre class="highlight"><c- nf>GET</c-> <c- nn>/redirect?client_id=https%3A%2F%2Fprojectron.example%2F%23id</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>alice.jarvis.example</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="7.1.2" id="resource-indication"><span class="secno">7.1.2. </span><span class="content">Resource Indication</span><a class="self-link" href="#resource-indication"></a></h4>
+   <p>When the <code>resource</code> query parameter is used, the Authorization Agent will use it
+as an indication that access to a specific data instance is intended to be shared.</p>
+   <h4 class="heading settled" data-level="7.1.3" id="authorization-agent-discovery"><span class="secno">7.1.3. </span><span class="content">Authorization Agent Discovery</span><a class="self-link" href="#authorization-agent-discovery"></a></h4>
+   <p>The <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑨">Authorization Agent</a> for a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥③">Social Agent</a> can be discovered
+by de-referencing the <a data-link-type="dfn" href="#identity" id="ref-for-identity③">identity</a> of that <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥④">Social Agent</a>, and extracting
+the object value of the <code>interop:hasAuthorizationAgent</code> statement from the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑤">Social Agent</a> graph in the returned <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑥">identity profile document</a>.</p>
+   <p>The extracted <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①⓪">Authorization Agent</a> IRI <em class="rfc2119">MUST</em> be
+unique to that <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑥">Social Agent</a>. In scenarios where the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①①">Authorization Agent</a> services multiple <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑦">Social Agents</a>, this may be facilitated through
+a unique sub-domain (see example below) or path.</p>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑧">Social Agent</a> at https://alice.example/#id - <a href="snippets/alice.example/alice.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- c>######## Registry Sets ########</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice</c-><c- p>:</c-><c- f>registries</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- c>######## Authorization Agent ########</c-></span><span class="line-no highlight-line" data-line="13"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- nn>alice-jarvis</c-><c- p>:</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①"><a class="self-link" href="#issue-d41d8cd9①"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/171" style="text-transform:none">solid/data-interoperability-panel/171</a><a href="https://github.com/solid/data-interoperability-panel/issues/171">Authorization Agent URI should be distinct for each user</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9②"><a class="self-link" href="#issue-d41d8cd9②"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/232" style="text-transform:none">solid/data-interoperability-panel/232</a><a href="https://github.com/solid/data-interoperability-panel/issues/232">Multiple authorisation apps per social agent</a></div>
+   <h4 class="heading settled" data-level="7.1.4" id="agent-registration-discovery"><span class="secno">7.1.4. </span><span class="content">Agent Registration Discovery</span><a class="self-link" href="#agent-registration-discovery"></a></h4>
+   <p>An <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑧">Agent</a> that needs to discover whether a target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑨">Social Agent</a> has
+a corresponding <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑤">Agent Registration</a> for them can query the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①②">Authorization Agent</a> for that target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⓪">Social Agent</a>.</p>
+   <p>To discover a corresponding <a data-link-type="dfn">Agent Regsitration</a> the requesting <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑨">Agent</a> may perform an HTTP <code>HEAD</code> or HTTP <code>GET</code> request on the IRI of the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①③">Authorization Agent</a> for the target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦①">Social Agent</a>.</p>
+   <p>The response will include an <code>HTTP Link</code> header relating the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑥">Agent Registration</a> to the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⓪">Agent</a> making the request via the <code>http://www.w3.org/ns/solid/interop#registeredAgent</code> link relation.</p>
+   <figure>
+    <figcaption>HEAD request to and response from Authorization Agent</figcaption>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>alice.jarvis.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://projectron.example/#app>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://alice.jarvis.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9③"><a class="self-link" href="#issue-d41d8cd9③"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/252" style="text-transform:none">solid/data-interoperability-panel/252</a><a href="https://github.com/solid/data-interoperability-panel/issues/252">Should we restrict Social Agent Reigstration discovery to AA of that social agent?</a></div>
+   <h2 class="heading settled" data-level="8" id="needs"><span class="secno">8. </span><span class="content">Access Needs</span><a class="self-link" href="#needs"></a></h2>
+   <p><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦②">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application③⑤">Applications</a> in the <a data-link-type="dfn" href="#ecosystem" id="ref-for-ecosystem①">ecosystem</a> often
+require access to data controlled by some other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦③">Social Agent</a>.
+Consequently, a common way to explain
+and communicate data needs between these parties is required.</p>
+   <p>A given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦④">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application③⑥">Application</a> expresses their access needs by
+providing one or more <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①③">Access Need Groups</a> to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑤">Social Agent</a> controlling the data they require access to. The channels through which
+these may be communicated are detailed in <a href="#authorization">§ 7 Authorization Flows</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①④">Access Need Group</a> is associated with one or more <a data-link-type="dfn" href="#access-need" id="ref-for-access-need④">Access Needs</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑤">Access Needs</a> represent a request to access a particular type of data
+identified by <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑨">shape tree</a> type, corresponding with <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⓪">Data Registrations</a> in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑥">Data Registry</a>, an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑦">Identity Profile Document</a>, or a <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑦">Registry Set</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑤">Access Need Groups</a> are essential to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑥">Social Agent’s</a> decision-making
+when determining whether to grant access.</p>
+   <h3 class="heading settled" data-level="8.1" id="access-need-group"><span class="secno">8.1. </span><span class="content">Access Need Group</span><a class="self-link" href="#access-need-group"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need-group①">Access Need Group</dfn> is a collection of <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑥">Access Needs</a> used to communicate an access request to <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑦">Social Agents</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑥">Access Need Groups</a> are immutable. If an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑦">Access Need Group</a> needs to change,
+it should be replaced.</p>
+   <p>If an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑧">Access Need Group</a> is replaced, history may be retained by linking
+to it from the replacement <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑨">Access Need Group</a> via <code>interop:replaces</code>.</p>
+   <p><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⓪">Access Need Groups</a> are described using language-specific <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①">Access Need Group Descriptions</a>.</p>
+   <p><a href="interop.ttl#AccessNeedGroup">Class Definition</a> - <a href="interop.shex#AccessNeedGroupShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeedGroup">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAccessDescriptionSet
+      <td><a href="#classAccessDescriptionSet">AccessDescriptionSet</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①">Access Description Set</a> containing <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①①">Access Need Group Descriptions</a> and <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①">Access Need Descriptions</a> in the preferred language of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑧">Social Agent</a>
+     <tr>
+      <td>accessNecessity
+      <td><code>interop:AccessRequired</code>, <code>interop:AccessOptional</code>
+      <td>Necessity of the access to the requesting party
+     <tr>
+      <td>accessScenario
+      <td><code>interop:PersonalAccess</code>, <code>interop:SharedAccess</code>
+      <td>Context in which the access group should be presented
+     <tr>
+      <td>authenticatesAs
+      <td><code>interop:SocialAgent</code> or <code>interop:Application</code>
+      <td>Access will be granted to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑨">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application③⑦">Application</a>
+     <tr>
+      <td>hasAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Link to an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑦">Access Need</a>
+     <tr>
+      <td>replaces
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>Previous <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①①">Access Need Group</a> replaced by current instance
+   </table>
+   <figure>
+    <figcaption>An example <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①②">Access Need Group</a> for Projectron - <a href="snippets/projectron.example/needs.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#need-group-pm></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedGroup</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessScenario</c-> <c- nn>interop</c-><c- p>:</c-><c- f>PersonalAccess</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>authenticatesAs</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SocialAgent</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessDescriptionSet</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-en</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-es</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-nl</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-fr</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-ru</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-ko</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- g>&lt;#need-project></c-> <c- p>.</c->
+
+<c- g>&lt;#need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>.</c->
+
+<c- g>&lt;#need-task></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromNeed</c-> <c- g>&lt;#need-project></c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="8.2" id="needs-access-need"><span class="secno">8.2. </span><span class="content">Access Need</span><a class="self-link" href="#needs-access-need"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need">Access Need</dfn> represents the requirement of one specific type
+of data represented by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⓪">shape tree</a>, as part of an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①③">Access Need Group</a>.</p>
+   <p>It is often the case that a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①①">shape tree</a> associated with an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑧">Access Need</a> references other <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①②">shape trees</a>, providing a
+path to request access to related types. Consequently, <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑨">Access Needs</a> can be specified that <em>inherit</em> from other <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⓪">Access Needs</a> through a shape tree reference.</p>
+   <p>Specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑧">Data Instances</a> may be requested by explicitly
+associating them with the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①①">Access Need</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need" id="ref-for-access-need①②">Access Needs</a> are immutable. If an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①③">Access Need</a> needs to change, it should be replaced.</p>
+   <p><a data-link-type="dfn" href="#access-need" id="ref-for-access-need①④">Access Needs</a> are described using language-specific <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①①">Access Need Descriptions</a>.</p>
+   <p><a href="interop.ttl#AccessNeed">Class Definition</a> - <a href="interop.shex#AccessNeedGroup">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeed">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredShapeTree
+      <td><code>st:ShapeTree</code>
+      <td>The <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①③">shape tree</a> requested by the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑤">Access Need</a>
+     <tr>
+      <td>accessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Requested modes of access for the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑥">Access Need</a>
+     <tr>
+      <td>creatorAccessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Requested mode of access for the creator of a Data Instance.
+        Adds to the set of modes linked via <code>interop:accessMode</code>. Only valid when <code>accessMode</code> includes <code>acl:Create</code>, <code>acl:Write</code>, or <code>acl:Append</code>
+     <tr>
+      <td>accessNecessity
+      <td><code>interop:AccessRequired</code>, <code>interop:AccessOptional</code>
+      <td>Necessity of the access to the requesting party
+     <tr>
+      <td>hasDataInstance
+      <td><a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑨">Data Instance</a>
+      <td>Request specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⓪">Data Instance</a> of the registered <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①④">shape tree</a>. Requires advance knowledge of the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①①">Data Instance</a>
+     <tr>
+      <td>inheritsFromNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Links to another <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑦">Access Need</a> whose registeredShapeTree
+      references the shape tree associated with the current <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑧">Access Need</a>.
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑨">Access Needs</a> for Projects and Tasks in an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①④">Access Need Group</a> for Projectron - <a href="snippets/projectron.example/needs.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>.</c->
+
+<c- g>&lt;#need-task></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromNeed</c-> <c- g>&lt;#need-project></c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9④"><a class="self-link" href="#issue-d41d8cd9④"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/243" style="text-transform:none">solid/data-interoperability-panel/243</a><a href="https://github.com/solid/data-interoperability-panel/issues/243">Access Needs for Public Resources</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9⑤"><a class="self-link" href="#issue-d41d8cd9⑤"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/237" style="text-transform:none">solid/data-interoperability-panel/237</a><a href="https://github.com/solid/data-interoperability-panel/issues/237">Access needs for pod browser apps</a></div>
+   <h3 class="heading settled" data-level="8.3" id="access-descriptions"><span class="secno">8.3. </span><span class="content">Access Descriptions</span><a class="self-link" href="#access-descriptions"></a></h3>
+   <h4 class="heading settled" data-level="8.3.1" id="access-need-group-description"><span class="secno">8.3.1. </span><span class="content">Access Need Group Description</span><a class="self-link" href="#access-need-group-description"></a></h4>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need-group-description①">Access Need Group Description</dfn> provides a short label or
+title and a more in-depth description that explains why a given <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑤">Access Need Group</a> is being requested of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⓪">Social Agent</a>.</p>
+   <p><a href="interop.ttl#AccessNeedGroupDescription">Class Definition</a> - <a href="interop.shex#AccessNeedGroupDescriptionShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeedGroupDescription">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>inAccessDescriptionSet
+      <td><a href="#classAccessDescriptionSet">AccessDescriptionSet</a>
+      <td><a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①①">Access Description Set</a> the description is part of
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑥">Access Need Group</a> the description applies to
+     <tr>
+      <td>skos:preflabel
+      <td><code>xsd:string</code>
+      <td>Short label (title) for the <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑦">Access Need Group</a>
+     <tr>
+      <td>skos:definition
+      <td><code>xsd:string</code>
+      <td>Description of why the <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑧">Access Need Group</a> requires the
+      access it is requesting.
+   </table>
+   <figure>
+    <figcaption>English <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①②">Access Need Group Description</a> for Projectron - <a href="snippets/projectron.example/access-en.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#en-need-group-pm></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedGroupDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-group-pm</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Read and Contribute to Projects"</c-><c- o>@</c->en <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>definition</c-> <c- s>"Allow Projectron to read the Projects you select, and create new ones. Projectron won't modify existing data, but can add more."</c-><c- o>@</c->en <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="8.3.2" id="access-need-description"><span class="secno">8.3.2. </span><span class="content">Access Need Description</span><a class="self-link" href="#access-need-description"></a></h4>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need-description①">Access Need Description</dfn> provides a specific
+explanation of why that data type is being requested by
+a given <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②⓪">Access Need</a>.</p>
+   <p><a href="interop.ttl#AccessNeedDescription">Class Definition</a> - <a href="interop.shex#AccessNeedDescriptionShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeedDescription">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>inAccessDescriptionSet
+      <td><a href="#classAccessDescriptionSet">AccessDescriptionSet</a>
+      <td><a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①②">Access Description Set</a> the description is part of
+     <tr>
+      <td>hasAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td><a data-link-type="dfn" href="#access-need" id="ref-for-access-need②①">Access Need</a> the description applies to
+     <tr>
+      <td>skos:prefLabel
+      <td><code>xsd:string</code>
+      <td>Specific explanation of why that data type is being requested
+   </table>
+   <figure>
+    <figcaption>English <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①②">Access Need Description</a> for Projects - <a href="snippets/projectron.example/access-en.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#en-need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-project</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Access to Projects is essential for Projectron to perform its core function of Project Management"</c-><c- o>@</c->en <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="8.3.3" id="access-description-set"><span class="secno">8.3.3. </span><span class="content">Access Description Set</span><a class="self-link" href="#access-description-set"></a></h4>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-description-set①">Access Description Set</dfn> is a collection of <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①③">Access Need Group Descriptions</a> and <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①③">Access Need Descriptions</a>.</p>
+   <p><a href="interop.ttl#AccessDescriptionSet">Class Definition</a> - <a href="interop.shex#AccessDescriptionSetShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessDescriptionSet">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>usesLanguage
+      <td><code>xsd:language</code>
+      <td>Language that the <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①④">Access Need Group Descriptions</a> and <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②②">Access Needs</a> in the Set use
+   </table>
+   <figure>
+    <figcaption>English <a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①③">Access Description Set</a> for Projectron - <a href="snippets/projectron.example/access-en.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessDescriptionSet</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>usesLanguage</c-> <c- s>"en"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>language</c-> <c- p>.</c->
+
+<c- g>&lt;#en-need-group-pm></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedGroupDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-group-pm</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Read and Contribute to Projects"</c-><c- o>@</c->en <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>definition</c-> <c- s>"Allow Projectron to read the Projects you select, and create new ones. Projectron won't modify existing data, but can add more."</c-><c- o>@</c->en <c- p>.</c->
+
+<c- g>&lt;#en-need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-project</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Access to Projects is essential for Projectron to perform its core function of Project Management"</c-><c- o>@</c->en <c- p>.</c->
+
+<c- g>&lt;#en-need-task></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-task</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Access to Tasks allows Projectron to identify and manage the work to be done in a given Project."</c-><c- o>@</c->en <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="8.4" id="access-request"><span class="secno">8.4. </span><span class="content">Access Request</span><a class="self-link" href="#access-request"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-request①">Access Request</dfn> is used to send <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑨">Access Need Groups</a> from
+one <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②①">Agent</a> to another.</p>
+   <p><a href="interop.ttl#AccessRequest">Class Definition</a> - <a href="interop.shex#AccessRequestShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessRequest">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>fromSocialAgent
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧①">Social Agent</a> who sent the <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①①">Access Request</a>
+     <tr>
+      <td>toSocialAgent
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧②">Social Agent</a> the <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①②">Access Request</a> is meant for
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>One or more <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②⓪">Access Need Groups</a> detailing the access requested
+   </table>
+   <figure>
+    <figcaption>An <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①③">Access Request</a> sent from one agent to another</figcaption>
+<pre class="include-code highlight"><c- g>&lt;></c-> <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessRequest</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>fromSocialAgent</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>toSocialAgent</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-group-pm</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9⑥"><a class="self-link" href="#issue-d41d8cd9⑥"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/214" style="text-transform:none">solid/data-interoperability-panel/214</a><a href="https://github.com/solid/data-interoperability-panel/issues/214">Use invitation to validate the source of an incoming request</a></div>
+   <h2 class="heading settled" data-level="9" id="authorizations"><span class="secno">9. </span><span class="content">Access Authorizations</span><a class="self-link" href="#authorizations"></a></h2>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①">Access Authorizations</a> record a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧③">Social Agent’s</a> decision to grant access to
+some portion of the data in their control to another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧④">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application③⑧">Application</a>. <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②">Access Authorizations</a> are not shared with a grantee.</p>
+   <p><a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑤">Access Grants</a> are generated from <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①③">Access Authorizations</a>. They are shared
+with a given <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②②">Agent</a> to communicate the scope of access that has been
+granted to them.</p>
+   <h3 class="heading settled" data-level="9.1" id="access-authorization"><span class="secno">9.1. </span><span class="content">Access Authorization</span><a class="self-link" href="#access-authorization"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-authorization①">Access Authorization</dfn> records the decision of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑤">Social Agent</a> to grant access to some portion of data in their control to
+another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②③">Agent</a>.</p>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①④">Access Authorizations</a> should not be shared with the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②④">Agent</a> that
+has been granted access. <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑥">Access Grants</a> are generated from <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑤">Access Authorizations</a>, and are appropriate to share with the grantee.</p>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑥">Access Authorizations</a> are recorded in a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑥">Social Agent’s</a> <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry①">Authorization Registry</a>.</p>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑦">Access Authorizations</a> are immutable. If an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑧">Access Authorization</a> for an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑤">Agent</a> needs to change, it should be replaced.</p>
+   <p>If an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑨">Access Authorization</a> is replaced, history may be retained by unlinking the
+previous <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⓪">Access Authorization</a> from the <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry②">Authorization Registry</a>, and linking
+to it from the replacement <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①①">Access Authorization</a> via <code>interop:replaces</code>.</p>
+   <p><a href="interop.ttl#AccessAuthorization">Class Definition</a> - <a href="interop.shex#AccessAuthorizationShape">Shape Definition</a> - <a href="interop.tree#AccessAuthorizationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessAuthorization">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑦">Social Agent</a> that granted the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①②">Access Authorization</a>
+     <tr>
+      <td>grantedWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application③⑨">Application</a> used to grant the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①③">Access Authorization</a>
+     <tr>
+      <td>grantedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①④">Access Authorization</a> was granted
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑧">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④⓪">Application</a> that has received
+      authorization
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>An <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②①">Access Need Group</a> used to communicate the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②③">Access Needs</a> that the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑤">Access Authorization</a> is
+      satisfying
+     <tr>
+      <td>hasDataAuthorization
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td>Authorization for a specific type of data
+     <tr>
+      <td>replaces
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td>Previous <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑥">Access Authorization</a> replaced by current instance
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑦">Access Authorization</a> for Projectron at
+    https://alice.example/authorization/e2765d6c - <a href="snippets/alice.example/e2765d6c.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>e2765d6c</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#d8219b1f</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataAuthorization</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-> <c- p>,</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e4cb692</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑧">Access Authorization</a> for Bob at
+    https://alice.example/authorization/4460dce3 - <a href="snippets/alice.example/4460dce3.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>4460dce3</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#d8219b1f</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataAuthorization</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>f800b10c</c-> <c- p>,</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>ec6057d9</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9⑦"><a class="self-link" href="#issue-d41d8cd9⑦"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/177" style="text-transform:none">solid/data-interoperability-panel/177</a><a href="https://github.com/solid/data-interoperability-panel/issues/177">Should a copy of access needs be retained when consent is granted?</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9⑧"><a class="self-link" href="#issue-d41d8cd9⑧"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/221" style="text-transform:none">solid/data-interoperability-panel/221</a><a href="https://github.com/solid/data-interoperability-panel/issues/221">Document pattern of using local group as grantee of consent</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9⑨"><a class="self-link" href="#issue-d41d8cd9⑨"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/256" style="text-transform:none">solid/data-interoperability-panel/256</a><a href="https://github.com/solid/data-interoperability-panel/issues/256">Resource Owner restricting their own access</a></div>
+   <h3 class="heading settled" data-level="9.2" id="data-authorization"><span class="secno">9.2. </span><span class="content">Data Authorization</span><a class="self-link" href="#data-authorization"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-authorization①">Data Authorization</dfn> records the decision of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑨">Social Agent</a> to grant access to a specific type of data in their control, identified
+by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑤">Shape Tree</a>. They are always associated with a single <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑨">Access Authorization</a>.</p>
+   <p><a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①">Data Authorizations</a> should not be shared with the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑥">Agent</a> that has
+been granted access. <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①">Data Grants</a> are generated from <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①">Data Authorizations</a>,
+and are appropriate to share with the grantee.</p>
+   <p><a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②">Data Authorizations</a> are immutable. If a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①③">Data Authorization</a> needs to change, it should be replaced.</p>
+   <p><a href="interop.ttl#DataAuthorization">Class Definition</a> - <a href="interop.shex#DataAuthorizationShape">Shape Definition</a> - <a href="interop.tree#DataAuthorizationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataAuthorization">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⓪">Social Agent</a> that granted the <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①④">Data Authorization</a>
+     <tr>
+      <td>dataOwner
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨①">Social Agent</a> that owns the data being authorized
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨②">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④①">Application</a> that has received
+      authorization
+     <tr>
+      <td>registeredShapeTree
+      <td><a class="vocab" href="https://www.w3.org/ns/shapetrees#ShapeTree">st:ShapeTree</a>
+      <td><a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑥">Shape Tree</a> representing the type of data being authorized
+     <tr>
+      <td>accessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Modes of access granted to the authorized data
+     <tr>
+      <td>creatorAccessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Additional access mode assigned to the creator of a
+        data instance. Adds to the set of modes linked via <code>interop:accessMode</code>. Only valid when <code>accessMode</code> includes <code>acl:Create</code>, <code>acl:Write</code>, or <code>acl:Append</code>
+     <tr>
+      <td>scopeOfAuthorization
+      <td>interop:All, interop:AllFromAgent, interop:AllFromRegistry,
+      interop:SelectedFromRegistry, interop:Inherited
+      <td>Identifies the <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope">access scope</a> of the <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑤">Data Authorization</a>
+     <tr>
+      <td>hasDataRegistration
+      <td>A <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②①">Data Registration</a> for <code>registeredShapeTree</code>
+      <td>Links to a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②②">Data Registration</a> of registeredShapeTree in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑦">Data Registry</a> that is a subject of the current <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑥">Data Authorization</a>.
+     <tr>
+      <td>hasDataInstance
+      <td><a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①②">Data instance</a> of <code>registeredShapeTree</code>
+      <td>Links to a <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①③">Data Instance</a> of registeredShapeTree in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑧">Data Registry</a>.
+     <tr>
+      <td>satisfiesAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Links to the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②④">Access Need</a> satisfied by the <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑦">Data Authorization</a>
+     <tr>
+      <td>inheritsFromAuthorization
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td>Links to a parent <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑧">Data Authorization</a> whose registeredShapeTree
+      references the shape tree associated with the current <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑨">Data Authorization</a>.
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⓪">Data Authorization</a> for Projectron to access Projects
+    at https://alice.example/authorization/54a1b6a0 - <a href="snippets/alice.example/54a1b6a0.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>All</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①①">Data Authorization</a> for Projectron to access Tasks
+    at https://alice.example/authorization/0e4cb692 - <a href="snippets/alice.example/0e4cb692.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e4cb692</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromAuthorization</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="9.3" id="access-grant"><span class="secno">9.3. </span><span class="content">Access Grant</span><a class="self-link" href="#access-grant"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-grant①">Access Grant</dfn> provides an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑦">Agent</a> with a detailed
+description of access that has been granted to them. <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑦">Access Grants</a> are generated from <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②⓪">Access Authorizations</a>, and are stored in the <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑨">Agent Registry</a> of the <a data-link-type="dfn">Data Owner</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑧">Access Grant</a> has one or more <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①">Data Grants</a>, each of which
+represents access granted to a specific type of data.</p>
+   <p><a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑨">Access Grants</a> are immutable. If an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①⓪">Access Grant</a> needs to change, it must be replaced.</p>
+   <p><a href="interop.ttl#AccessGrant">Class Definition</a> - <a href="interop.shex#AccessGrantShape">Shape Definition</a> - <a href="interop.tree#AccessGrantTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessGrant">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨③">Social Agent</a> that granted the <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①①">Access Grant</a>
+     <tr>
+      <td>grantedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①②">Access Grant</a> was granted
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>Links to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨④">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④②">Application</a> that was granted access.
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②②">Access Need Group</a> associated with the Access Grant.
+     <tr>
+      <td>hasDataGrant
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td>Links to a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②">Data Grant</a> associated with the Access Grant.
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①③">Access Grant</a> to Projectron, stored in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑦">Agent Registration</a> for Projectron in her <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①⓪">Agent Registry</a> at
+  https://alice.pod.example/agents/2f2f3628/27eae14b - <a href="snippets/alice.example/27eae14b.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>27eae14b</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#d8219b1f</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataGrant</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-> <c- p>,</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>0945218b</c-> <c- p>,</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c-> <c- p>,</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>017d6a07</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="9.4" id="data-grant"><span class="secno">9.4. </span><span class="content">Data Grant</span><a class="self-link" href="#data-grant"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-grant①">Data Grant</dfn> provides an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑧">Agent</a> with a detailed description
+of access that has been granted to them for a specific type of data,
+identified by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑦">Shape Tree</a>. Each <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③">Data Grant</a> is associated with
+a single <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①④">Access Grant</a>.</p>
+   <p>A <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①④">Data Grant</a> may inherit from another <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑤">Data Grant</a>, when the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑧">shape tree</a> associated with the "parent" <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑥">Data Grant</a> has one or
+more <a data-link-type="dfn" href="#shape-tree-reference" id="ref-for-shape-tree-reference">Shape Tree References</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑦">Data Grant</a> has an assigned scope (<code>interop:scopeOfGrant</code>), which
+determines how permissions are assigned.</p>
+   <p>When creating a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑧">Data Grant</a>, there should be an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②⑤">Access Need</a> linked
+via <code>interop:satisfiesAccessNeed</code> with the same <code>interop:registeredShapeTree</code>.</p>
+   <p>When a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑤">Social Agent</a> grants another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑨">Agent</a> access to data that was shared
+with them, a <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①">Delegated Data Grant</a> is used instead.</p>
+   <p><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑨">Data Grants</a> are immutable. If a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⓪">Data Grant</a> needs to change, it should be replaced.</p>
+   <p><a href="interop.ttl#DataGrant">Class Definition</a> - <a href="interop.shex#DataGrantShape">Shape Definition</a> - <a href="interop.tree#DataGrantTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataGrant">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>dataOwner
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑥">Social Agent</a> that owns the data being granted
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑦">Social Agent</a> that granted the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①①">Data Grant</a>
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑧">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④③">Application</a> that was granted access.
+     <tr>
+      <td>registeredShapeTree
+      <td>st:ShapeTree
+      <td><a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②③">Data Registration</a> for the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑨">shape tree</a> that access
+      will be granted to
+     <tr>
+      <td>hasDataRegistration
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td><a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②④">Data Registration</a> for <code>registeredShapeTree</code> that the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①②">Data Grant</a> applies to
+     <tr>
+      <td>accessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Modes of access granted to the target data at hasDataRegistration
+     <tr>
+      <td>creatorAccessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Additional access mode assigned to the creator of a
+        data instance. Adds to the set of modes linked via <code>interop:accessMode</code>. Only valid when <code>accessMode</code> includes <code>acl:Create</code>, <code>acl:Write</code>, or <code>acl:Append</code>
+     <tr>
+      <td>scopeOfGrant
+      <td>interop:All, interop:AllFromAgent, interop:AllFromRegistry,
+      interop:SelectedFromRegistry, interop:Inherited
+      <td>Identifies the <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope①">access scope</a> of the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①③">Data Grant</a>
+     <tr>
+      <td>satisfiesAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Links to the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②⑥">Access Need</a> satisfied by the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①④">Data Grant</a>
+     <tr>
+      <td>hasDataInstance
+      <td>Instance of registeredShapeTree
+      <td>Links to a <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①④">Data Instance</a> of registeredShapeTree.
+     <tr>
+      <td>inheritsFromGrant
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td>Links to another <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑤">Data Grant</a> whose registeredShapeTree
+      references the shape tree associated with the current <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑥">Data Grant</a>.
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑦">Data Grant</a> for Projectron to access Projects at
+  https://alice.example/agents/2f2f3628/40d038ea - <a href="snippets/alice.example/40d038ea.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑧">Data Grant</a> for Projectron to access Tasks at
+  https://alice.example/agents/2f2f3628/0945218b - <a href="snippets/alice.example/0945218b.ttl">View</a> </figcaption>
+<pre class="include-code highlight">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>df4ab227\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①⓪"><a class="self-link" href="#issue-d41d8cd9①⓪"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/223" style="text-transform:none">solid/data-interoperability-panel/223</a><a href="https://github.com/solid/data-interoperability-panel/issues/223">Address Issuer restrection in data grants, plus RO Client constraints</a></div>
+   <h3 class="heading settled" data-level="9.5" id="delegated-data-grant"><span class="secno">9.5. </span><span class="content">Delegated Data Grant</span><a class="self-link" href="#delegated-data-grant"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="delegated-data-grant①">Delegated Data Grant</dfn> is a sub-class of <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑨">Data Grant</a> used when a grantee re-shares or "delegates" access they’ve
+received to another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⓪">Agent</a>. The most common use case
+is when Alice shares access with Bob, and Bob delegates
+that access to his project management application.</p>
+   <p><a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①①">Delegated Data Grants</a> are immutable. If a <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①②">Delegated Data Grant</a> needs to change, it should be replaced.</p>
+   <p><a href="interop.ttl#DelegatedDataGrant">Class Definition</a> - <a href="interop.shex#DelegatedDataGrantShape">Shape Definition</a> - <a href="interop.tree#DelegatedDataGrantTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDelegatedDataGrant">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>delegationOfGrant
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⓪">Data Grant</a> that is being delegated
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①③">Delegated Data Grant</a> for Projectron to access Projects
+  that Bob shared with her at https://alice.example/agents/2f2f3628/fe818190 - <a href="snippets/alice.example/fe818190.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c->
+    <c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①④">Delegated Data Grant</a> for Projectron to access Tasks
+  that Bob shared with her at https://alice.example/agents/2f2f3628/017d6a07 - <a href="snippets/alice.example/017d6a07.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>017d6a07</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>45e092cf\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c-> <c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c->
+    <c- nn>bob-alice</c-><c- p>:</c-><c- f>d5b5760c</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①①"><a class="self-link" href="#issue-d41d8cd9①①"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a></div>
+   <h3 class="heading settled" data-level="9.6" id="access-scopes"><span class="secno">9.6. </span><span class="content">Data Access Scopes</span><a class="self-link" href="#access-scopes"></a></h3>
+   <p>Each <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①②">Data Authorization</a> applies to a specific type of data,
+identified by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②⓪">shape tree</a>. The amount of access authorized for data
+of that type is specified by the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-scope">Access Scope</dfn>, via <code>interop:scopeOfAuthorization</code>.</p>
+   <p><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②①">Data Grants</a> are generated from a given <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①③">Data Authorization</a> based on <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope②">access scope</a> and other supporting criteria detailed below.</p>
+   <p>Each <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②②">Data Grant</a> corresponds to a specific <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑤">Data Registration</a> in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑨">Data Registry</a>, and has an associated <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope③">access scope</a> and <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode">access modes</a>.</p>
+   <p class="issue" id="issue-a2fe1e29"><a class="self-link" href="#issue-a2fe1e29"></a> This specification uses some access modes in the <code>acl:</code> namespace that
+have not been adopted to demonstrate the most secure and accurate
+expression of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑨">Social Agent’s</a> authorization. <a href="https://github.com/solid/authorization-panel/issues/253">Discussions are underway</a> to add these modes.</p>
+   <p class="issue" id="issue-5157d1cb"><a class="self-link" href="#issue-5157d1cb"></a> <a data-link-type="biblio" href="#biblio-wac" title="Web Access Control">[WAC]</a> does not have any mechanism to extend or modify
+inherited permissions.</p>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Scope
+      <th>Authorization
+      <th>Grant
+      <th>Description
+    <tbody>
+     <tr>
+      <td><a href="#scope-all"><b><code>All</code></b></a>
+      <td>Yes
+      <td><b>No</b>
+      <td>All of the owner’s data of a specified type, and all data shared with the owner of that type, across the owner’s registries
+     <tr>
+      <td><a href="#scope-fromagent"><b><code>AllFromAgent</code></b></a>
+      <td>Yes
+      <td><b>No</b>
+      <td>All data of a given type shared by a specified <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⓪">Social Agent</a> with the owner, across that <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪①">Social Agent’s</a> registries
+     <tr>
+      <td><a href="#scope-fromregistry"><b><code>AllFromRegistry</code></b></a>
+      <td>Yes
+      <td>Yes
+      <td>All of the data owner’s data of a specified type in a specified <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⓪">Data Registry</a>
+     <tr>
+      <td><a href="#scope-selected"><b><code>SelectedFromRegistry</code></b></a>
+      <td>Yes
+      <td>Yes
+      <td>Only specified <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑤">Data Instances</a> of the data owner’s of a given type in a specified <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①①">Data Registry</a>
+     <tr>
+      <td><a href="#scope-inherited"><b><code>Inherited</code></b></a>
+      <td>Yes
+      <td>Yes
+      <td>Only <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑥">Data Instances</a> of the data owner’s that are associated with <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑦">Data Instances</a> allowed by another authorization or grant
+   </table>
+   <h4 class="heading settled" data-level="9.6.1" id="scope-all"><span class="secno">9.6.1. </span><span class="content"><code>All</code></span><a class="self-link" href="#scope-all"></a></h4>
+   <p>The <code>interop:All</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope④">access scope</a> includes all data of a specified type
+belonging to a given data owner, and all data of that same type shared with the data
+owner, across all of the data owner’s registries.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationAllShape">DataAuthorizationAllShape</a></p>
+   <p>The follow example illustrates <em>Alice’s</em> authorization to give <em>Projectron</em> access to
+data of type <code>pm-shapetrees:ProjectTree</code> with a scope of <code>interop:All</code>. Since
+Alice has two <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①②">Data Registries</a> and Bob has shared projects with her, several <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②③">Data Grants</a> will be generated from this <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①④">Data Authorization</a> and shared
+with Projectron.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> <code>interop:All</code> is only valid for a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑤">Data Authorization</a>.
+Generated <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②④">Data Grants</a> use the more specific <code>interop:AllFromRegistry</code> for each unique <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①③">Data Registry</a>, including Bob’s.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑥">Data Authorization</a> for Projectron to access Projects
+    at https://alice.example/authorization/54a1b6a0 - <a href="snippets/alice.example/54a1b6a0.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>All</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑤">Data Grant</a> for Projectron to access Projects in her
+  Work <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①④">Data Registry</a> at
+  https://alice.example/agents/2f2f3628/40d038ea - <a href="snippets/alice.example/40d038ea.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑥">Data Grant</a> for Projectron to access her Projects in
+  her Personal <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑤">Data Registry</a> at
+  https://alice.example/agents/2f2f3628/a0623c8f - <a href="snippets/alice.example/a0623c8f.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>a0623c8f</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-personal-data</c-><c- p>:</c-><c- f>fe7a8e7b\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①⑤">Delegated Data Grant</a> for Projectron to access Projects
+  that Bob shared with her at https://alice.example/agents/2f2f3628/fe818190 - <a href="snippets/alice.example/fe818190.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c-></span><span class="line-no"></span><span class="line">    <c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <h4 class="heading settled" data-level="9.6.2" id="scope-fromagent"><span class="secno">9.6.2. </span><span class="content"><code>AllFromAgent</code></span><a class="self-link" href="#scope-fromagent"></a></h4>
+   <p>The <code>interop:AllFromAgent</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑤">access scope</a> includes all data of a given type
+owned and shared by a specified <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪②">Social Agent</a>, across all of their <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑥">Data Registries</a>. Essentially, Alice can use this scope to delegate
+any access that she has been given to another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪③">Social Agent’s</a> data (e.g. Bob), to another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③①">Agent</a> of her choosing.</p>
+   <p>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪④">Social Agent</a> whose access is being shared is identified via <code>interop:dataOwner</code>.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationAllFromAgentShape">DataAuthorizationAllFromAgentShape</a></p>
+   <p>The following example illustrates <em>Alice’s</em> authorization to give Performchart access to
+data of type <code>pm-shapetrees:ProjectTree</code> with a scope of <code>interop:AllFromAgent</code> and an <code>interop:dataOwner</code> of <em>Bob</em>.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> While Bob has granted Alice the ability to manipulate his project data,
+Alice grants Performchart a narrower scope of read-only access.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑦">Data Authorization</a> for Performchart to access Projects
+    that Bob shared with her at https://alice.example/authorization/0e36ba8f - <a href="snippets/alice.example/0e36ba8f.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e36ba8f</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromAgent</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>Bob has shared data of this type with Alice from
+only one <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑦">Data Registry</a>, which he shared with her previously
+through her <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑧">Agent Registration</a> in his <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①①">Agent Registry</a>.</p>
+   <figure>
+    <figcaption>Bob’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑦">Data Grant</a> for Alice to access Projects
+  at https://bob.example/agents/255aa181/b2b6a645 - <a href="snippets/bob.example/b2b6a645.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>Alice generates one <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①⑥">Delegated Data Grant</a> for Performchart to access
+the Project data that Bob shared with her, which she stores in
+the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑨">Agent Registration</a> for Performchart in her <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①②">Agent Registry</a>.
+It is marked as a delegation of Bob’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑧">Data Grant</a> via <code>interop:delegationOfGrant</code>.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①⑦">Delegated Data Grant</a> for Performchart to access Projects
+  that Bob shared with her at https://alice.example/agents/c2328cdd/efc426c9 - <a href="snippets/alice.example/efc426c9.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice-performchart</c-><c- p>:</c-><c- f>efc426c9</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c-></span><span class="line-no"></span><span class="line">    <c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <h4 class="heading settled" data-level="9.6.3" id="scope-fromregistry"><span class="secno">9.6.3. </span><span class="content"><code>AllFromRegistry</code></span><a class="self-link" href="#scope-fromregistry"></a></h4>
+   <p>The <code>interop:AllFromRegistry</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑥">access scope</a> includes all
+data of a specified type in a specified <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑧">Data Registry</a> of a given data owner.
+Since a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑨">Data Registry</a> can only have one <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑥">Data Registration</a> per <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②①">shape tree</a>,
+this scope provide access to all <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑧">Data Instances</a> in the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑦">Data Registration</a> of the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②②">shape tree</a> specified via <code>interop:registeredShapeTree</code>.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationAllFromRegistryShape">DataAuthorizationAllFromRegistryShape</a> - <a href="interop.shex#DataGrantAllFromRegistryShape">DataGrantAllFromRegistryShape</a></p>
+   <p>The following example illustrates <em>Bob’s</em> authorization to give Alice access to
+all data of type <code>pm-shapetrees:ProjectTree</code> in the <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②⓪">Data Registry</a> he uses
+for his professional work.</p>
+   <figure>
+    <figcaption>Bob’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑧">Data Authorization</a> at https://bob.example/authorization/e4b1b154
+  for Alice to access his Project data - <a href="snippets/bob.example/e4b1b154.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>bob-authorization</c-><c- p>:</c-><c- f>e4b1b154</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"></span></pre>
+   </figure>
+   <p>The following <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑨">Data Grant</a> is generated for Alice based on the above <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑨">Data Authorization</a>, and stored in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations①⓪">Agent Registration</a> for Alice in
+Bob’s <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①③">Agent Registry</a>.</p>
+   <figure>
+    <figcaption>Bob’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⓪">Data Grant</a> at https://bob.example/agents/255aa181/b2b6a645
+  for Alice to access his work Project data - <a href="snippets/bob.example/b2b6a645.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>When a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③①">Data Grant</a> is assigned the <code>interop:AllFromRegistry</code> scope, the <code>interop:grantee</code> is authorized to access all <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑨">Data Instances</a> in the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑧">Data Registration</a> linked via <code>interop:hasDataRegistration</code>,
+limited by the <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode①">access modes</a> linked via <code>interop:accessMode</code>.</p>
+   <p>In the above example, Bob would be giving Alice the following access to <code>pm-shapetrees:ProjectTree</code> <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⓪">Data Instances</a> (Projects) in the <code>bob-work-data:08a99a10</code> <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑨">Data Registration</a>:</p>
+   <ul>
+    <li data-md>
+     <p>Read the Data Registration</p>
+    <li data-md>
+     <p>List all Projects</p>
+    <li data-md>
+     <p>Read all Projects</p>
+    <li data-md>
+     <p>Create a new Project</p>
+    <li data-md>
+     <p>Read a Project she creates</p>
+    <li data-md>
+     <p>Delete a Project she creates</p>
+    <li data-md>
+     <p>Create resources in a Project she creates</p>
+    <li data-md>
+     <p>Modify existing resources in a Project she creates</p>
+   </ul>
+   <figure>
+    <figcaption>Interpreting <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode②">access modes</a> for a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⓪">Data Registration</a> with
+  AllFromRegistry scope</figcaption>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Mode
+       <th>Description
+     <tbody>
+      <tr>
+       <td><code>acl:Create</code>
+       <td>Create new <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②①">Data Instances</a>. <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode③">Access modes</a> assigned to
+        the creator on the created <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②②">Data Instance</a> should be a union of <code>interop:accessMode</code> and <code>interop:createAccessMode</code> modes. <b>acl:Create is not currently supported.
+        Substitute with acl:Write or acl:Append, but may exceed intended scope
+        of access.</b>
+      <tr>
+       <td><code>acl:Read</code>
+       <td>Read <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③①">Data Registration</a>. List and read all <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②③">Data Instances</a>
+      <tr>
+       <td><code>acl:Update</code>
+       <td>Modify <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②④">Data Instances</a>. Modification of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③②">Data Registration</a> graph
+        not permitted. <b><code>acl:Update</code> is not currently supported. Substitute with <code>acl:Write</code> or <code>acl:Append</code>, but may exceed intended scope of access.</b>
+      <tr>
+       <td><code>acl:Delete</code>
+       <td>Delete <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑤">Data Instances</a>. Deletion of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③③">Data Registration</a> not permitted. <b><code>acl:Delete</code> is not currently supported. Substitute with <code>acl:Write</code>, but
+        may exceed intended scope of access.</b>
+    </table>
+   </figure>
+   <h4 class="heading settled" data-level="9.6.4" id="scope-selected"><span class="secno">9.6.4. </span><span class="content"><code>SelectedFromRegistry</code></span><a class="self-link" href="#scope-selected"></a></h4>
+   <p>The <code>interop:SelectedFromRegistry</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑦">access scope</a> includes only
+specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑥">Data Instances</a> of the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②③">shape tree</a> specified via <code>interop:registeredShapeTree</code> in the <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②①">Data Registry</a> of a given
+data owner.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationSelectedFromRegistryShape">DataAuthorizationSelectedFromRegistryShape</a> - <a href="interop.shex#DataGrantSelectedFromRegistryShape">DataGrantSelectedFromRegistryShape</a></p>
+   <p>The following example illustrates <em>Jose’s</em> authorization for Alice to access
+two specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑦">Data Instances</a> of <code>pm-shapetrees:ProjectTree</code> in the <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②②">Data Registry</a> he uses for his professional work.</p>
+   <figure>
+    <figcaption>Jose’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⓪">Data Authorization</a> at https://jose.example/authorization/69095550
+  for Alice to access his Project data - <a href="snippets/jose.example/69095550.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>jose-authorization</c-><c- p>:</c-><c- f>69095550</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/9355352a</c-> <c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/3d3dc323</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>The following <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③②">Data Grant</a> is generated for Alice based on the above <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②①">Data Authorization</a>, and stored in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations①①">Agent Registration</a> for Alice in
+Jose’s <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①④">Agent Registry</a>.</p>
+   <figure>
+    <figcaption>Jose’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③③">Data Grant</a> at https://jose.example/agents/efba320e/2aa21a8c
+  to share specific work projects with Alice - <a href="snippets/jose.example/2aa21a8c.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/9355352a</c-> <c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/3d3dc323</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>When a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③④">Data Grant</a> is assigned the <code>interop:SelectedFromRegistry</code> scope, the <code>interop:grantee</code> is authorized to access only the specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑧">Data Instances</a> linked via <code>interop:hasDataInstance</code> in the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③④">Data Registration</a> linked via <code>interop:hasDataRegistration</code>,
+limited by the <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode④">access modes</a> linked via <code>interop:accessMode</code>.</p>
+   <figure>
+    <figcaption>Valid <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑤">access modes</a> for a <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑨">Data Instance</a></figcaption>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Mode
+       <th>Description
+     <tbody>
+      <tr>
+       <td><code>acl:Create</code>
+       <td>Create new resources within the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⓪">Data Instances</a> where applicable. <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑥">Access modes</a> assigned to
+        the creator on a created resource should be a union of <code>interop:accessMode</code> and <code>interop:createAccessMode</code> modes. <b>acl:Create is not currently supported.
+        Substitute with acl:Write or acl:Append, but may exceed intended scope
+        of access.</b>
+      <tr>
+       <td><code>acl:Read</code>
+       <td>Read <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③①">Data Instance</a> and any contained resources where applicable.
+      <tr>
+       <td><code>acl:Update</code>
+       <td>Modify <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③②">Data Instance</a> and any contained resources where applicable. <b><code>acl:Update</code> is not currently supported. Substitute with <code>acl:Write</code> or <code>acl:Append</code>, but may exceed intended scope of access.</b>
+      <tr>
+       <td><code>acl:Append</code>
+       <td>Add new data to resources in the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③③">Data Instance</a>, without changing any
+        existing data.
+      <tr>
+       <td><code>acl:Delete</code>
+       <td>Delete <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③④">Data Instance</a> or any contained resources where applicable. <b><code>acl:Delete</code> is not currently supported. Substitute with <code>acl:Write</code>, but
+        may exceed intended scope of access.</b>
+    </table>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①②"><a class="self-link" href="#issue-d41d8cd9①②"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/186" style="text-transform:none">solid/data-interoperability-panel/186</a><a href="https://github.com/solid/data-interoperability-panel/issues/186">Human readable labels for Data Instances, needed when selecting instances on consent screen. </a></div>
+   <h4 class="heading settled" data-level="9.6.5" id="scope-inherited"><span class="secno">9.6.5. </span><span class="content"><code>Inherited</code></span><a class="self-link" href="#scope-inherited"></a></h4>
+   <p>The <code>interop:Inherited</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑧">access scope</a> is unique in that it depends
+on the existence of another <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②②">Data Authorization</a> with a scope of <code>interop:All</code>, <code>interop:AllFromAgent</code>, <code>interop:AllFromRegistry</code>, or <code>interop:SelectedFromRegistry</code>.</p>
+   <p>When a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②③">Data Authorization</a> exists with
+one of those scopes, and its <code>interop:registeredShapeTree</code> specifies
+one or more virtual hierarchies via <code>st:references</code>, a corresponding <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②④">Data Authorization</a> with a scope of <code>interop:Inherited</code> can be created
+for each distinct reference.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationInheritedShape">DataAuthorizationInheritedShape</a> - <a href="interop.shex#DataGrantInheritedShape">DataGrantInheritedShape</a></p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑤">Data Authorization</a> for Projectron to access Projects
+    at https://alice.example/authorization/54a1b6a0 - <a href="snippets/alice.example/54a1b6a0.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>All</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>The <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②④">shape tree</a> <code>pm-shapetrees:ProjectTree</code> specifies one virtual hierarchy
+via <code>st:references</code>, indicating that a Project <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑤">Data Instance</a> virtually
+includes Task instances of <code>pm-shapetrees:TaskTree</code> through the
+predicate <code>pm:hasTask</code>.</p>
+   <figure>
+    <figcaption> ProjectTree definition at https://data.example/shapetrees/pm-shapetrees.tree - <a href="snippets/data.example/pm-shapetrees.tree">View Definition</a> </figcaption>
+<pre class="include-code highlight"><c- g>&lt;#ProjectTree></c->
+  <c- b>a</c-> <c- nn>st</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>st</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>shape</c-> <c- nn>pm-shex</c-><c- p>:</c-><c- f>ProjectShape</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>references</c-> <c- p>[</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- g>&lt;#TaskTree></c-> <c- p>;</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>viaPredicate</c-> <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+  <c- p>]</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <p>Consequently, a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑥">Data Authorization</a> with <code>interop:Inherited</code> scope can be created
+for <code>pm-shapetrees:TaskTree</code>.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑦">Data Authorization</a> for Projectron to access Tasks
+    at https://alice.example/authorization/0e4cb692 - <a href="snippets/alice.example/0e4cb692.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e4cb692</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromAuthorization</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑤">Data Grants</a> for Projects and their associated Tasks can then be generated
+for Projectron based on the above <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑧">Data Authorizations</a>.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑥">Data Grant</a> for Projectron to access Projects in her
+  Work <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②③">Data Registry</a> at
+  https://alice.example/agents/2f2f3628/40d038ea - <a href="snippets/alice.example/40d038ea.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑦">Data Grant</a> for Projectron to access Tasks associated
+  with authorized Work Projects at
+  https://alice.example/agents/2f2f3628/0945218b - <a href="snippets/alice.example/0945218b.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>0945218b</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>df4ab227\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>When a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑧">Data Grant</a> is assigned the <code>interop:Inherited</code> scope, the <code>interop:grantee</code> is authorized to access only the specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑥">Data Instances</a> linked via <code>st:references</code> in the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②⑤">shape tree</a> of the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑨">Data Grant</a> linked via <code>interop:inheritsFromGrant</code></p>
+   <p>In the example above, Alice grants Projectron the following access to <b>only the</b> <code>pm-shapetrees:TaskTree</code> <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑦">Data Instances</a> (Tasks) in the <code>alice-work-data:df4ab227</code> <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑤">Data Registration</a> that are linked
+to <code>pm-shapetrees:ProjectTree</code> <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑧">Data Instances</a> (Projects) in the <code>alice-work-data:8501f084</code> <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑥">Data Registration</a>.</p>
+   <p>For example, the three Tasks linked from the Project <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑨">Data Instance</a> below via <code>pm:hasTask</code> would be included in the <code>interop:Inherited</code> scope.</p>
+   <figure>
+    <figcaption>A Project <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④⓪">Data Instance</a> in <code>alice-work-data:8501f084</code> - <a href="snippets/work.alice.example/16e1eae9.ttl">View</a> </figcaption>
+<pre class="include-code highlight">
+<c- nn>alice-work-projects</c-><c- p>:</c-><c- f>16e1eae9</c->
+  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>id</c-> <c- mi>6</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>name</c-> <c- s>"Solid Project"</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>created_at</c-> <c- s>"2021-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>9b60a354</c-> <c- p>,</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>6e545b74</c-> <c- p>,</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>d33e01c8</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Valid <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑦">access modes</a> on <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑦">Data Registration</a> with Inherited scope</figcaption>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Mode
+       <th>Description
+     <tbody>
+      <tr>
+       <td><code>acl:Create</code>
+       <td>Create new <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④①">Data Instances</a> linked by shape tree reference. <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑧">Access modes</a> assigned to
+        the creator on the created <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④②">Data Instance</a> should be a union of <code>interop:accessMode</code> and <code>interop:createAccessMode</code> modes. <b>acl:Create is not currently supported.
+        Substitute with acl:Write or acl:Append, but may exceed intended scope
+        of access.</b>
+      <tr>
+       <td><code>acl:Read</code>
+       <td>Read <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④③">Data Instances</a> linked by shape tree reference
+      <tr>
+       <td><code>acl:Update</code>
+       <td>Modify <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④④">Data Instances</a> linked by shape tree reference. <b><code>acl:Update</code> is not currently supported. Substitute with <code>acl:Write</code> or <code>acl:Append</code>, but may exceed intended scope of access.</b>
+      <tr>
+       <td><code>acl:Append</code>
+       <td>Add new data to <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④⑤">Data Instances</a> linked by shape tree reference,
+        without changing any existing data.
+      <tr>
+       <td><code>acl:Delete</code>
+       <td>Delete <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④⑥">Data Instances</a> linked by shape tree reference. Deletion of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑧">Data Registration</a> not permitted. <b><code>acl:Delete</code> is not currently supported. Substitute with <code>acl:Write</code>, but
+        may exceed intended scope of access.</b>
+    </table>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①③"><a class="self-link" href="#issue-d41d8cd9①③"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/174" style="text-transform:none">solid/data-interoperability-panel/174</a><a href="https://github.com/solid/data-interoperability-panel/issues/174">Determine how to dynamically authorize access to reference lists on inherited instances</a></div>
+   <h3 class="heading settled" data-level="9.7" id="access-receipt"><span class="secno">9.7. </span><span class="content">Access Receipt</span><a class="self-link" href="#access-receipt"></a></h3>
+   <p>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑤">Social Agent</a> provides an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-receipt①">Access Receipt</dfn> to another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③②">Agent</a> after granting them access to some scope of data
+in an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②①">Access Authorization</a>.</p>
+   <p><a href="interop.ttl#AccessReceipt">Class Definition</a> - <a href="interop.shex#AccessReceiptShape">Shape Definition</a> - <a href="interop.tree#AccessReceiptTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessReceipt">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>providedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①②">Access Receipt</a> was provided
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑥">Social Agent</a> who granted access and delivered the <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①③">Access Receipt</a>.
+   </table>
+   <figure>
+    <figcaption>An example <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①④">Access Receipt</a> from Alice to Bob</figcaption>
+<pre class="include-code highlight"><c- g>&lt;></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessReceipt</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>providedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <p>The <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①④">Authorization Agent</a> of the recipient can use <a href="#agent-registration-discovery">§ 7.1.4 Agent Registration Discovery</a> to discover the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①④">Social Agent Registration</a> created for them. It should use the value of <code>grantedBy</code> as the target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑦">Social Agent</a>.</p>
+   <h3 class="heading settled" data-level="9.8" id="access-registry"><span class="secno">9.8. </span><span class="content">Authorization Registry</span><a class="self-link" href="#access-registry"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-registry">Authorization Registry</dfn> is a collection of <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②②">Access Authorizations</a>.</p>
+   <p>The <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry③">Authorization Registry</a> is linked to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑧">Social Agent</a> via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑧">Registry Set</a>.</p>
+   <p>An <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry④">Authorization Registry</a> links to any number of registered <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②③">Access Authorizations</a>.</p>
+   <p><a href="interop.ttl#AuthorizationRegistry">Class Definition</a> - <a href="interop.shex#AuthorizationRegistryShape">Shape Definition</a> - <a href="interop.tree#AuthorizationRegistryTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAuthorizationRegistry">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAccessAuthorization
+      <td><a href="interop.ttl#AccessAuthorization">AccessAuthorization</a>
+      <td>Link to associated <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②④">Access Authorizations</a>
+   </table>
+   <figure>
+    <figcaption>An <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry⑤">Authorization Registry</a> at
+  https://alice.example/authorization/ - <a href="snippets/alice.example/authorization.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AuthorizationRegistry</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessAuthorization</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>e2765d6c</c-> <c- p>,</c->   <c- c># projectron</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>47e07897</c-> <c- p>,</c->   <c- c># jarvis</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>d577d117</c-> <c- p>,</c->   <c- c># sarah</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>4460dce3</c-> <c- p>,</c->   <c- c># bob</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>cce01253</c-> <c- p>.</c->   <c- c># performchart</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="9.8.1" id="access-hierarchy"><span class="secno">9.8.1. </span><span class="content">Resource Hierarchy</span><a class="self-link" href="#access-hierarchy"></a></h4>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Resource
+      <th>Class
+      <th>Shape
+      <th>Shape Tree
+    <tbody>
+     <tr>
+      <td><code><a href="snippets/alice.example/authorization.ttl">authorizations/</a></code>
+      <td><a href="#classAuthorizationRegistry">AuthorizationRegistry</a>
+      <td><a href="interop.shex#AuthorizationRegistryShape">AuthorizationRegistryShape</a>
+      <td><a href="interop.tree#AuthorizationRegistryTree">AuthorizationRegistryTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/e2765d6c.ttl">e2765d6c/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/54a1b6a0.ttl">54a1b6a0/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/0e4cb692.ttl">0e4cb692/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/47e07897.ttl">47e07897/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/55363f56.ttl">55363f56/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/935458cf.ttl">935458cf/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/d577d117.ttl">d577d117/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/2d1568fb.ttl">2d1568fb/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/5ca4692b.ttl">5ca4692b/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/4460dce3.ttl">4460dce3/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/f800b10c.ttl">f800b10c/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/ec6057d9.ttl">ec6057d9/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/cce01253.ttl">cce01253/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/8f178288.ttl">8f178288/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/6531c8e2.ttl">6531c8e2/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/0e36ba8f.ttl">0e36ba8f/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/ca14a518.ttl">ca14a518/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/3e94161f.ttl">3e94161f/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/60e37fe3.ttl">60e37fe3/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+   </table>
+   <p>The <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry⑥">Authorization Registry</a> resources MAY use any resource or subject name.</p>
+   <p>The resource names for <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①⑤">Access Grants</a> <em class="rfc2119">SHOULD</em> be unpredictable.</p>
+   <h2 class="heading settled" data-level="10" id="security"><span class="secno">10. </span><span class="content">Security</span><a class="self-link" href="#security"></a></h2>
+   <h3 class="heading settled" data-level="10.1" id="security-appauthz"><span class="secno">10.1. </span><span class="content">Application Authorization</span><a class="self-link" href="#security-appauthz"></a></h3>
+   <p>For authorization purposes, client <a data-link-type="dfn" href="#application" id="ref-for-application④④">Applications</a> in use today fall into
+two buckets:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="strongly-identifiable-applications">Strongly identifiable applications</dfn> can be identified by
+third parties independently from the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑨">Social Agent</a> controlling them.
+Only <a data-link-type="dfn" href="#server-side-application" id="ref-for-server-side-application">server-side applications</a> are
+strongly identifiable. As confidential clients, they can keep secrets
+and can present attestations and third-party credentials
+via DNS / domain certificates.</p>
+   <p>In the case of a <a data-link-type="dfn" href="#strongly-identifiable-applications" id="ref-for-strongly-identifiable-applications">strongly identifiable application</a>, the <a data-link-type="dfn" href="#application" id="ref-for-application④⑤">Application</a> has its own <a data-link-type="dfn" href="#identity" id="ref-for-identity④">identity</a>. A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①⓪">Social Agent</a> can authorize a given <a data-link-type="dfn" href="#application" id="ref-for-application④⑥">Application</a> to access data based solely on the <a data-link-type="dfn" href="#identity" id="ref-for-identity⑤">identity</a> of that <a data-link-type="dfn" href="#application" id="ref-for-application④⑦">Application</a>.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="weakly-identifiable-applications">Weakly identifiable applications</dfn> include in-browser Javascript <a data-link-type="dfn" href="#application" id="ref-for-application④⑧">Applications</a> and native desktop or mobile <a data-link-type="dfn" href="#application" id="ref-for-application④⑨">Applications</a>. They are
+considered weakly identifiable because they
+are not able to keep secrets on an instance level. They are often referred to
+as public clients. Native apps should be strongly-identifiable in theory
+(since they are able to keep secrets on an instance level), but not in
+practice because the OS manufacturers do not make their trust
+infrastructure available. Weakly identifiable clients are only strongly
+identifiable to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①①">Social Agent</a> controlling them.</p>
+   <p>In the case of <a data-link-type="dfn" href="#weakly-identifiable-applications" id="ref-for-weakly-identifiable-applications">Weakly identifiable applications</a>, the ability for a Solid
+pod to limit access to data by the <a data-link-type="dfn" href="#application" id="ref-for-application⑤⓪">Application</a> in use is only as strong as
+the trustworthiness of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①②">Social Agent</a> piloting that <a data-link-type="dfn" href="#application" id="ref-for-application⑤①">Application</a>, along with
+their ability to avoid using malicious <a data-link-type="dfn" href="#application" id="ref-for-application⑤②">Applications</a>. The <a data-link-type="dfn" href="#identity" id="ref-for-identity⑥">identity</a> of the <a data-link-type="dfn" href="#application" id="ref-for-application⑤③">Application</a> can be manipulated
+by the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①③">Social Agent</a> in control. This means that Alice can strongly control
+the <a data-link-type="dfn" href="#application" id="ref-for-application⑤④">Applications</a> that she uses to access her own data, but has
+limited ability to control the <a data-link-type="dfn" href="#application" id="ref-for-application⑤⑤">Applications</a> that Bob uses to access the data
+she shares with him.</p>
+   <h2 class="heading settled" data-level="11" id="definitions"><span class="secno">11. </span><span class="content">Definitions</span><a class="self-link" href="#definitions"></a></h2>
+   <p><b>All definitions as stated below should be considered in the context of
+an interoperable <a data-link-type="dfn" href="#ecosystem" id="ref-for-ecosystem②">ecosystem</a> for <a data-link-type="dfn" href="#solid" id="ref-for-solid">Solid</a>, whether explicitly stated
+or not.</b></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="solid">Solid</dfn> is a protocol made up of a number of open web standards
+aimed at decentralizing data on the web.</p>
+   <p>A Solid <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="pod">pod</dfn> is a place for storing and accessing data via
+the <a data-link-type="dfn" href="#solid" id="ref-for-solid①">Solid</a> protocol, with mechanisms for controlling who or what can
+access that data.</p>
+   <p>An interoperable <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="ecosystem">ecosystem</dfn> is
+a collection of <a data-link-type="dfn" href="#solid" id="ref-for-solid②">Solid</a> compatible <a data-link-type="dfn" href="#application" id="ref-for-application⑤⑥">applications</a> developed by one or more
+entities, used by a community of users, that can safely access and manipulate
+the same kinds of data in <a data-link-type="dfn" href="#pod" id="ref-for-pod">pods</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="server-side-application">server-side application</dfn> runs on a dedicated server. They may
+also act as autonomous <a data-link-type="dfn" href="#authenticated-agent" id="ref-for-authenticated-agent">authenticated agents</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="user-piloted-application">user-piloted application</dfn> runs on a user’s device, with the user
+as the <a data-link-type="dfn" href="#authenticated-agent" id="ref-for-authenticated-agent①">authenticated agent</a>. They include in-browser javascript
+applications, native desktop applications, and mobile applications.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authenticated-agent">authenticated agent</dfn> is an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③③">agent</a> that has strongly
+authenticated their <a data-link-type="dfn" href="#identity" id="ref-for-identity⑦">identity</a> by proving control of the <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑧">identity profile document</a> via an authentication protocol such as <a data-link-type="biblio" href="#biblio-solid-oidc" title="Solid-OIDC Specification">[SOLID-OIDC]</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="identity">identity</dfn> is a unique URI that can be dereferenced
+to return an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑨">identity profile document</a>. Compatible
+identity systems include <a data-link-type="dfn" href="#webid" id="ref-for-webid">WebID</a> and <a data-link-type="dfn" href="#did" id="ref-for-did">DID</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="identity-profile-document">identity profile document</dfn> is a linked data document obtained by
+dereferencing the URI for a given <a data-link-type="dfn" href="#identity" id="ref-for-identity⑧">identity</a>. It provides information that
+can be used to prove that a given <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③④">Agent</a> controls the document.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="webid">WebID</dfn> is a web resource at an HTTP URI which refers to an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑤">agent</a>. An <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document①⓪">identity profile document</a> can be accessed by
+dereferencing the WebID. <a data-link-type="biblio" href="#biblio-webid" title="WebID 1.0">[WEBID]</a></p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="did">DID</dfn> is a URI that associates a DID subject (e.g. an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑥">agent</a>,
+thing, data model, abstract entity, etc.) with a DID document,
+equivalent to an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document①①">identity profile document</a>, to allow trustable
+interactions with that subject. <a data-link-type="biblio" href="#biblio-did" title="Decentralized Identifiers (DIDs) v1.0">[DID]</a></p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application-identity">application identity</dfn> is a web resource at an HTTP URI
+that uniquely identifies a given <a data-link-type="dfn" href="#application" id="ref-for-application⑤⑦">Application</a>, and dereferences to an <a data-link-type="dfn" href="#application-profile-document" id="ref-for-application-profile-document">application profile document</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application-profile-document">application profile document</dfn> is a linked data document
+obtained by dereferencing the URI for a given <a data-link-type="dfn" href="#application-identity" id="ref-for-application-identity">application identity</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="acl-resource">acl resource</dfn> as defined by <a data-link-type="biblio" href="#biblio-wac" title="Web Access Control">[WAC]</a> may be directly
+associated with a resource or indirectly associated with a resource
+through inheritance. It determines which <a data-link-type="dfn" href="#authorization-subject" id="ref-for-authorization-subject">authorization subjects</a> can
+access a resource, and the modes of access they have for it.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-mode">access mode</dfn> denotes operations (e.g. read, write)
+that a given <a data-link-type="dfn" href="#authorization-subject" id="ref-for-authorization-subject①">authorization subject</a> can perform on a resource.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-subject">authorization subject</dfn> is the target of a given authorization
+statement in an <a data-link-type="dfn" href="#acl-resource" id="ref-for-acl-resource">acl resource</a>. It is either an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑦">Agent</a> (individual,
+group, <a data-link-type="dfn" href="#server-side-application" id="ref-for-server-side-application①">server-side application</a>), a <a data-link-type="dfn" href="#user-piloted-application" id="ref-for-user-piloted-application">User-Piloted Application</a> in use by <em>any</em> <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑧">Agent</a>, or a combination of
+a specific <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑨">Agent</a> using a specific <a data-link-type="dfn" href="#user-piloted-application" id="ref-for-user-piloted-application①">User-Piloted Application</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-statement">authorization statement</dfn> is ...</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape">shape</dfn> provides a schema that RDF data graphs must meet in order
+to be considered conformant. A shape associated with a given resource in a <a data-link-type="dfn" href="#pod" id="ref-for-pod①">pod</a> ensures that any data stored in that resource must conform to the
+associated shape. Shape languages include <a data-link-type="biblio" href="#biblio-shex" title="Shape Expressions Language 2.1">[SHEX]</a> and <a data-link-type="biblio" href="#biblio-shacl" title="Shapes Constraint Language (SHACL)">[SHACL]</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape-tree">Shape Tree</dfn> defines a prospective tree of related resources
+which can be read and written by applications. The shape tree associates
+each of these resources with a shape. This allows one to treat a set of
+related resources as a single grouping, and apply that to a range of
+operations including access control, data organization, data validation,
+and data migration. <a data-link-type="biblio" href="#biblio-shapetrees" title="Shape Trees">[SHAPETREES]</a></p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape-tree-decorator">Shape Tree Decorator</dfn> provides additional human-readable
+description and context for a given <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②⑥">shape tree</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape-tree-reference">Shape Tree Reference</dfn> provides the necessary context to
+associate instances of related shape trees via a ShapePath</p>
+  </main>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#access-authorization①">Access Authorization</a><span>, in § 9.1</span>
+   <li><a href="#access-description-set①">Access Description Set</a><span>, in § 8.3.3</span>
+   <li><a href="#access-grant①">Access Grant</a><span>, in § 9.3</span>
+   <li><a href="#access-mode">access mode</a><span>, in § 11</span>
+   <li><a href="#access-need">Access Need</a><span>, in § 8.2</span>
+   <li><a href="#access-need-description①">Access Need Description</a><span>, in § 8.3.2</span>
+   <li><a href="#access-need-group①">Access Need Group</a><span>, in § 8.1</span>
+   <li><a href="#access-need-group-description①">Access Need Group Description</a><span>, in § 8.3.1</span>
+   <li><a href="#access-receipt①">Access Receipt</a><span>, in § 9.7</span>
+   <li><a href="#access-request①">Access Request</a><span>, in § 8.4</span>
+   <li><a href="#access-scope">Access Scope</a><span>, in § 9.6</span>
+   <li><a href="#acl-resource">acl resource</a><span>, in § 11</span>
+   <li><a href="#agent-registrations">Agent Registrations</a><span>, in § 5.4</span>
+   <li><a href="#agent-registry">Agent Registry</a><span>, in § 5.4</span>
+   <li><a href="#agents①">Agents</a><span>, in § 2</span>
+   <li><a href="#application">Application</a><span>, in § 4</span>
+   <li><a href="#application-identity">application identity</a><span>, in § 11</span>
+   <li><a href="#application-profile-document">application profile document</a><span>, in § 11</span>
+   <li><a href="#application-registration①">Application Registration</a><span>, in § 5.1</span>
+   <li><a href="#authenticated-agent">authenticated agent</a><span>, in § 11</span>
+   <li><a href="#authorization-agent①">Authorization Agent</a><span>, in § 7.1</span>
+   <li><a href="#authorization-registry">Authorization Registry</a><span>, in § 9.8</span>
+   <li><a href="#authorization-statement">authorization statement</a><span>, in § 11</span>
+   <li><a href="#authorization-subject">authorization subject</a><span>, in § 11</span>
+   <li><a href="#data-authorization①">Data Authorization</a><span>, in § 9.2</span>
+   <li><a href="#data-grant①">Data Grant</a><span>, in § 9.4</span>
+   <li><a href="#data-instance">Data Instance</a><span>, in § 6.1</span>
+   <li><a href="#data-registration①">Data Registration</a><span>, in § 6.1</span>
+   <li><a href="#data-registry①">Data Registry</a><span>, in § 6.2</span>
+   <li><a href="#delegated-data-grant①">Delegated Data Grant</a><span>, in § 9.5</span>
+   <li><a href="#did">DID</a><span>, in § 11</span>
+   <li><a href="#ecosystem">ecosystem</a><span>, in § 11</span>
+   <li><a href="#identity">identity</a><span>, in § 11</span>
+   <li><a href="#identity-profile-document">identity profile document</a><span>, in § 11</span>
+   <li><a href="#pod">pod</a><span>, in § 11</span>
+   <li><a href="#registry">Registry</a><span>, in § 3</span>
+   <li><a href="#registry-set">Registry Set</a><span>, in § 3.1</span>
+   <li><a href="#server-side-application">server-side application</a><span>, in § 11</span>
+   <li><a href="#shape">shape</a><span>, in § 11</span>
+   <li><a href="#shape-tree">Shape Tree</a><span>, in § 11</span>
+   <li><a href="#shape-tree-decorator">Shape Tree Decorator</a><span>, in § 11</span>
+   <li><a href="#shape-tree-reference">Shape Tree Reference</a><span>, in § 11</span>
+   <li><a href="#social-agent">Social Agent</a><span>, in § 3</span>
+   <li><a href="#social-agent-invitation①">Social Agent Invitation</a><span>, in § 5.3</span>
+   <li><a href="#social-agent-registration①">Social Agent Registration</a><span>, in § 5.2</span>
+   <li><a href="#solid">Solid</a><span>, in § 11</span>
+   <li><a href="#strongly-identifiable-applications">Strongly identifiable applications</a><span>, in § 10.1</span>
+   <li><a href="#user-piloted-application">user-piloted application</a><span>, in § 11</span>
+   <li><a href="#weakly-identifiable-applications">Weakly identifiable applications</a><span>, in § 10.1</span>
+   <li><a href="#webid">WebID</a><span>, in § 11</span>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-capability-urls">[CAPABILITY-URLS]
+   <dd>Jeni Tennison. <a href="https://w3ctag.github.io/capability-urls/"><cite>Good Practices for Capability URLs</cite></a>. URL: <a href="https://w3ctag.github.io/capability-urls/">https://w3ctag.github.io/capability-urls/</a>
+   <dt id="biblio-wac">[WAC]
+   <dd><a href="https://solid.github.io/specification/wac/"><cite>Web Access Control</cite></a>. URL: <a href="https://solid.github.io/specification/wac/">https://solid.github.io/specification/wac/</a>
+   <dt id="biblio-webid">[WEBID]
+   <dd>Tim Berners-Lee; Henry Story; Andrei Sambra. <a href="https://www.w3.org/2005/Incubator/webid/spec/identity/"><cite>WebID 1.0</cite></a>. URL: <a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">https://www.w3.org/2005/Incubator/webid/spec/identity/</a>
+  </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-did">[DID]
+   <dd>Drummond Reed; et al. <a href="https://www.w3.org/TR/did-core/"><cite>Decentralized Identifiers (DIDs) v1.0</cite></a>. URL: <a href="https://www.w3.org/TR/did-core/">https://www.w3.org/TR/did-core/</a>
+   <dt id="biblio-problems-and-goals">[PROBLEMS-AND-GOALS]
+   <dd>Justin Bingham; et al. <a href="https://github.com/solid/data-interoperability-panel/blob/master/problems-and-goals.md"><cite>Problems and Goals for Interoperability, Collaboration, and Security in a Solid Pod</cite></a>. URL: <a href="https://github.com/solid/data-interoperability-panel/blob/master/problems-and-goals.md">https://github.com/solid/data-interoperability-panel/blob/master/problems-and-goals.md</a>
+   <dt id="biblio-shacl">[SHACL]
+   <dd>Holger Knublauch; Dimitris Kontokostas. <a href="https://www.w3.org/TR/shacl/"><cite>Shapes Constraint Language (SHACL)</cite></a>. URL: <a href="https://www.w3.org/TR/shacl/">https://www.w3.org/TR/shacl/</a>
+   <dt id="biblio-shapetrees">[SHAPETREES]
+   <dd>Justin Bingham; Eric Prud'hommeaux. <a href="https://shapetrees.org/TR/specification/"><cite>Shape Trees</cite></a>. URL: <a href="https://shapetrees.org/TR/specification/">https://shapetrees.org/TR/specification/</a>
+   <dt id="biblio-shex">[SHEX]
+   <dd>Eric Prud'hommeaux; et al. <a href="http://shex.io/shex-semantics/index.html"><cite>Shape Expressions Language 2.1</cite></a>. URL: <a href="http://shex.io/shex-semantics/index.html">http://shex.io/shex-semantics/index.html</a>
+   <dt id="biblio-solid-oidc">[SOLID-OIDC]
+   <dd>Dmitri Zagidulin; Aaron Coburn; elf Pavlik. <a href="https://solid.github.io/solid-oidc/"><cite>Solid-OIDC Specification</cite></a>. URL: <a href="https://solid.github.io/solid-oidc/">https://solid.github.io/solid-oidc/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/210" style="text-transform:none">solid/data-interoperability-panel/210</a><a href="https://github.com/solid/data-interoperability-panel/issues/210">Incorporate profile requirements from solid-oidc for Social Agents and Applications.</a> <a class="issue-return" href="#issue-d41d8cd9" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/171" style="text-transform:none">solid/data-interoperability-panel/171</a><a href="https://github.com/solid/data-interoperability-panel/issues/171">Authorization Agent URI should be distinct for each user</a> <a class="issue-return" href="#issue-d41d8cd9①" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/232" style="text-transform:none">solid/data-interoperability-panel/232</a><a href="https://github.com/solid/data-interoperability-panel/issues/232">Multiple authorisation apps per social agent</a> <a class="issue-return" href="#issue-d41d8cd9②" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/252" style="text-transform:none">solid/data-interoperability-panel/252</a><a href="https://github.com/solid/data-interoperability-panel/issues/252">Should we restrict Social Agent Reigstration discovery to AA of that social agent?</a> <a class="issue-return" href="#issue-d41d8cd9③" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/243" style="text-transform:none">solid/data-interoperability-panel/243</a><a href="https://github.com/solid/data-interoperability-panel/issues/243">Access Needs for Public Resources</a> <a class="issue-return" href="#issue-d41d8cd9④" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/237" style="text-transform:none">solid/data-interoperability-panel/237</a><a href="https://github.com/solid/data-interoperability-panel/issues/237">Access needs for pod browser apps</a> <a class="issue-return" href="#issue-d41d8cd9⑤" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/214" style="text-transform:none">solid/data-interoperability-panel/214</a><a href="https://github.com/solid/data-interoperability-panel/issues/214">Use invitation to validate the source of an incoming request</a> <a class="issue-return" href="#issue-d41d8cd9⑥" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/177" style="text-transform:none">solid/data-interoperability-panel/177</a><a href="https://github.com/solid/data-interoperability-panel/issues/177">Should a copy of access needs be retained when consent is granted?</a> <a class="issue-return" href="#issue-d41d8cd9⑦" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/221" style="text-transform:none">solid/data-interoperability-panel/221</a><a href="https://github.com/solid/data-interoperability-panel/issues/221">Document pattern of using local group as grantee of consent</a> <a class="issue-return" href="#issue-d41d8cd9⑧" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/256" style="text-transform:none">solid/data-interoperability-panel/256</a><a href="https://github.com/solid/data-interoperability-panel/issues/256">Resource Owner restricting their own access</a> <a class="issue-return" href="#issue-d41d8cd9⑨" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/223" style="text-transform:none">solid/data-interoperability-panel/223</a><a href="https://github.com/solid/data-interoperability-panel/issues/223">Address Issuer restrection in data grants, plus RO Client constraints</a> <a class="issue-return" href="#issue-d41d8cd9①⓪" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a> <a class="issue-return" href="#issue-d41d8cd9①①" title="Jump to section">↵</a></div>
+   <div class="issue"> This specification uses some access modes in the <code>acl:</code> namespace that
+have not been adopted to demonstrate the most secure and accurate
+expression of a <a data-link-type="dfn" href="#social-agent">Social Agent’s</a> authorization. <a href="https://github.com/solid/authorization-panel/issues/253">Discussions are underway</a> to add these modes. <a class="issue-return" href="#issue-a2fe1e29" title="Jump to section">↵</a></div>
+   <div class="issue"> <a data-link-type="biblio" href="#biblio-wac" title="Web Access Control">[WAC]</a> does not have any mechanism to extend or modify
+inherited permissions. <a class="issue-return" href="#issue-5157d1cb" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/186" style="text-transform:none">solid/data-interoperability-panel/186</a><a href="https://github.com/solid/data-interoperability-panel/issues/186">Human readable labels for Data Instances, needed when selecting instances on consent screen. </a> <a class="issue-return" href="#issue-d41d8cd9①②" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/174" style="text-transform:none">solid/data-interoperability-panel/174</a><a href="https://github.com/solid/data-interoperability-panel/issues/174">Determine how to dynamically authorize access to reference lists on inherited instances</a> <a class="issue-return" href="#issue-d41d8cd9①③" title="Jump to section">↵</a></div>
+  </div>
+<script>/* Boilerplate: script-dom-helper */
+"use strict";
+function query(sel) { return document.querySelector(sel); }
+
+function queryAll(sel) { return [...document.querySelectorAll(sel)]; }
+
+function iter(obj) {
+	if(!obj) return [];
+	var it = obj[Symbol.iterator];
+	if(it) return it;
+	return Object.entries(obj);
+}
+
+function mk(tagname, attrs, ...children) {
+	const el = document.createElement(tagname);
+	for(const [k,v] of iter(attrs)) {
+		if(k.slice(0,3) == "_on") {
+			const eventName = k.slice(3);
+			el.addEventListener(eventName, v);
+		} else if(k[0] == "_") {
+			// property, not attribute
+			el[k.slice(1)] = v;
+		} else {
+			if(v === false || v == null) {
+        continue;
+      } else if(v === true) {
+        el.setAttribute(k, "");
+        continue;
+      } else {
+  			el.setAttribute(k, v);
+      }
+		}
+	}
+	append(el, children);
+	return el;
+}
+
+/* Create shortcuts for every known HTML element */
+[
+  "a",
+  "abbr",
+  "acronym",
+  "address",
+  "applet",
+  "area",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "base",
+  "basefont",
+  "bdo",
+  "big",
+  "blockquote",
+  "body",
+  "br",
+  "button",
+  "canvas",
+  "caption",
+  "center",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "font",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "head",
+  "header",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "html",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "map",
+  "mark",
+  "meta",
+  "meter",
+  "nav",
+  "nobr",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "param",
+  "pre",
+  "progress",
+  "q",
+  "s",
+  "samp",
+  "script",
+  "section",
+  "select",
+  "small",
+  "source",
+  "span",
+  "strike",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+  "xmp",
+].forEach(tagname=>{
+	mk[tagname] = (...args) => mk(tagname, ...args);
+});
+
+function* nodesFromChildList(children) {
+	for(const child of children.flat(Infinity)) {
+		if(child instanceof Node) {
+			yield child;
+		} else {
+			yield new Text(child);
+		}
+	}
+}
+function append(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		if(el instanceof Node) el.appendChild(child);
+		else el.push(child);
+	}
+	return el;
+}
+
+function insertAfter(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		el.parentNode.insertBefore(child, el.nextSibling);
+	}
+	return el;
+}
+
+function clearContents(el) {
+	el.innerHTML = "";
+	return el;
+}
+
+function parseHTML(markup) {
+	if(markup.toLowerCase().trim().indexOf('<!doctype') === 0) {
+		const doc = document.implementation.createHTMLDocument("");
+		doc.documentElement.innerHTML = markup;
+		return doc;
+	} else {
+		const el = mk.template({});
+		el.innerHTML = markup;
+		return el.content;
+	}
+}</script>
+<script>/* Boilerplate: script-dfn-panel */
+"use strict";
+{
+let dfnPanelData = {
+"access-authorization①": {"dfnID":"access-authorization\u2460","dfnText":"Access Authorization","external":false,"refSections":[{"refs":[{"id":"ref-for-access-authorization\u2460"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2460"},{"id":"ref-for-access-authorization\u2460\u2461"},{"id":"ref-for-access-authorization\u2460\u2462"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2463"},{"id":"ref-for-access-authorization\u2460\u2464"},{"id":"ref-for-access-authorization\u2460\u2465"},{"id":"ref-for-access-authorization\u2460\u2466"},{"id":"ref-for-access-authorization\u2460\u2467"},{"id":"ref-for-access-authorization\u2460\u2468"},{"id":"ref-for-access-authorization\u2460\u2460\u24ea"},{"id":"ref-for-access-authorization\u2460\u2460\u2460"},{"id":"ref-for-access-authorization\u2460\u2460\u2461"},{"id":"ref-for-access-authorization\u2460\u2460\u2462"},{"id":"ref-for-access-authorization\u2460\u2460\u2463"},{"id":"ref-for-access-authorization\u2460\u2460\u2464"},{"id":"ref-for-access-authorization\u2460\u2460\u2465"},{"id":"ref-for-access-authorization\u2460\u2460\u2466"},{"id":"ref-for-access-authorization\u2460\u2460\u2467"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2460\u2468"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2461\u24ea"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2461\u2460"}],"title":"9.7. Access Receipt"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2461\u2461"},{"id":"ref-for-access-authorization\u2460\u2461\u2462"},{"id":"ref-for-access-authorization\u2460\u2461\u2463"}],"title":"9.8. Authorization Registry"}],"url":"#access-authorization\u2460"},
+"access-description-set①": {"dfnID":"access-description-set\u2460","dfnText":"Access Description Set","external":false,"refSections":[{"refs":[{"id":"ref-for-access-description-set\u2460"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-description-set\u2460\u2460"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-access-description-set\u2460\u2461"}],"title":"8.3.2. Access Need Description"},{"refs":[{"id":"ref-for-access-description-set\u2460\u2462"}],"title":"8.3.3. Access Description Set"}],"url":"#access-description-set\u2460"},
+"access-grant①": {"dfnID":"access-grant\u2460","dfnText":"Access Grant","external":false,"refSections":[{"refs":[{"id":"ref-for-access-grant\u2460"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-access-grant\u2460\u2460"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-access-grant\u2460\u2461"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-access-grant\u2460\u2462"},{"id":"ref-for-access-grant\u2460\u2463"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-grant\u2460\u2464"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-access-grant\u2460\u2465"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-grant\u2460\u2466"},{"id":"ref-for-access-grant\u2460\u2467"},{"id":"ref-for-access-grant\u2460\u2468"},{"id":"ref-for-access-grant\u2460\u2460\u24ea"},{"id":"ref-for-access-grant\u2460\u2460\u2460"},{"id":"ref-for-access-grant\u2460\u2460\u2461"},{"id":"ref-for-access-grant\u2460\u2460\u2462"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-access-grant\u2460\u2460\u2463"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-access-grant\u2460\u2460\u2464"}],"title":"9.8.1. Resource Hierarchy"}],"url":"#access-grant\u2460"},
+"access-mode": {"dfnID":"access-mode","dfnText":"access mode","external":false,"refSections":[{"refs":[{"id":"ref-for-access-mode"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-access-mode\u2460"},{"id":"ref-for-access-mode\u2461"},{"id":"ref-for-access-mode\u2462"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-access-mode\u2463"},{"id":"ref-for-access-mode\u2464"},{"id":"ref-for-access-mode\u2465"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-access-mode\u2466"},{"id":"ref-for-access-mode\u2467"}],"title":"9.6.5. Inherited"}],"url":"#access-mode"},
+"access-need": {"dfnID":"access-need","dfnText":"Access Need","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need"},{"id":"ref-for-access-need\u2460"},{"id":"ref-for-access-need\u2461"},{"id":"ref-for-access-need\u2462"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-need\u2463"},{"id":"ref-for-access-need\u2464"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-access-need\u2465"},{"id":"ref-for-access-need\u2466"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need\u2467"},{"id":"ref-for-access-need\u2468"},{"id":"ref-for-access-need\u2460\u24ea"},{"id":"ref-for-access-need\u2460\u2460"},{"id":"ref-for-access-need\u2460\u2461"},{"id":"ref-for-access-need\u2460\u2462"},{"id":"ref-for-access-need\u2460\u2463"},{"id":"ref-for-access-need\u2460\u2464"},{"id":"ref-for-access-need\u2460\u2465"},{"id":"ref-for-access-need\u2460\u2466"},{"id":"ref-for-access-need\u2460\u2467"},{"id":"ref-for-access-need\u2460\u2468"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-access-need\u2461\u24ea"},{"id":"ref-for-access-need\u2461\u2460"}],"title":"8.3.2. Access Need Description"},{"refs":[{"id":"ref-for-access-need\u2461\u2461"}],"title":"8.3.3. Access Description Set"},{"refs":[{"id":"ref-for-access-need\u2461\u2462"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-need\u2461\u2463"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-access-need\u2461\u2464"},{"id":"ref-for-access-need\u2461\u2465"}],"title":"9.4. Data Grant"}],"url":"#access-need"},
+"access-need-description①": {"dfnID":"access-need-description\u2460","dfnText":"Access Need Description","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need-description\u2460"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need-description\u2460\u2460"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-access-need-description\u2460\u2461"}],"title":"8.3.2. Access Need Description"},{"refs":[{"id":"ref-for-access-need-description\u2460\u2462"}],"title":"8.3.3. Access Description Set"}],"url":"#access-need-description\u2460"},
+"access-need-group-description①": {"dfnID":"access-need-group-description\u2460","dfnText":"Access Need Group Description","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need-group-description\u2460"},{"id":"ref-for-access-need-group-description\u2460\u2460"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need-group-description\u2460\u2461"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-access-need-group-description\u2460\u2462"},{"id":"ref-for-access-need-group-description\u2460\u2463"}],"title":"8.3.3. Access Description Set"}],"url":"#access-need-group-description\u2460"},
+"access-need-group①": {"dfnID":"access-need-group\u2460","dfnText":"Access Need Group","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need-group\u2460"},{"id":"ref-for-access-need-group\u2460\u2460"},{"id":"ref-for-access-need-group\u2460\u2461"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2462"},{"id":"ref-for-access-need-group\u2460\u2463"},{"id":"ref-for-access-need-group\u2460\u2464"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2465"},{"id":"ref-for-access-need-group\u2460\u2466"},{"id":"ref-for-access-need-group\u2460\u2467"},{"id":"ref-for-access-need-group\u2460\u2468"},{"id":"ref-for-access-need-group\u2460\u2460\u24ea"},{"id":"ref-for-access-need-group\u2460\u2460\u2460"},{"id":"ref-for-access-need-group\u2460\u2460\u2461"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2460\u2462"},{"id":"ref-for-access-need-group\u2460\u2460\u2463"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2460\u2464"},{"id":"ref-for-access-need-group\u2460\u2460\u2465"},{"id":"ref-for-access-need-group\u2460\u2460\u2466"},{"id":"ref-for-access-need-group\u2460\u2460\u2467"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2460\u2468"},{"id":"ref-for-access-need-group\u2460\u2461\u24ea"}],"title":"8.4. Access Request"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2461\u2460"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2461\u2461"}],"title":"9.3. Access Grant"}],"url":"#access-need-group\u2460"},
+"access-receipt①": {"dfnID":"access-receipt\u2460","dfnText":"Access Receipt","external":false,"refSections":[{"refs":[{"id":"ref-for-access-receipt\u2460"},{"id":"ref-for-access-receipt\u2460\u2460"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-receipt\u2460\u2461"},{"id":"ref-for-access-receipt\u2460\u2462"},{"id":"ref-for-access-receipt\u2460\u2463"}],"title":"9.7. Access Receipt"}],"url":"#access-receipt\u2460"},
+"access-request①": {"dfnID":"access-request\u2460","dfnText":"Access Request","external":false,"refSections":[{"refs":[{"id":"ref-for-access-request\u2460"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-request\u2460\u2460"},{"id":"ref-for-access-request\u2460\u2461"},{"id":"ref-for-access-request\u2460\u2462"}],"title":"8.4. Access Request"}],"url":"#access-request\u2460"},
+"access-scope": {"dfnID":"access-scope","dfnText":"Access Scope","external":false,"refSections":[{"refs":[{"id":"ref-for-access-scope"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-access-scope\u2460"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-access-scope\u2461"},{"id":"ref-for-access-scope\u2462"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-access-scope\u2463"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-access-scope\u2464"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-access-scope\u2465"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-access-scope\u2466"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-access-scope\u2467"}],"title":"9.6.5. Inherited"}],"url":"#access-scope"},
+"acl-resource": {"dfnID":"acl-resource","dfnText":"acl resource","external":false,"refSections":[{"refs":[{"id":"ref-for-acl-resource"}],"title":"11. Definitions"}],"url":"#acl-resource"},
+"agent-registrations": {"dfnID":"agent-registrations","dfnText":"Agent Registrations","external":false,"refSections":[{"refs":[{"id":"ref-for-agent-registrations"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-agent-registrations\u2460"},{"id":"ref-for-agent-registrations\u2461"},{"id":"ref-for-agent-registrations\u2462"}],"title":"5.4.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-agent-registrations\u2463"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-agent-registrations\u2464"},{"id":"ref-for-agent-registrations\u2465"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-agent-registrations\u2466"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-agent-registrations\u2467"},{"id":"ref-for-agent-registrations\u2468"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-agent-registrations\u2460\u24ea"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-agent-registrations\u2460\u2460"}],"title":"9.6.4. SelectedFromRegistry"}],"url":"#agent-registrations"},
+"agent-registry": {"dfnID":"agent-registry","dfnText":"Agent Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-agent-registry"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-agent-registry\u2460"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-agent-registry\u2461"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-agent-registry\u2462"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-agent-registry\u2463"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-agent-registry\u2464"},{"id":"ref-for-agent-registry\u2465"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-agent-registry\u2466"}],"title":"5.4.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-agent-registry\u2467"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-agent-registry\u2468"},{"id":"ref-for-agent-registry\u2460\u24ea"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-agent-registry\u2460\u2460"},{"id":"ref-for-agent-registry\u2460\u2461"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-agent-registry\u2460\u2462"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-agent-registry\u2460\u2463"}],"title":"9.6.4. SelectedFromRegistry"}],"url":"#agent-registry"},
+"agents①": {"dfnID":"agents\u2460","dfnText":"Agents","external":false,"refSections":[{"refs":[{"id":"ref-for-agents\u2460"},{"id":"ref-for-agents\u2460\u2460"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-agents\u2460\u2461"},{"id":"ref-for-agents\u2460\u2462"},{"id":"ref-for-agents\u2460\u2463"},{"id":"ref-for-agents\u2460\u2464"},{"id":"ref-for-agents\u2460\u2465"},{"id":"ref-for-agents\u2460\u2466"},{"id":"ref-for-agents\u2460\u2467"},{"id":"ref-for-agents\u2460\u2468"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u24ea"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2460"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2461"},{"id":"ref-for-agents\u2460\u2460\u2462"},{"id":"ref-for-agents\u2460\u2460\u2463"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2464"},{"id":"ref-for-agents\u2460\u2460\u2465"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2466"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2467"},{"id":"ref-for-agents\u2460\u2460\u2468"},{"id":"ref-for-agents\u2460\u2461\u24ea"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2460"}],"title":"8.4. Access Request"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2461"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2462"},{"id":"ref-for-agents\u2460\u2461\u2463"},{"id":"ref-for-agents\u2460\u2461\u2464"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2465"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2466"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2467"},{"id":"ref-for-agents\u2460\u2461\u2468"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u24ea"}],"title":"9.5. Delegated Data Grant"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u2460"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u2461"}],"title":"9.7. Access Receipt"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u2462"},{"id":"ref-for-agents\u2460\u2462\u2463"},{"id":"ref-for-agents\u2460\u2462\u2464"},{"id":"ref-for-agents\u2460\u2462\u2465"},{"id":"ref-for-agents\u2460\u2462\u2466"},{"id":"ref-for-agents\u2460\u2462\u2467"},{"id":"ref-for-agents\u2460\u2462\u2468"}],"title":"11. Definitions"}],"url":"#agents\u2460"},
+"application": {"dfnID":"application","dfnText":"Application","external":false,"refSections":[{"refs":[{"id":"ref-for-application"},{"id":"ref-for-application\u2460"},{"id":"ref-for-application\u2461"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-application\u2462"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-application\u2463"},{"id":"ref-for-application\u2464"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-application\u2465"},{"id":"ref-for-application\u2466"},{"id":"ref-for-application\u2467"},{"id":"ref-for-application\u2468"},{"id":"ref-for-application\u2460\u24ea"},{"id":"ref-for-application\u2460\u2460"},{"id":"ref-for-application\u2460\u2461"},{"id":"ref-for-application\u2460\u2462"},{"id":"ref-for-application\u2460\u2463"},{"id":"ref-for-application\u2460\u2464"},{"id":"ref-for-application\u2460\u2465"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-application\u2460\u2466"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-application\u2460\u2467"},{"id":"ref-for-application\u2460\u2468"},{"id":"ref-for-application\u2461\u24ea"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-application\u2461\u2460"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-application\u2461\u2461"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-application\u2461\u2462"},{"id":"ref-for-application\u2461\u2463"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-application\u2461\u2464"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-application\u2461\u2465"},{"id":"ref-for-application\u2461\u2466"},{"id":"ref-for-application\u2461\u2467"},{"id":"ref-for-application\u2461\u2468"},{"id":"ref-for-application\u2462\u24ea"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-application\u2462\u2460"},{"id":"ref-for-application\u2462\u2461"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-application\u2462\u2462"},{"id":"ref-for-application\u2462\u2463"}],"title":"7.1.1. Authorization Redirect Endpoint"},{"refs":[{"id":"ref-for-application\u2462\u2464"},{"id":"ref-for-application\u2462\u2465"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-application\u2462\u2466"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-application\u2462\u2467"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-application\u2462\u2468"},{"id":"ref-for-application\u2463\u24ea"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-application\u2463\u2460"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-application\u2463\u2461"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-application\u2463\u2462"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-application\u2463\u2463"},{"id":"ref-for-application\u2463\u2464"},{"id":"ref-for-application\u2463\u2465"},{"id":"ref-for-application\u2463\u2466"},{"id":"ref-for-application\u2463\u2467"},{"id":"ref-for-application\u2463\u2468"},{"id":"ref-for-application\u2464\u24ea"},{"id":"ref-for-application\u2464\u2460"},{"id":"ref-for-application\u2464\u2461"},{"id":"ref-for-application\u2464\u2462"},{"id":"ref-for-application\u2464\u2463"},{"id":"ref-for-application\u2464\u2464"}],"title":"10.1. Application Authorization"},{"refs":[{"id":"ref-for-application\u2464\u2465"},{"id":"ref-for-application\u2464\u2466"}],"title":"11. Definitions"}],"url":"#application"},
+"application-identity": {"dfnID":"application-identity","dfnText":"application identity","external":false,"refSections":[{"refs":[{"id":"ref-for-application-identity"}],"title":"11. Definitions"}],"url":"#application-identity"},
+"application-profile-document": {"dfnID":"application-profile-document","dfnText":"application profile document","external":false,"refSections":[{"refs":[{"id":"ref-for-application-profile-document"}],"title":"11. Definitions"}],"url":"#application-profile-document"},
+"application-registration①": {"dfnID":"application-registration\u2460","dfnText":"Application Registration","external":false,"refSections":[{"refs":[{"id":"ref-for-application-registration\u2460"},{"id":"ref-for-application-registration\u2460\u2460"},{"id":"ref-for-application-registration\u2460\u2461"},{"id":"ref-for-application-registration\u2460\u2462"},{"id":"ref-for-application-registration\u2460\u2463"},{"id":"ref-for-application-registration\u2460\u2464"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-application-registration\u2460\u2465"},{"id":"ref-for-application-registration\u2460\u2466"}],"title":"5.4. Agent Registry"}],"url":"#application-registration\u2460"},
+"authenticated-agent": {"dfnID":"authenticated-agent","dfnText":"authenticated agent","external":false,"refSections":[{"refs":[{"id":"ref-for-authenticated-agent"},{"id":"ref-for-authenticated-agent\u2460"}],"title":"11. Definitions"}],"url":"#authenticated-agent"},
+"authorization-agent①": {"dfnID":"authorization-agent\u2460","dfnText":"Authorization Agent","external":false,"refSections":[{"refs":[{"id":"ref-for-authorization-agent\u2460"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2460"},{"id":"ref-for-authorization-agent\u2460\u2461"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2462"},{"id":"ref-for-authorization-agent\u2460\u2463"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2464"},{"id":"ref-for-authorization-agent\u2460\u2465"},{"id":"ref-for-authorization-agent\u2460\u2466"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2467"}],"title":"7.1.1. Authorization Redirect Endpoint"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2468"},{"id":"ref-for-authorization-agent\u2460\u2460\u24ea"},{"id":"ref-for-authorization-agent\u2460\u2460\u2460"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2460\u2461"},{"id":"ref-for-authorization-agent\u2460\u2460\u2462"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2460\u2463"}],"title":"9.7. Access Receipt"}],"url":"#authorization-agent\u2460"},
+"authorization-registry": {"dfnID":"authorization-registry","dfnText":"Authorization Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-authorization-registry"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-authorization-registry\u2460"},{"id":"ref-for-authorization-registry\u2461"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-authorization-registry\u2462"},{"id":"ref-for-authorization-registry\u2463"},{"id":"ref-for-authorization-registry\u2464"}],"title":"9.8. Authorization Registry"},{"refs":[{"id":"ref-for-authorization-registry\u2465"}],"title":"9.8.1. Resource Hierarchy"}],"url":"#authorization-registry"},
+"authorization-statement": {"dfnID":"authorization-statement","dfnText":"authorization statement","external":false,"refSections":[],"url":"#authorization-statement"},
+"authorization-subject": {"dfnID":"authorization-subject","dfnText":"authorization subject","external":false,"refSections":[{"refs":[{"id":"ref-for-authorization-subject"},{"id":"ref-for-authorization-subject\u2460"}],"title":"11. Definitions"}],"url":"#authorization-subject"},
+"data-authorization①": {"dfnID":"data-authorization\u2460","dfnText":"Data Authorization","external":false,"refSections":[{"refs":[{"id":"ref-for-data-authorization\u2460"},{"id":"ref-for-data-authorization\u2460\u2460"},{"id":"ref-for-data-authorization\u2460\u2461"},{"id":"ref-for-data-authorization\u2460\u2462"},{"id":"ref-for-data-authorization\u2460\u2463"},{"id":"ref-for-data-authorization\u2460\u2464"},{"id":"ref-for-data-authorization\u2460\u2465"},{"id":"ref-for-data-authorization\u2460\u2466"},{"id":"ref-for-data-authorization\u2460\u2467"},{"id":"ref-for-data-authorization\u2460\u2468"},{"id":"ref-for-data-authorization\u2460\u2460\u24ea"},{"id":"ref-for-data-authorization\u2460\u2460\u2460"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2461"},{"id":"ref-for-data-authorization\u2460\u2460\u2462"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2463"},{"id":"ref-for-data-authorization\u2460\u2460\u2464"},{"id":"ref-for-data-authorization\u2460\u2460\u2465"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2466"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2467"},{"id":"ref-for-data-authorization\u2460\u2460\u2468"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2461\u24ea"},{"id":"ref-for-data-authorization\u2460\u2461\u2460"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2461\u2461"},{"id":"ref-for-data-authorization\u2460\u2461\u2462"},{"id":"ref-for-data-authorization\u2460\u2461\u2463"},{"id":"ref-for-data-authorization\u2460\u2461\u2464"},{"id":"ref-for-data-authorization\u2460\u2461\u2465"},{"id":"ref-for-data-authorization\u2460\u2461\u2466"},{"id":"ref-for-data-authorization\u2460\u2461\u2467"}],"title":"9.6.5. Inherited"}],"url":"#data-authorization\u2460"},
+"data-grant①": {"dfnID":"data-grant\u2460","dfnText":"Data Grant","external":false,"refSections":[{"refs":[{"id":"ref-for-data-grant\u2460"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-grant\u2460\u2460"},{"id":"ref-for-data-grant\u2460\u2461"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-data-grant\u2460\u2462"},{"id":"ref-for-data-grant\u2460\u2463"},{"id":"ref-for-data-grant\u2460\u2464"},{"id":"ref-for-data-grant\u2460\u2465"},{"id":"ref-for-data-grant\u2460\u2466"},{"id":"ref-for-data-grant\u2460\u2467"},{"id":"ref-for-data-grant\u2460\u2468"},{"id":"ref-for-data-grant\u2460\u2460\u24ea"},{"id":"ref-for-data-grant\u2460\u2460\u2460"},{"id":"ref-for-data-grant\u2460\u2460\u2461"},{"id":"ref-for-data-grant\u2460\u2460\u2462"},{"id":"ref-for-data-grant\u2460\u2460\u2463"},{"id":"ref-for-data-grant\u2460\u2460\u2464"},{"id":"ref-for-data-grant\u2460\u2460\u2465"},{"id":"ref-for-data-grant\u2460\u2460\u2466"},{"id":"ref-for-data-grant\u2460\u2460\u2467"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-data-grant\u2460\u2460\u2468"},{"id":"ref-for-data-grant\u2460\u2461\u24ea"}],"title":"9.5. Delegated Data Grant"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2460"},{"id":"ref-for-data-grant\u2460\u2461\u2461"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2462"},{"id":"ref-for-data-grant\u2460\u2461\u2463"},{"id":"ref-for-data-grant\u2460\u2461\u2464"},{"id":"ref-for-data-grant\u2460\u2461\u2465"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2466"},{"id":"ref-for-data-grant\u2460\u2461\u2467"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2468"},{"id":"ref-for-data-grant\u2460\u2462\u24ea"},{"id":"ref-for-data-grant\u2460\u2462\u2460"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-grant\u2460\u2462\u2461"},{"id":"ref-for-data-grant\u2460\u2462\u2462"},{"id":"ref-for-data-grant\u2460\u2462\u2463"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-grant\u2460\u2462\u2464"},{"id":"ref-for-data-grant\u2460\u2462\u2465"},{"id":"ref-for-data-grant\u2460\u2462\u2466"},{"id":"ref-for-data-grant\u2460\u2462\u2467"},{"id":"ref-for-data-grant\u2460\u2462\u2468"}],"title":"9.6.5. Inherited"}],"url":"#data-grant\u2460"},
+"data-instance": {"dfnID":"data-instance","dfnText":"Data Instance","external":false,"refSections":[{"refs":[{"id":"ref-for-data-instance"},{"id":"ref-for-data-instance\u2460"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-data-instance\u2461"},{"id":"ref-for-data-instance\u2462"},{"id":"ref-for-data-instance\u2463"},{"id":"ref-for-data-instance\u2464"},{"id":"ref-for-data-instance\u2465"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-data-instance\u2466"}],"title":"7.1.1. Authorization Redirect Endpoint"},{"refs":[{"id":"ref-for-data-instance\u2467"},{"id":"ref-for-data-instance\u2468"},{"id":"ref-for-data-instance\u2460\u24ea"},{"id":"ref-for-data-instance\u2460\u2460"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-data-instance\u2460\u2461"},{"id":"ref-for-data-instance\u2460\u2462"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-instance\u2460\u2463"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-data-instance\u2460\u2464"},{"id":"ref-for-data-instance\u2460\u2465"},{"id":"ref-for-data-instance\u2460\u2466"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-instance\u2460\u2467"},{"id":"ref-for-data-instance\u2460\u2468"},{"id":"ref-for-data-instance\u2461\u24ea"},{"id":"ref-for-data-instance\u2461\u2460"},{"id":"ref-for-data-instance\u2461\u2461"},{"id":"ref-for-data-instance\u2461\u2462"},{"id":"ref-for-data-instance\u2461\u2463"},{"id":"ref-for-data-instance\u2461\u2464"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-instance\u2461\u2465"},{"id":"ref-for-data-instance\u2461\u2466"},{"id":"ref-for-data-instance\u2461\u2467"},{"id":"ref-for-data-instance\u2461\u2468"},{"id":"ref-for-data-instance\u2462\u24ea"},{"id":"ref-for-data-instance\u2462\u2460"},{"id":"ref-for-data-instance\u2462\u2461"},{"id":"ref-for-data-instance\u2462\u2462"},{"id":"ref-for-data-instance\u2462\u2463"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-instance\u2462\u2464"},{"id":"ref-for-data-instance\u2462\u2465"},{"id":"ref-for-data-instance\u2462\u2466"},{"id":"ref-for-data-instance\u2462\u2467"},{"id":"ref-for-data-instance\u2462\u2468"},{"id":"ref-for-data-instance\u2463\u24ea"},{"id":"ref-for-data-instance\u2463\u2460"},{"id":"ref-for-data-instance\u2463\u2461"},{"id":"ref-for-data-instance\u2463\u2462"},{"id":"ref-for-data-instance\u2463\u2463"},{"id":"ref-for-data-instance\u2463\u2464"},{"id":"ref-for-data-instance\u2463\u2465"}],"title":"9.6.5. Inherited"}],"url":"#data-instance"},
+"data-registration①": {"dfnID":"data-registration\u2460","dfnText":"Data Registration","external":false,"refSections":[{"refs":[{"id":"ref-for-data-registration\u2460"},{"id":"ref-for-data-registration\u2460\u2460"},{"id":"ref-for-data-registration\u2460\u2461"},{"id":"ref-for-data-registration\u2460\u2462"},{"id":"ref-for-data-registration\u2460\u2463"},{"id":"ref-for-data-registration\u2460\u2464"},{"id":"ref-for-data-registration\u2460\u2465"},{"id":"ref-for-data-registration\u2460\u2466"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-data-registration\u2460\u2467"},{"id":"ref-for-data-registration\u2460\u2468"},{"id":"ref-for-data-registration\u2460\u2460\u24ea"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-data-registration\u2460\u2460\u2460"},{"id":"ref-for-data-registration\u2460\u2460\u2461"},{"id":"ref-for-data-registration\u2460\u2460\u2462"},{"id":"ref-for-data-registration\u2460\u2460\u2463"},{"id":"ref-for-data-registration\u2460\u2460\u2464"},{"id":"ref-for-data-registration\u2460\u2460\u2465"},{"id":"ref-for-data-registration\u2460\u2460\u2466"},{"id":"ref-for-data-registration\u2460\u2460\u2467"},{"id":"ref-for-data-registration\u2460\u2460\u2468"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u24ea"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2460"},{"id":"ref-for-data-registration\u2460\u2461\u2461"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2462"},{"id":"ref-for-data-registration\u2460\u2461\u2463"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2464"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2465"},{"id":"ref-for-data-registration\u2460\u2461\u2466"},{"id":"ref-for-data-registration\u2460\u2461\u2467"},{"id":"ref-for-data-registration\u2460\u2461\u2468"},{"id":"ref-for-data-registration\u2460\u2462\u24ea"},{"id":"ref-for-data-registration\u2460\u2462\u2460"},{"id":"ref-for-data-registration\u2460\u2462\u2461"},{"id":"ref-for-data-registration\u2460\u2462\u2462"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-registration\u2460\u2462\u2463"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-registration\u2460\u2462\u2464"},{"id":"ref-for-data-registration\u2460\u2462\u2465"},{"id":"ref-for-data-registration\u2460\u2462\u2466"},{"id":"ref-for-data-registration\u2460\u2462\u2467"}],"title":"9.6.5. Inherited"}],"url":"#data-registration\u2460"},
+"data-registry①": {"dfnID":"data-registry\u2460","dfnText":"Data Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-data-registry\u2460"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-data-registry\u2460\u2461"},{"id":"ref-for-data-registry\u2460\u2462"},{"id":"ref-for-data-registry\u2460\u2463"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-data-registry\u2460\u2464"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-data-registry\u2460\u2465"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-data-registry\u2460\u2466"},{"id":"ref-for-data-registry\u2460\u2467"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-registry\u2460\u2468"},{"id":"ref-for-data-registry\u2460\u2460\u24ea"},{"id":"ref-for-data-registry\u2460\u2460\u2460"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460\u2461"},{"id":"ref-for-data-registry\u2460\u2460\u2462"},{"id":"ref-for-data-registry\u2460\u2460\u2463"},{"id":"ref-for-data-registry\u2460\u2460\u2464"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460\u2465"},{"id":"ref-for-data-registry\u2460\u2460\u2466"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460\u2467"},{"id":"ref-for-data-registry\u2460\u2460\u2468"},{"id":"ref-for-data-registry\u2460\u2461\u24ea"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-registry\u2460\u2461\u2460"},{"id":"ref-for-data-registry\u2460\u2461\u2461"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-registry\u2460\u2461\u2462"}],"title":"9.6.5. Inherited"}],"url":"#data-registry\u2460"},
+"delegated-data-grant①": {"dfnID":"delegated-data-grant\u2460","dfnText":"Delegated Data Grant","external":false,"refSections":[{"refs":[{"id":"ref-for-delegated-data-grant\u2460"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-delegated-data-grant\u2460\u2460"},{"id":"ref-for-delegated-data-grant\u2460\u2461"},{"id":"ref-for-delegated-data-grant\u2460\u2462"},{"id":"ref-for-delegated-data-grant\u2460\u2463"}],"title":"9.5. Delegated Data Grant"},{"refs":[{"id":"ref-for-delegated-data-grant\u2460\u2464"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-delegated-data-grant\u2460\u2465"},{"id":"ref-for-delegated-data-grant\u2460\u2466"}],"title":"9.6.2. AllFromAgent"}],"url":"#delegated-data-grant\u2460"},
+"did": {"dfnID":"did","dfnText":"DID","external":false,"refSections":[{"refs":[{"id":"ref-for-did"}],"title":"11. Definitions"}],"url":"#did"},
+"ecosystem": {"dfnID":"ecosystem","dfnText":"ecosystem","external":false,"refSections":[{"refs":[{"id":"ref-for-ecosystem"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-ecosystem\u2460"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-ecosystem\u2461"}],"title":"11. Definitions"}],"url":"#ecosystem"},
+"identity": {"dfnID":"identity","dfnText":"identity","external":false,"refSections":[{"refs":[{"id":"ref-for-identity"},{"id":"ref-for-identity\u2460"},{"id":"ref-for-identity\u2461"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-identity\u2462"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-identity\u2463"},{"id":"ref-for-identity\u2464"},{"id":"ref-for-identity\u2465"}],"title":"10.1. Application Authorization"},{"refs":[{"id":"ref-for-identity\u2466"},{"id":"ref-for-identity\u2467"}],"title":"11. Definitions"}],"url":"#identity"},
+"identity-profile-document": {"dfnID":"identity-profile-document","dfnText":"identity profile document","external":false,"refSections":[{"refs":[{"id":"ref-for-identity-profile-document"},{"id":"ref-for-identity-profile-document\u2460"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-identity-profile-document\u2461"},{"id":"ref-for-identity-profile-document\u2462"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-identity-profile-document\u2463"},{"id":"ref-for-identity-profile-document\u2464"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-identity-profile-document\u2465"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-identity-profile-document\u2466"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-identity-profile-document\u2467"},{"id":"ref-for-identity-profile-document\u2468"},{"id":"ref-for-identity-profile-document\u2460\u24ea"},{"id":"ref-for-identity-profile-document\u2460\u2460"}],"title":"11. Definitions"}],"url":"#identity-profile-document"},
+"pod": {"dfnID":"pod","dfnText":"pod","external":false,"refSections":[{"refs":[{"id":"ref-for-pod"},{"id":"ref-for-pod\u2460"}],"title":"11. Definitions"}],"url":"#pod"},
+"registry": {"dfnID":"registry","dfnText":"Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-registry"},{"id":"ref-for-registry\u2460"},{"id":"ref-for-registry\u2461"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-registry\u2462"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-registry\u2463"}],"title":"5.2. Social Agent Registration"}],"url":"#registry"},
+"registry-set": {"dfnID":"registry-set","dfnText":"Registry Set","external":false,"refSections":[{"refs":[{"id":"ref-for-registry-set"},{"id":"ref-for-registry-set\u2460"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-registry-set\u2461"},{"id":"ref-for-registry-set\u2462"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-registry-set\u2463"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-registry-set\u2464"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-registry-set\u2465"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-registry-set\u2466"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-registry-set\u2467"}],"title":"9.8. Authorization Registry"}],"url":"#registry-set"},
+"server-side-application": {"dfnID":"server-side-application","dfnText":"server-side application","external":false,"refSections":[{"refs":[{"id":"ref-for-server-side-application"}],"title":"10.1. Application Authorization"},{"refs":[{"id":"ref-for-server-side-application\u2460"}],"title":"11. Definitions"}],"url":"#server-side-application"},
+"shape": {"dfnID":"shape","dfnText":"shape","external":false,"refSections":[{"refs":[{"id":"ref-for-shape"}],"title":"1. Introduction"}],"url":"#shape"},
+"shape-tree": {"dfnID":"shape-tree","dfnText":"Shape Tree","external":false,"refSections":[{"refs":[{"id":"ref-for-shape-tree"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-shape-tree\u2460"},{"id":"ref-for-shape-tree\u2461"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-shape-tree\u2462"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-shape-tree\u2463"},{"id":"ref-for-shape-tree\u2464"},{"id":"ref-for-shape-tree\u2465"},{"id":"ref-for-shape-tree\u2466"},{"id":"ref-for-shape-tree\u2467"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-shape-tree\u2468"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-shape-tree\u2460\u24ea"},{"id":"ref-for-shape-tree\u2460\u2460"},{"id":"ref-for-shape-tree\u2460\u2461"},{"id":"ref-for-shape-tree\u2460\u2462"},{"id":"ref-for-shape-tree\u2460\u2463"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-shape-tree\u2460\u2464"},{"id":"ref-for-shape-tree\u2460\u2465"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-shape-tree\u2460\u2466"},{"id":"ref-for-shape-tree\u2460\u2467"},{"id":"ref-for-shape-tree\u2460\u2468"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-shape-tree\u2461\u24ea"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2460"},{"id":"ref-for-shape-tree\u2461\u2461"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2462"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2463"},{"id":"ref-for-shape-tree\u2461\u2464"}],"title":"9.6.5. Inherited"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2465"}],"title":"11. Definitions"}],"url":"#shape-tree"},
+"shape-tree-decorator": {"dfnID":"shape-tree-decorator","dfnText":"Shape Tree Decorator","external":false,"refSections":[],"url":"#shape-tree-decorator"},
+"shape-tree-reference": {"dfnID":"shape-tree-reference","dfnText":"Shape Tree Reference","external":false,"refSections":[{"refs":[{"id":"ref-for-shape-tree-reference"}],"title":"9.4. Data Grant"}],"url":"#shape-tree-reference"},
+"social-agent": {"dfnID":"social-agent","dfnText":"Social Agent","external":false,"refSections":[{"refs":[{"id":"ref-for-social-agent"},{"id":"ref-for-social-agent\u2460"},{"id":"ref-for-social-agent\u2461"},{"id":"ref-for-social-agent\u2462"},{"id":"ref-for-social-agent\u2463"},{"id":"ref-for-social-agent\u2464"},{"id":"ref-for-social-agent\u2465"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-social-agent\u2466"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-social-agent\u2467"},{"id":"ref-for-social-agent\u2468"},{"id":"ref-for-social-agent\u2460\u24ea"},{"id":"ref-for-social-agent\u2460\u2460"},{"id":"ref-for-social-agent\u2460\u2461"},{"id":"ref-for-social-agent\u2460\u2462"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-social-agent\u2460\u2463"},{"id":"ref-for-social-agent\u2460\u2464"},{"id":"ref-for-social-agent\u2460\u2465"},{"id":"ref-for-social-agent\u2460\u2466"},{"id":"ref-for-social-agent\u2460\u2467"},{"id":"ref-for-social-agent\u2460\u2468"},{"id":"ref-for-social-agent\u2461\u24ea"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-social-agent\u2461\u2460"},{"id":"ref-for-social-agent\u2461\u2461"},{"id":"ref-for-social-agent\u2461\u2462"},{"id":"ref-for-social-agent\u2461\u2463"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-social-agent\u2461\u2464"},{"id":"ref-for-social-agent\u2461\u2465"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-social-agent\u2461\u2466"},{"id":"ref-for-social-agent\u2461\u2467"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-social-agent\u2461\u2468"},{"id":"ref-for-social-agent\u2462\u24ea"},{"id":"ref-for-social-agent\u2462\u2460"},{"id":"ref-for-social-agent\u2462\u2461"},{"id":"ref-for-social-agent\u2462\u2462"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-social-agent\u2462\u2463"},{"id":"ref-for-social-agent\u2462\u2464"},{"id":"ref-for-social-agent\u2462\u2465"},{"id":"ref-for-social-agent\u2462\u2466"},{"id":"ref-for-social-agent\u2462\u2467"},{"id":"ref-for-social-agent\u2462\u2468"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-social-agent\u2463\u24ea"},{"id":"ref-for-social-agent\u2463\u2460"},{"id":"ref-for-social-agent\u2463\u2461"},{"id":"ref-for-social-agent\u2463\u2462"},{"id":"ref-for-social-agent\u2463\u2463"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-social-agent\u2463\u2464"}],"title":"6. Data Registrations"},{"refs":[{"id":"ref-for-social-agent\u2463\u2465"},{"id":"ref-for-social-agent\u2463\u2466"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-social-agent\u2463\u2467"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-social-agent\u2463\u2468"},{"id":"ref-for-social-agent\u2464\u24ea"},{"id":"ref-for-social-agent\u2464\u2460"},{"id":"ref-for-social-agent\u2464\u2461"},{"id":"ref-for-social-agent\u2464\u2462"},{"id":"ref-for-social-agent\u2464\u2463"},{"id":"ref-for-social-agent\u2464\u2464"},{"id":"ref-for-social-agent\u2464\u2465"},{"id":"ref-for-social-agent\u2464\u2466"},{"id":"ref-for-social-agent\u2464\u2467"},{"id":"ref-for-social-agent\u2464\u2468"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-social-agent\u2465\u24ea"},{"id":"ref-for-social-agent\u2465\u2460"},{"id":"ref-for-social-agent\u2465\u2461"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-social-agent\u2465\u2462"},{"id":"ref-for-social-agent\u2465\u2463"},{"id":"ref-for-social-agent\u2465\u2464"},{"id":"ref-for-social-agent\u2465\u2465"},{"id":"ref-for-social-agent\u2465\u2466"},{"id":"ref-for-social-agent\u2465\u2467"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-social-agent\u2465\u2468"},{"id":"ref-for-social-agent\u2466\u24ea"},{"id":"ref-for-social-agent\u2466\u2460"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-social-agent\u2466\u2461"},{"id":"ref-for-social-agent\u2466\u2462"},{"id":"ref-for-social-agent\u2466\u2463"},{"id":"ref-for-social-agent\u2466\u2464"},{"id":"ref-for-social-agent\u2466\u2465"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-social-agent\u2466\u2466"},{"id":"ref-for-social-agent\u2466\u2467"},{"id":"ref-for-social-agent\u2466\u2468"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-social-agent\u2467\u24ea"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-social-agent\u2467\u2460"},{"id":"ref-for-social-agent\u2467\u2461"}],"title":"8.4. Access Request"},{"refs":[{"id":"ref-for-social-agent\u2467\u2462"},{"id":"ref-for-social-agent\u2467\u2463"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-social-agent\u2467\u2464"},{"id":"ref-for-social-agent\u2467\u2465"},{"id":"ref-for-social-agent\u2467\u2466"},{"id":"ref-for-social-agent\u2467\u2467"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-social-agent\u2467\u2468"},{"id":"ref-for-social-agent\u2468\u24ea"},{"id":"ref-for-social-agent\u2468\u2460"},{"id":"ref-for-social-agent\u2468\u2461"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-social-agent\u2468\u2462"},{"id":"ref-for-social-agent\u2468\u2463"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-social-agent\u2468\u2464"},{"id":"ref-for-social-agent\u2468\u2465"},{"id":"ref-for-social-agent\u2468\u2466"},{"id":"ref-for-social-agent\u2468\u2467"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-social-agent\u2468\u2468"},{"id":"ref-for-social-agent\u2460\u24ea\u24ea"},{"id":"ref-for-social-agent\u2460\u24ea\u2460"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2461"},{"id":"ref-for-social-agent\u2460\u24ea\u2462"},{"id":"ref-for-social-agent\u2460\u24ea\u2463"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2464"},{"id":"ref-for-social-agent\u2460\u24ea\u2465"},{"id":"ref-for-social-agent\u2460\u24ea\u2466"}],"title":"9.7. Access Receipt"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2467"}],"title":"9.8. Authorization Registry"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2468"},{"id":"ref-for-social-agent\u2460\u2460\u24ea"},{"id":"ref-for-social-agent\u2460\u2460\u2460"},{"id":"ref-for-social-agent\u2460\u2460\u2461"},{"id":"ref-for-social-agent\u2460\u2460\u2462"}],"title":"10.1. Application Authorization"}],"url":"#social-agent"},
+"social-agent-invitation①": {"dfnID":"social-agent-invitation\u2460","dfnText":"Social Agent Invitation","external":false,"refSections":[{"refs":[{"id":"ref-for-social-agent-invitation\u2460"},{"id":"ref-for-social-agent-invitation\u2460\u2460"},{"id":"ref-for-social-agent-invitation\u2460\u2461"},{"id":"ref-for-social-agent-invitation\u2460\u2462"},{"id":"ref-for-social-agent-invitation\u2460\u2463"},{"id":"ref-for-social-agent-invitation\u2460\u2464"},{"id":"ref-for-social-agent-invitation\u2460\u2465"},{"id":"ref-for-social-agent-invitation\u2460\u2466"},{"id":"ref-for-social-agent-invitation\u2460\u2467"},{"id":"ref-for-social-agent-invitation\u2460\u2468"}],"title":"5.3. Social Agent Invitation"}],"url":"#social-agent-invitation\u2460"},
+"social-agent-registration①": {"dfnID":"social-agent-registration\u2460","dfnText":"Social Agent Registration","external":false,"refSections":[{"refs":[{"id":"ref-for-social-agent-registration\u2460"},{"id":"ref-for-social-agent-registration\u2460\u2460"},{"id":"ref-for-social-agent-registration\u2460\u2461"},{"id":"ref-for-social-agent-registration\u2460\u2462"},{"id":"ref-for-social-agent-registration\u2460\u2463"},{"id":"ref-for-social-agent-registration\u2460\u2464"},{"id":"ref-for-social-agent-registration\u2460\u2465"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-social-agent-registration\u2460\u2466"},{"id":"ref-for-social-agent-registration\u2460\u2467"},{"id":"ref-for-social-agent-registration\u2460\u2468"},{"id":"ref-for-social-agent-registration\u2460\u2460\u24ea"},{"id":"ref-for-social-agent-registration\u2460\u2460\u2460"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-social-agent-registration\u2460\u2460\u2461"},{"id":"ref-for-social-agent-registration\u2460\u2460\u2462"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-social-agent-registration\u2460\u2460\u2463"}],"title":"9.7. Access Receipt"}],"url":"#social-agent-registration\u2460"},
+"solid": {"dfnID":"solid","dfnText":"Solid","external":false,"refSections":[{"refs":[{"id":"ref-for-solid"},{"id":"ref-for-solid\u2460"},{"id":"ref-for-solid\u2461"}],"title":"11. Definitions"}],"url":"#solid"},
+"strongly-identifiable-applications": {"dfnID":"strongly-identifiable-applications","dfnText":"Strongly identifiable applications","external":false,"refSections":[{"refs":[{"id":"ref-for-strongly-identifiable-applications"}],"title":"10.1. Application Authorization"}],"url":"#strongly-identifiable-applications"},
+"user-piloted-application": {"dfnID":"user-piloted-application","dfnText":"user-piloted application","external":false,"refSections":[{"refs":[{"id":"ref-for-user-piloted-application"},{"id":"ref-for-user-piloted-application\u2460"}],"title":"11. Definitions"}],"url":"#user-piloted-application"},
+"weakly-identifiable-applications": {"dfnID":"weakly-identifiable-applications","dfnText":"Weakly identifiable applications","external":false,"refSections":[{"refs":[{"id":"ref-for-weakly-identifiable-applications"}],"title":"10.1. Application Authorization"}],"url":"#weakly-identifiable-applications"},
+"webid": {"dfnID":"webid","dfnText":"WebID","external":false,"refSections":[{"refs":[{"id":"ref-for-webid"}],"title":"11. Definitions"}],"url":"#webid"},
+};
+
+document.addEventListener("DOMContentLoaded", ()=>{
+    genAllDfnPanels();
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+});
+
+window.addEventListener("resize", () => {
+    // Pin any visible dfn panel
+    queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>positionDfnPanel(el));
+});
+
+function genAllDfnPanels() {
+    for(const panelData of Object.values(dfnPanelData)) {
+        const dfnID = panelData.dfnID;
+        const dfn = document.getElementById(dfnID);
+        if(!dfn) {
+            console.log(`Can't find dfn#${dfnID}.`, panelData);
+            continue;
+        }
+        dfn.panelData = panelData;
+        insertDfnPopupAction(dfn);
+    }
+}
+
+function genDfnPanel(dfn, { dfnID, url, dfnText, refSections, external }) {
+    const dfnPanel = mk.aside({
+        class: "dfn-panel on",
+        id: `infopanel-for-${dfnID}`,
+        "data-for": dfnID,
+        "aria-labelled-by":`infopaneltitle-for-${dfnID}`,
+        },
+        mk.span({id:`infopaneltitle-for-${dfnID}`, style:"display:none"},
+            `Info about the '${dfnText}' ${external?"external":""} reference.`),
+        mk.a({href:url, class:"dfn-link"}, url),
+        refSections.length == 0 ? [] :
+            mk.b({}, "Referenced in:"),
+            mk.ul({},
+                ...refSections.map(section=>
+                    mk.li({},
+                        ...section.refs.map((ref, refI)=>
+                            [
+                                mk.a({ href: `#${ref.id}` },
+                                    (refI == 0) ? section.title : `(${refI + 1})`
+                                ),
+                                " ",
+                            ]
+                        ),
+                    ),
+                ),
+            ),
+        genLinkingSyntaxes(dfn),
+    );
+
+    dfnPanel.addEventListener('click', (event) => {
+        if (event.target.nodeName == 'A') {
+            scrollToTargetAndHighlight(event);
+            pinDfnPanel(dfnPanel);
+        }
+        event.stopPropagation();
+        refocusOnTarget(event);
+    });
+    dfnPanel.addEventListener('keydown', (event) => {
+        if(event.keyCode == 27) { // Escape key
+            hideDfnPanel({dfnPanel});
+            event.stopPropagation();
+            event.preventDefault();
+        }
+    });
+
+    dfnPanel.dfn = dfn;
+    dfn.dfnPanel = dfnPanel;
+    return dfnPanel;
+}
+
+
+
+function hideAllDfnPanels() {
+    // Delete the currently-active dfn panel.
+    queryAll(".dfn-panel").forEach(dfnPanel=>hideDfnPanel({dfnPanel}));
+}
+
+function showDfnPanel(dfn) {
+    hideAllDfnPanels(); // Only display one at a time.
+
+    dfn.setAttribute("aria-expanded", "true");
+
+    const dfnPanel = genDfnPanel(dfn, dfn.panelData);
+
+    // Give the dfn a unique tabindex, and then
+    // give all the tabbable panel bits successive indexes.
+    let tabIndex = 100;
+    dfn.tabIndex = tabIndex++;
+    const tabbable = dfnPanel.querySelectorAll(":is(a, button)");
+    for (const el of tabbable) {
+        el.tabIndex = tabIndex++;
+    }
+
+    append(document.body, dfnPanel);
+    positionDfnPanel(dfnPanel);
+}
+
+function positionDfnPanel(dfnPanel) {
+    const dfn = dfnPanel.dfn;
+    const dfnPos = getBounds(dfn);
+    dfnPanel.style.top = dfnPos.bottom + "px";
+    dfnPanel.style.left = dfnPos.left + "px";
+
+    const panelPos = dfnPanel.getBoundingClientRect();
+    const panelMargin = 8;
+    const maxRight = document.body.parentNode.clientWidth - panelMargin;
+    if (panelPos.right > maxRight) {
+        const overflowAmount = panelPos.right - maxRight;
+        const newLeft = Math.max(panelMargin, dfnPos.left - overflowAmount);
+        dfnPanel.style.left = newLeft + "px";
+    }
+}
+
+function pinDfnPanel(dfnPanel) {
+    // Switch it to "activated" state, which pins it.
+    dfnPanel.classList.add("activated");
+    dfnPanel.style.position = "fixed";
+    dfnPanel.style.left = null;
+    dfnPanel.style.top = null;
+}
+
+function hideDfnPanel({dfn, dfnPanel}) {
+    if(!dfnPanel) dfnPanel = dfn.dfnPanel;
+    if(!dfn) dfn = dfnPanel.dfn;
+    dfn.dfnPanel = undefined;
+    dfnPanel.dfn = undefined;
+    dfn.setAttribute("aria-expanded", "false");
+    dfn.tabIndex = undefined;
+    dfnPanel.remove()
+}
+
+function toggleDfnPanel(dfn) {
+    if(dfn.dfnPanel) {
+        hideDfnPanel(dfn);
+    } else {
+        showDfnPanel(dfn);
+    }
+}
+
+function insertDfnPopupAction(dfn) {
+    dfn.setAttribute('role', 'button');
+    dfn.setAttribute('aria-expanded', 'false')
+    dfn.tabIndex = 0;
+    dfn.classList.add('has-dfn-panel');
+    dfn.addEventListener('click', (event) => {
+        toggleDfnPanel(dfn);
+        event.stopPropagation();
+    });
+    dfn.addEventListener('keypress', (event) => {
+        const kc = event.keyCode;
+        // 32->Space, 13->Enter
+        if(kc == 32 || kc == 13) {
+            toggleDfnPanel(dfn);
+            event.stopPropagation();
+            event.preventDefault();
+        }
+    });
+}
+
+function refocusOnTarget(event) {
+    const target = event.target;
+    setTimeout(() => {
+        // Refocus on the event.target element.
+        // This is needed after browser scrolls to the destination.
+        target.focus();
+    });
+}
+
+// TODO: shared util
+// Returns the root-level absolute position {left and top} of element.
+function getBounds(el, relativeTo=document.body) {
+    const relativeRect = relativeTo.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const top = elRect.top - relativeRect.top;
+    const left = elRect.left - relativeRect.left;
+    return {
+        top,
+        left,
+        bottom: top + elRect.height,
+        right: left + elRect.width,
+    }
+}
+
+function scrollToTargetAndHighlight(event) {
+    let hash = event.target.hash;
+    if (hash) {
+        hash = decodeURIComponent(hash.substring(1));
+        const dest = document.getElementById(hash);
+        if (dest) {
+            dest.classList.add('highlighted');
+            setTimeout(() => dest.classList.remove('highlighted'), 1000);
+        }
+    }
+}
+
+// Functions, divided by link type, that wrap an autolink's
+// contents with the appropriate outer syntax.
+// Alternately, a string naming another type they format
+// the same as.
+function needsFor(type) {
+    switch(type) {
+        case "descriptor":
+        case "value":
+        case "element-attr":
+        case "attr-value":
+        case "element-state":
+        case "method":
+        case "constructor":
+        case "argument":
+        case "attribute":
+        case "const":
+        case "dict-member":
+        case "event":
+        case "enum-value":
+        case "stringifier":
+        case "serializer":
+        case "iterator":
+        case "maplike":
+        case "setlike":
+        case "state":
+        case "mode":
+        case "context":
+        case "facet": return true;
+
+        default: return false;
+    }
+}
+function refusesFor(type) {
+    switch(type) {
+        case "property":
+        case "element":
+        case "interface":
+        case "namespace":
+        case "callback":
+        case "dictionary":
+        case "enum":
+        case "exception":
+        case "typedef":
+        case "http-header":
+        case "permission": return true;
+
+        default: return false;
+    }
+}
+function linkFormatterFromType(type) {
+    switch(type) {
+        case 'scheme':
+        case 'permission':
+        case 'dfn': return (text) => `[=${text}=]`;
+
+        case 'abstract-op': return (text) => `[\$${text}\$]`;
+
+        case 'function':
+        case 'at-rule':
+        case 'selector':
+        case 'value': return (text) => `''${text}''`;
+
+        case 'http-header': return (text) => `[:${text}:]`;
+
+        case 'interface':
+        case 'constructor':
+        case 'method':
+        case 'argument':
+        case 'attribute':
+        case 'callback':
+        case 'dictionary':
+        case 'dict-member':
+        case 'enum':
+        case 'enum-value':
+        case 'exception':
+        case 'const':
+        case 'typedef':
+        case 'stringifier':
+        case 'serializer':
+        case 'iterator':
+        case 'maplike':
+        case 'setlike':
+        case 'extended-attribute':
+        case 'event':
+        case 'idl': return (text) => `{{${text}}}`;
+
+        case 'element-state':
+        case 'element-attr':
+        case 'attr-value':
+        case 'element': return (element) => `<{${element}}>`;
+
+        case 'grammar': return (text) => `${text} (within a <pre class=prod>)`;
+
+        case 'type': return (text)=> `<<${text}>>`;
+
+        case 'descriptor':
+        case 'property': return (text) => `'${text}'`;
+
+        default: return;
+    };
+};
+
+function genLinkingSyntaxes(dfn) {
+    if(dfn.tagName != "DFN") return;
+
+    const type = dfn.getAttribute('data-dfn-type');
+    if(!type) {
+        console.log(`<dfn> doesn't have a data-dfn-type:`, dfn);
+        return [];
+    }
+
+    // Return a function that wraps link text based on the type
+    const linkFormatter = linkFormatterFromType(type);
+    if(!linkFormatter) {
+        console.log(`<dfn> has an unknown data-dfn-type:`, dfn);
+        return [];
+    }
+
+    let ltAlts;
+    if(dfn.hasAttribute('data-lt')) {
+        ltAlts = dfn.getAttribute('data-lt')
+            .split("|")
+            .map(x=>x.trim());
+    } else {
+        ltAlts = [dfn.textContent.trim()];
+    }
+    if(type == "type") {
+        // lt of "<foo>", but "foo" is the interior;
+        // <<foo/bar>> is how you write it with a for,
+        // not <foo/<bar>> or whatever.
+        for(var i = 0; i < ltAlts.length; i++) {
+            const lt = ltAlts[i];
+            const match = /<(.*)>/.exec(lt);
+            if(match) { ltAlts[i] = match[1]; }
+        }
+    }
+
+    let forAlts;
+    if(dfn.hasAttribute('data-dfn-for')) {
+        forAlts = dfn.getAttribute('data-dfn-for')
+            .split(",")
+            .map(x=>x.trim());
+    } else {
+        forAlts = [''];
+    }
+
+    let linkingSyntaxes = [];
+    if(!needsFor(type)) {
+        for(const lt of ltAlts) {
+            linkingSyntaxes.push(linkFormatter(lt));
+        }
+    }
+    if(!refusesFor(type)) {
+        for(const f of forAlts) {
+            linkingSyntaxes.push(linkFormatter(`${f}/${ltAlts[0]}`))
+        }
+    }
+    return [
+        mk.b({}, 'Possible linking syntaxes:'),
+        mk.ul({},
+            ...linkingSyntaxes.map(link => {
+                const copyLink = async () =>
+                    await navigator.clipboard.writeText(link);
+                return mk.li({},
+                    mk.div({ class: 'link-item' },
+                        mk.button({
+                            class: 'copy-icon', title: 'Copy',
+                            type: 'button',
+                            _onclick: copyLink,
+                            tabindex: 0,
+                        }, mk.span({ class: 'icon' }) ),
+                        mk.span({}, link)
+                    )
+                );
+            })
+        )
+    ];
+}
+}
+</script>
+<script>/* Boilerplate: script-ref-hints */
+"use strict";
+{
+let refsData = {
+"#access-authorization①": {"displayText":"access authorization","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access authorization","type":"dfn","url":"#access-authorization\u2460"},
+"#access-description-set①": {"displayText":"access description set","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access description set","type":"dfn","url":"#access-description-set\u2460"},
+"#access-grant①": {"displayText":"access grant","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access grant","type":"dfn","url":"#access-grant\u2460"},
+"#access-mode": {"displayText":"access mode","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access mode","type":"dfn","url":"#access-mode"},
+"#access-need": {"displayText":"access need","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need","type":"dfn","url":"#access-need"},
+"#access-need-description①": {"displayText":"access need description","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need description","type":"dfn","url":"#access-need-description\u2460"},
+"#access-need-group-description①": {"displayText":"access need group description","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need group description","type":"dfn","url":"#access-need-group-description\u2460"},
+"#access-need-group①": {"displayText":"access need group","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need group","type":"dfn","url":"#access-need-group\u2460"},
+"#access-receipt①": {"displayText":"access receipt","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access receipt","type":"dfn","url":"#access-receipt\u2460"},
+"#access-request①": {"displayText":"access request","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access request","type":"dfn","url":"#access-request\u2460"},
+"#access-scope": {"displayText":"access scope","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access scope","type":"dfn","url":"#access-scope"},
+"#acl-resource": {"displayText":"acl resource","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"acl resource","type":"dfn","url":"#acl-resource"},
+"#agent-registrations": {"displayText":"agent registrations","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"agent registrations","type":"dfn","url":"#agent-registrations"},
+"#agent-registry": {"displayText":"agent registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"agent registry","type":"dfn","url":"#agent-registry"},
+"#agents①": {"displayText":"agents","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"agents","type":"dfn","url":"#agents\u2460"},
+"#application": {"displayText":"application","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application","type":"dfn","url":"#application"},
+"#application-identity": {"displayText":"application identity","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application identity","type":"dfn","url":"#application-identity"},
+"#application-profile-document": {"displayText":"application profile document","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application profile document","type":"dfn","url":"#application-profile-document"},
+"#application-registration①": {"displayText":"application registration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application registration","type":"dfn","url":"#application-registration\u2460"},
+"#authenticated-agent": {"displayText":"authenticated agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authenticated agent","type":"dfn","url":"#authenticated-agent"},
+"#authorization-agent①": {"displayText":"authorization agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authorization agent","type":"dfn","url":"#authorization-agent\u2460"},
+"#authorization-registry": {"displayText":"authorization registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authorization registry","type":"dfn","url":"#authorization-registry"},
+"#authorization-subject": {"displayText":"authorization subject","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authorization subject","type":"dfn","url":"#authorization-subject"},
+"#data-authorization①": {"displayText":"data authorization","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data authorization","type":"dfn","url":"#data-authorization\u2460"},
+"#data-grant①": {"displayText":"data grant","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data grant","type":"dfn","url":"#data-grant\u2460"},
+"#data-instance": {"displayText":"data instance","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data instance","type":"dfn","url":"#data-instance"},
+"#data-registration①": {"displayText":"data registration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data registration","type":"dfn","url":"#data-registration\u2460"},
+"#data-registry①": {"displayText":"data registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data registry","type":"dfn","url":"#data-registry\u2460"},
+"#delegated-data-grant①": {"displayText":"delegated data grant","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"delegated data grant","type":"dfn","url":"#delegated-data-grant\u2460"},
+"#did": {"displayText":"did","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"did","type":"dfn","url":"#did"},
+"#ecosystem": {"displayText":"ecosystem","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"ecosystem","type":"dfn","url":"#ecosystem"},
+"#identity": {"displayText":"identity","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"identity","type":"dfn","url":"#identity"},
+"#identity-profile-document": {"displayText":"identity profile document","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"identity profile document","type":"dfn","url":"#identity-profile-document"},
+"#pod": {"displayText":"pod","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"pod","type":"dfn","url":"#pod"},
+"#registry": {"displayText":"registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"registry","type":"dfn","url":"#registry"},
+"#registry-set": {"displayText":"registry set","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"registry set","type":"dfn","url":"#registry-set"},
+"#server-side-application": {"displayText":"server-side application","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"server-side application","type":"dfn","url":"#server-side-application"},
+"#shape": {"displayText":"shape","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"shape","type":"dfn","url":"#shape"},
+"#shape-tree": {"displayText":"shape tree","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"shape tree","type":"dfn","url":"#shape-tree"},
+"#shape-tree-reference": {"displayText":"shape tree reference","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"shape tree reference","type":"dfn","url":"#shape-tree-reference"},
+"#social-agent": {"displayText":"social agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"social agent","type":"dfn","url":"#social-agent"},
+"#social-agent-invitation①": {"displayText":"social agent invitation","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"social agent invitation","type":"dfn","url":"#social-agent-invitation\u2460"},
+"#social-agent-registration①": {"displayText":"social agent registration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"social agent registration","type":"dfn","url":"#social-agent-registration\u2460"},
+"#solid": {"displayText":"solid","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"solid","type":"dfn","url":"#solid"},
+"#strongly-identifiable-applications": {"displayText":"strongly identifiable applications","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"strongly identifiable applications","type":"dfn","url":"#strongly-identifiable-applications"},
+"#user-piloted-application": {"displayText":"user-piloted application","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"user-piloted application","type":"dfn","url":"#user-piloted-application"},
+"#weakly-identifiable-applications": {"displayText":"weakly identifiable applications","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"weakly identifiable applications","type":"dfn","url":"#weakly-identifiable-applications"},
+"#webid": {"displayText":"webid","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"webid","type":"dfn","url":"#webid"},
+};
+
+function mkRefHint(link, ref) {
+    const linkText = link.textContent;
+    let dfnTextElements = '';
+    if (ref.displayText.toLowerCase() != linkText.toLowerCase()) {
+        // Give the original term if it's being displayed in a different way.
+        // But allow casing differences, they're insignificant.
+        dfnTextElements =
+            mk.li({},
+                mk.b({}, "Term: "),
+                mk.span({}, ref.displayText)
+            );
+    }
+    const forList = ref.for_;
+    let forListElements;
+    if(forList.length == 0) {
+        forListElements = [];
+    } else if(forList.length == 1) {
+        forListElements = mk.li({},
+            mk.b({}, "For: "),
+            mk.span({}, forList[0]),
+        );
+    } else {
+        forListElements = mk.li({},
+            mk.b({}, "For: "),
+            mk.ul({},
+                ...forList.map(forItem =>
+                    mk.li({},
+                        mk.span({}, forItem)
+                    ),
+                ),
+            ),
+        );
+    }
+    const url = ref.url;
+    const safeUrl = encodeURIComponent(url);
+    const hintPanel = mk.aside({
+        class: "ref-hint",
+        id: `ref-hint-for-${safeUrl}`,
+        "data-for": url,
+        "aria-labelled-by": `ref-hint-for-${safeUrl}`,
+    },
+        mk.ul({},
+            dfnTextElements,
+            mk.li({},
+                mk.b({}, "URL: "),
+                mk.a({ href: url, class: "ref" }, url),
+            ),
+            mk.li({},
+                mk.b({}, "Type: "),
+                mk.span({}, `${ref.type}`),
+            ),
+            mk.li({},
+                mk.b({}, "Spec: "),
+                mk.span({}, `${ref.spec ? ref.spec : ''}`),
+            ),
+            forListElements
+        ),
+    );
+    hintPanel.forLink = link;
+    setupRefHintEventListeners(link, hintPanel);
+    return hintPanel;
+}
+
+function hideAllRefHints() {
+    queryAll(".ref-hint").forEach(el=>hideRefHint(el));
+}
+
+function hideRefHint(refHint) {
+    const link = refHint.forLink;
+    link.setAttribute("aria-expanded", "false");
+    if(refHint.teardownEventListeners) {
+        refHint.teardownEventListeners();
+    }
+    refHint.remove();
+}
+
+function showRefHint(link) {
+    if(link.classList.contains("dfn-link")) return;
+    const url = link.getAttribute("href");
+    const refHintKey = link.getAttribute("data-refhint-key");
+    let key = url;
+    if(refHintKey) {
+        key = refHintKey + "_" + url;
+    }
+    const ref = refsData[key];
+    if(!ref) return;
+
+    hideAllRefHints(); // Only display one at this time.
+
+    const refHint = mkRefHint(link, ref);
+    append(document.body, refHint);
+    link.setAttribute("aria-expanded", "true");
+    positionRefHint(refHint);
+}
+
+function setupRefHintEventListeners(link, refHint) {
+    if (refHint.teardownEventListeners) return;
+    // Add event handlers to hide the refHint after the user moves away
+    // from both the link and refHint, if not hovering either within one second.
+    let timeout = null;
+    const startHidingRefHint = (event) => {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+        timeout = setTimeout(() => {
+            hideRefHint(refHint);
+        }, 1000);
+    }
+    const resetHidingRefHint = (event) => {
+        if (timeout) clearTimeout(timeout);
+        timeout = null;
+    };
+    link.addEventListener("mouseleave", startHidingRefHint);
+    link.addEventListener("mouseenter", resetHidingRefHint);
+    link.addEventListener("blur", startHidingRefHint);
+    link.addEventListener("focus", resetHidingRefHint);
+    refHint.addEventListener("mouseleave", startHidingRefHint);
+    refHint.addEventListener("mouseenter", resetHidingRefHint);
+    refHint.addEventListener("blur", startHidingRefHint);
+    refHint.addEventListener("focus", resetHidingRefHint);
+
+    refHint.teardownEventListeners = () => {
+        // remove event listeners
+        resetHidingRefHint();
+        link.removeEventListener("mouseleave", startHidingRefHint);
+        link.removeEventListener("mouseenter", resetHidingRefHint);
+        link.removeEventListener("blur", startHidingRefHint);
+        link.removeEventListener("focus", resetHidingRefHint);
+        refHint.removeEventListener("mouseleave", startHidingRefHint);
+        refHint.removeEventListener("mouseenter", resetHidingRefHint);
+        refHint.removeEventListener("blur", startHidingRefHint);
+        refHint.removeEventListener("focus", resetHidingRefHint);
+    };
+}
+
+function positionRefHint(refHint) {
+    const link = refHint.forLink;
+    const linkPos = getBounds(link);
+    refHint.style.top = linkPos.bottom + "px";
+    refHint.style.left = linkPos.left + "px";
+
+    const panelPos = refHint.getBoundingClientRect();
+    const panelMargin = 8;
+    const maxRight = document.body.parentNode.clientWidth - panelMargin;
+    if (panelPos.right > maxRight) {
+        const overflowAmount = panelPos.right - maxRight;
+        const newLeft = Math.max(panelMargin, linkPos.left - overflowAmount);
+        refHint.style.left = newLeft + "px";
+    }
+}
+
+// TODO: shared util
+// Returns the root-level absolute position {left and top} of element.
+function getBounds(el, relativeTo=document.body) {
+    const relativeRect = relativeTo.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const top = elRect.top - relativeRect.top;
+    const left = elRect.left - relativeRect.left;
+    return {
+        top,
+        left,
+        bottom: top + elRect.height,
+        right: left + elRect.width,
+    }
+}
+
+function showRefHintListener(e) {
+    // If the target isn't in a link (or is a link),
+    // just ignore it.
+    let link = e.target.closest("a");
+    if(!link) return;
+
+    // If the target is in a ref-hint panel
+    // (aka a link in the already-open one),
+    // also just ignore it.
+    if(link.closest(".ref-hint")) return;
+
+    // Otherwise, show the panel for the link.
+    showRefHint(link);
+}
+
+function hideAllHintsListener(e) {
+    // If the click is inside a ref-hint panel, ignore it.
+    if(e.target.closest(".ref-hint")) return;
+    // Otherwise, close all the current panels.
+    hideAllRefHints();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.body.addEventListener("mousedown", showRefHintListener);
+    document.body.addEventListener("focus", showRefHintListener);
+
+    document.body.addEventListener("click", hideAllHintsListener);
+});
+
+window.addEventListener("resize", () => {
+    // Hide any open ref hint.
+    hideAllRefHints();
+});
+}
+</script>

--- a/tag/sai-primer-application-v0.1.html
+++ b/tag/sai-primer-application-v0.1.html
@@ -1,0 +1,1066 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Solid Application Interoperability - Application Primer</title>
+  <meta content="CG-DRAFT" name="w3c-status">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
+  <link href="https://solidproject.org/TR/sai-primer-application" rel="canonical">
+  <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
+  <meta content="b1aa5b6d33d362cab931e0fa7c3674b51f45950b" name="revision">
+  <meta content="dark light" name="color-scheme">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
+<style>/* Boilerplate: style-autolinks */
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
+</style>
+<style>/* Boilerplate: style-colors */
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+</style>
+<style>/* Boilerplate: style-counters */
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}
+</style>
+<style>/* Boilerplate: style-issues */
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* Boilerplate: style-line-highlighting */
+:root {
+    --highlight-hover-bg: rgba(0, 0, 0, .05);
+}
+.line-numbered {
+    display: grid !important;
+    grid-template-columns: min-content 1fr;
+    grid-auto-flow: rows;
+}
+.line-numbered > *,
+.line-numbered::before,
+.line-numbered::after {
+    grid-column: 1/-1;
+}
+.line-no {
+    grid-column: 1;
+    color: gray;
+}
+.line {
+    grid-column: 2;
+}
+.line.highlight-line {
+    background: var(--highlight-hover-bg);
+}
+.line-no.highlight-line {
+    background: var(--highlight-hover-bg);
+    color: #444;
+    font-weight: bold;
+}
+.line-no.highlight-line[data-line]::before {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line);
+}
+.line-no.highlight-line[data-line-end]::after {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line-end);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --highlight-hover-bg: rgba(255, 255, 255, .05);
+    }
+}
+</style>
+<style>/* Boilerplate: style-md-lists */
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}
+</style>
+<style>/* Boilerplate: style-selflinks */
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">Solid Application Interoperability - Application Primer</h1>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2025-09-16">16 September 2025</time></p>
+   <details open>
+    <summary>More details about this document</summary>
+    <div data-fill-with="spec-metadata">
+     <dl>
+      <dt>This version:
+      <dd><a class="u-url" href="https://solidproject.org/TR/tag/sai-primer-application-v0.1">https://solidproject.org/TR/tag/sai-primer-application-v0.1</a>
+      <dt>Latest published version:
+      <dd><a href="https://solidproject.org/TR/sai-primer-application">https://solidproject.org/TR/sai-primer-application</a>
+      <dt>Feedback:
+      <dd><a href="https://github.com/solid/data-interoperability-panel/issues/">GitHub</a>
+      <dt class="editor">Editor:
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">elf Pavlik</span>
+      <dt>Version:
+      <dd>0.1
+     </dl>
+    </div>
+   </details>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">Copyright © 2025 the Contributors to the Solid Application Interoperability - Application Primer,
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This report was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+  Learn more about <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#shape-tree"><span class="secno">2</span> <span class="content">Shape Tree</span></a>
+    <li><a href="#appliction"><span class="secno">3</span> <span class="content">Application</span></a>
+    <li>
+     <a href="#authorization-flow"><span class="secno">4</span> <span class="content">Authorization Flow</span></a>
+     <ol class="toc">
+      <li><a href="#authorization-agent-discovery"><span class="secno">4.1</span> <span class="content">Authorization Agent Discovery</span></a>
+      <li><a href="#application-registration-discovery"><span class="secno">4.2</span> <span class="content">Application Registration Discovery</span></a>
+      <li><a href="#user-consent"><span class="secno">4.3</span> <span class="content">User Consent</span></a>
+      <li><a href="#resource-indication"><span class="secno">4.4</span> <span class="content">Resource Indication</span></a>
+     </ol>
+    <li>
+     <a href="#application-registration"><span class="secno">5</span> <span class="content">Application Registration</span></a>
+     <ol class="toc">
+      <li><a href="#access-grant"><span class="secno">5.1</span> <span class="content">Access Grant</span></a>
+      <li>
+       <a href="#data-grant"><span class="secno">5.2</span> <span class="content">Data Grant</span></a>
+       <ol class="toc">
+        <li><a href="#data-grant-scopes"><span class="secno">5.2.1</span> <span class="content">Scopes</span></a>
+        <li><a href="#data-grant-inheritance"><span class="secno">5.2.2</span> <span class="content">Inheritance</span></a>
+        <li><a href="#data-grant-delegation"><span class="secno">5.2.3</span> <span class="content">Delegation</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#data-registration"><span class="secno">6</span> <span class="content">Data Registration</span></a>
+     <ol class="toc">
+      <li><a href="#data-instance"><span class="secno">6.1</span> <span class="content">Data Instance</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+   </ol>
+  </nav>
+  <main>
+<script type="application/ld+json">
+{
+  "@context": {
+    "spec": "http://www.w3.org/ns/spec#",
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "author": { "@id": "schema:author", "@type": "@id" },
+    "editor": { "@id": "schema:editor", "@type": "@id" }
+  },
+  "@id": "https://solidproject.org/TR/sai-primer-application",
+  "@type": "spec:Primer",
+  "name": "SAI Application Primer",
+  "author": [
+    "https://elf-pavlik.hackers4peace.net"
+  ],
+  "editor": [
+    "https://elf-pavlik.hackers4peace.net"
+  ]
+}
+</script>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p>This primer is intended to accompany <a data-link-type="biblio" href="#biblio-sai" title="Solid Application Interoperability">[SAI]</a>.
+It is focused on providing a friendly introduction for developers of libraries intended
+for solid applications.</p>
+   <p>This document was developed alongside the open-source TypeScript implementation <a data-link-type="biblio" href="#biblio-sai-js" title="Solid Application Interoperability - TypeScript implementation">[SAI-JS]</a></p>
+   <p>We will follow example of an application called <em>Projectron</em>,
+which manages projects and tasks.
+End user, named <em>Alice</em>, collaborates on projects
+with other Individuals and Organizations.</p>
+   <h2 class="heading settled" data-level="2" id="shape-tree"><span class="secno">2. </span><span class="content">Shape Tree</span><a class="self-link" href="#shape-tree"></a></h2>
+   <p>Shape Trees <a data-link-type="biblio" href="#biblio-shapetrees" title="Shape Trees">[SHAPETREES]</a> allow  for the definition and validation of data hierarchies
+including which shapes <a data-link-type="biblio" href="#biblio-shex" title="Shape Expressions Language 2.1">[SHEX]</a> should be used to validate data.
+In our examples, we are going to use the following Shapes and Shape Trees.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>references</c-> <c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c-> <c- p>.</c->
+
+<c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>viaShapePath</c->
+    <c- s>"@&lt;https://solidshapes.example/shapes/Project>~&lt;https://vocab.example/project-management/hasTask>"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Project shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c-> <c- k>IRI</c-> <c- o>*</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Project shape (ShEx)</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>.</c->
+</pre>
+    <figcaption>Task shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Task</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Task shape (ShEx)</figcaption>
+   </figure>
+   <p class="issue" id="issue-f026f3dd"><a class="self-link" href="#issue-f026f3dd"></a> Reference shape path documentation</p>
+   <h2 class="heading settled" data-level="3" id="appliction"><span class="secno">3. </span><span class="content">Application</span><a class="self-link" href="#appliction"></a></h2>
+   <p>In this primer we will consider the use-case of a project management application
+identified by <code>https://projectron.example/#app</code> Every application has public WebID Document providing information about it.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Application</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationName</c-> <c- s>"Projectron"</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationDescription</c-> <c- s>"Manage projects with ease"</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationAuthor</c-> <c- nn>acme</c-><c- p>:</c-><c- f>\#corp</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>applicationThumbnail</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>thumb.svg</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-group-pm</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#need-group-pm</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessScenario</c-> <c- nn>interop</c-><c- p>:</c-><c- f>PersonalAccess</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>authenticatesAs</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Pilot</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessDecoratorIndex</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>index</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-project</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#need-project</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>write</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"><c- nn>projectron</c-><c- p>:</c-><c- f>\#need-issue</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Issue</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>write</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-project</c-> <c- p>.</c-></span></pre>
+    <figcaption>Projectron WebID document</figcaption>
+   </figure>
+   <p>Access Needs explain what kind of data application works with.
+They use combination of <a href="#shape-tree">§ 2 Shape Tree</a> and access modes to
+convey how the application can work with data.</p>
+   <p class="issue" id="issue-e982e541"><a class="self-link" href="#issue-e982e541"></a> Details can change based on experience from implementing Authorization Agent role</p>
+   <h2 class="heading settled" data-level="4" id="authorization-flow"><span class="secno">4. </span><span class="content">Authorization Flow</span><a class="self-link" href="#authorization-flow"></a></h2>
+   <p>User always needs to authenticate first.
+For the rest of this primer we’ll be assuming that user has already authenticated,
+and that applicaction know WebID of the authenticated user.</p>
+   <h3 class="heading settled" data-level="4.1" id="authorization-agent-discovery"><span class="secno">4.1. </span><span class="content">Authorization Agent Discovery</span><a class="self-link" href="#authorization-agent-discovery"></a></h3>
+   <p>Every user has an Authorization Agent which can be discovered from
+their WebID Document via <code>interop:hasAuthorizationAgent</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="4"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>13e60d32-77a6-4239-864d-cfe2c90807c8</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- g>&lt;https://auth.alice.example/></c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s WebID document</figcaption>
+   </figure>
+   <p>Here we see that Alice designates <code>https://auth.alice.example/</code> as their Authorization Agent.</p>
+   <h3 class="heading settled" data-level="4.2" id="application-registration-discovery"><span class="secno">4.2. </span><span class="content">Application Registration Discovery</span><a class="self-link" href="#application-registration-discovery"></a></h3>
+   <p>Application can discover Application Registration created for it by the user,
+by performing <code>HEAD</code> or <code>GET</code> request on IRI denoting
+user’s Authorization Agent. Response will include HTTP Link header relating
+Application Registration to the application making the request using <code>http://www.w3.org/ns/solid/interop#registeredAgent</code> as link relation.</p>
+   <figure>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>auth.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://projectron.example/#app>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://auth.alice.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+    <figcaption>HEAD request to and response from Authorization Agent</figcaption>
+   </figure>
+   <p>Details in <a href="https://solid.github.io/data-interoperability-panel/specification/#authorization">7. Data Authorization</a> (<a data-link-type="biblio" href="#biblio-sai" title="Solid Application Interoperability">[SAI]</a>)</p>
+   <h3 class="heading settled" data-level="4.3" id="user-consent"><span class="secno">4.3. </span><span class="content">User Consent</span><a class="self-link" href="#user-consent"></a></h3>
+   <p>In cases where an application hasn’t been registered yet, it needs to initiate the flow with the Authorization Agent.</p>
+   <p>After successful flow, the application will be able to discover its registration.</p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice finds an Application called Projectron that she’d like
+            to use to manage her Projects and Tasks.
+      <tr>
+       <td><b>2</b>
+       <td>Alice authenticates to Projectron with her WebID.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron dereferences her WebID and retrieves Authorization Agent from her WebID Profile Document.
+      <tr>
+       <td><b>4</b>
+       <td>Projectron asks Alice’s Authorization Agent whether Alice already has an Application Registration for Projectron.
+      <tr>
+       <td><b>5</b>
+       <td>Alice’s Authorization Agent checks the Agent Registry in Alice’s Pod for a Projectron Application Registration.
+      <tr>
+       <td><b>6</b>
+       <td>No Application Registration for Projectron is found.
+          Projectron now knows that Alice hasn’t given it permission to access her data, so it must ask.
+      <tr>
+       <td><b>7</b>
+       <td>Projectron redirects Alice to her Authorization Agent, supplying its identifier for context.
+      <tr>
+       <td><b>8</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron identifier, retrieving Projectron’s
+          Application profile graph and corresponding Access Need Groups from the WebID Profile Document,
+          as well as <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>9</b>
+       <td>Alice’s Authorization Agent presents the Access Need Groups from Projectron’s Application
+          profile graph, so that Alice understands what kind of data is being requested, and why.
+      <tr>
+       <td><b>10</b>
+       <td>Alice’s chooses the scope of access that Projectron will receive, to the data to 
+          which it has asked for access via the presented Access Needs.
+      <tr>
+       <td><b>11-13</b>
+       <td>Alice’s Authorization Agent records her decision as an Access Authorization in Alice’s
+            Authorization Registry. An Application Registration is created for Projectron in
+            Alice’s Agent Registry. An Access Grant and corresponding Data Grants are generated
+            from the Access Authorization and stored in the Projectron Application Registration. 
+      <tr>
+       <td><b>14</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the appropriate access has been granted.
+      <tr>
+       <td><b>15</b>
+       <td>Projectron again asks Alice’s Authorization Agent for a Projectron Application Registration.
+      <tr>
+       <td><b>16</b>
+       <td>Alice’s Authorization Agent finds the newly created Projectron Application Registration in the Agent Registry in Alice’s Pod.
+      <tr>
+       <td><b>17</b>
+       <td>Alice’s Authorization Agent provides the URI of the Application Registration to Projectron.
+      <tr>
+       <td><b>18</b>
+       <td>Projectron learns what access it received through the Access Grant in Alice’s Projectron Application Registration.
+      <tr>
+       <td><b>19</b>
+       <td>Projectron may now function as intended, within the scope of authorization it was given by Alice.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/application-requests-access-flow.seq.mmd.svg"></p>
+   <h3 class="heading settled" data-level="4.4" id="resource-indication"><span class="secno">4.4. </span><span class="content">Resource Indication</span><a class="self-link" href="#resource-indication"></a></h3>
+   <p>When the application has already been registered, and the user wants to
+initiate a sharing-specific <a href="#data-instance">§ 6.1 Data Instance</a>, an authorization flow with resource
+indication is available.</p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice’s is authenticated with Projectron.
+      <tr>
+       <td><b>2</b>
+       <td>Alice has already authorized Projectron.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron has read its Access Grant and displayed projects.
+      <tr>
+       <td><b>4</b>
+       <td>Alice initiates sharing of a specific project.
+      <tr>
+       <td><b>5</b>
+       <td>Projectron redirects Alice to her Authorization Agent, indicating the selected project.
+      <tr>
+       <td><b>6-8</b>
+       <td>Alice’s Authorization Agent fetches the indicated project and checks who already has access to it.
+          It also fetches list of all registered social agents to present it to Alice.
+      <tr>
+       <td><b>9</b>
+       <td>Alice chooses all the social agents with which she wants to share the selected project,
+          as well as modes of access for all selected agents. If the shape tree has references (e.g., tasks) she can
+          also select modes of access for each inherited shape tree.
+      <tr>
+       <td><b>10-11</b>
+       <td>Alice’s Authorization Agent records new access authorizations for all the selected agents
+          and regenerates access grants provided in their agent registrations.
+      <tr>
+       <td><b>12</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron WebID, retrieving Projection’s
+          Application profile graph from the WebID Profile Document,
+          to discover the <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>13</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the project has been shared.
+      <tr>
+       <td><b>14</b>
+       <td>Alice continues using Projectron.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/resource-indication.seq.mmd.svg"></p>
+   <h2 class="heading settled" data-level="5" id="application-registration"><span class="secno">5. </span><span class="content">Application Registration</span><a class="self-link" href="#application-registration"></a></h2>
+   <p>Application Registration can be considered an entry point to all the data
+that the user authorized it to access. The next step in the discovery of that data
+is the Access Grant linked via <code>interop:hasAccessGrant</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-auth</c-><c- p>:</c-><c- f>bcf22534-0187-4ae4-b88f-fe0f9fa96659</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>ApplicationRegistration</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- g>&lt;https://jarvis.alice.example/#agent></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>registeredAgent</c-> <c- g>&lt;https://projectron.example/#app></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="8"></span><span class="line highlight-line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrant</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe</c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s application registration for Projectron</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="5.1" id="access-grant"><span class="secno">5.1. </span><span class="content">Access Grant</span><a class="self-link" href="#access-grant"></a></h3>
+   <p>Access Grant links to all the Data Grants issued to the application
+via <code>interop:hasDataGrant</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-auth</c-><c- p>:</c-><c- f>dd442d1b-bcc7-40e2-bbb9-4abfa7309fbe</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- g>&lt;https://jarvis.alice.example/#agent></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>providedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>fromAgent</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>viaAgent</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrantSubject</c-></span><span class="line-no"></span><span class="line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>3fcef0f6-5807-4f1b-b77a-63d64df25a69\#grant-subject</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- g>&lt;#need-group-pm></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="13"></span><span class="line highlight-line">    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataGrant</c-></span><span class="line-no highlight-line" data-line="14"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="15"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>9827ae00-2778-4655-9f22-08bb9daaee26</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="16"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>7b2bc4ff-b4b8-47b8-96f6-06695f4c5126</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="17"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>54b1a123-23ca-4733-9371-700b52b9c567</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="18"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>12daf870-a343-4684-b828-c67c5c9c997a</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>7be5a39f-583d-4464-8ad8-a39e24b99fce</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>c205e9da-2dc5-4d1f-8be9-a3f90c13eedc</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>68dd1212-b0f3-4611-aae2-f9f5ea30ee07</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>92328851-ffb0-427d-847e-f6d9c8417648</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">      <c- nn>alice-auth</c-><c- p>:</c-><c- f>a2e961fa-a26a-4cd6-b00d-7992b8cfd1b8</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice-auth</c-><c- p>:</c-><c- f>3fcef0f6-5807-4f1b-b77a-63d64df25a69\#grant-subject</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessGrantSubject</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>accessByAgent</c->  <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">    <c- nn>interop</c-><c- p>:</c-><c- f>accessByApplication</c-> <c- g>&lt;https://projectron.example/#app></c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s access grant for Projectron</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="5.2" id="data-grant"><span class="secno">5.2. </span><span class="content">Data Grant</span><a class="self-link" href="#data-grant"></a></h3>
+   <p>Each Data grant represents access granted by specific Social Agent, to all or selected
+Data Instances in specific Data Registration.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Write</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c->
+      <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c->
+
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>9827ae00-2778-4655-9f22-08bb9daaee26</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c->
+      <c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c-> <c- p>.</c->
+
+<c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s data grant for Projectron - Pro Projects</figcaption>
+   </figure>
+   <p>A Data Grant is immutable, it never gets updated, instead it can be only replaced
+with a newer Data Grant.</p>
+   <p>Data Grant can be consider as the most important data structure, it provides following information:</p>
+   <dl>
+    <dt data-md>dataOwner
+    <dd data-md>
+     <p>Social Agent who owns the data</p>
+    <dt data-md>grantedBy
+    <dd data-md>
+     <p>Social Agent who granted the access</p>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by related Data Registration</p>
+    <dt data-md>hasDataRegistration
+    <dd data-md>
+     <p>Data Registration that this Data Grant applies to. As well as <code>iriPrefix</code> of that Data Registration (see <a href="#data-registration">§ 6 Data Registration</a>)</p>
+    <dt data-md>accessMode
+    <dd data-md>
+     <p>List of access modes defining what application can do with the data</p>
+    <dt data-md>scopeOfGrant
+    <dd data-md>
+     <p>Defines which instances can be accessed (see <a href="#data-grant-scopes">§ 5.2.1 Scopes</a>)</p>
+    <dt data-md>inheritsFromGrant
+    <dd data-md>
+     <p>If grant has <code>InheritInstances</code> scope, it will be the Data Grant for Data Registraion with parent Data Instances (see <a href="#data-grant-inheritance">§ 5.2.2 Inheritance</a>)</p>
+    <dt data-md>hasDataInstance
+    <dd data-md>
+     <p>If grant has <code>SelectedInstances</code> scope, it will be all the Data Instances that application can access in the Data Registration</p>
+    <dt data-md>delegationOfGrant
+    <dd data-md>
+     <p>If Data Grant is issued by Social Agent other than data owner, it will be the original Data Grant issued by the data owner (see <a href="#data-grant-delegation">§ 5.2.3 Delegation</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="5.2.1" id="data-grant-scopes"><span class="secno">5.2.1. </span><span class="content">Scopes</span><a class="self-link" href="#data-grant-scopes"></a></h4>
+   <p>Data Grant can have one of three scopes:</p>
+   <dl>
+    <dt data-md>AllFromRegistry
+    <dd data-md>
+     <p>All the Data Instances in the Data Registration. Application will be able to access the Data Registration and see the list of all contained instances (see <a href="#data-registration">§ 6 Data Registration</a>)</p>
+    <dt data-md>SelectedFromRegistry
+    <dd data-md>
+     <p>Only specific Data Instances in the Data Registration. Application will not be able to access the Data Registration, so it will not see the list al all contained instances. Instad list of selected Data Instances is available via <code>hasDataInstance</code></p>
+    <dt data-md>Inherited
+    <dd data-md>
+     <p>Only those Data Instances in the Data Registration, which are related to parent kData Instances in Data Registration of the Data Grant referenced with <code>inheritsFromGrant</code> (see <a href="#data-grant-inheritance">§ 5.2.2 Inheritance</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="5.2.2" id="data-grant-inheritance"><span class="secno">5.2.2. </span><span class="content">Inheritance</span><a class="self-link" href="#data-grant-inheritance"></a></h4>
+   <p><code>InheritInstances</code> Data Grant doesn’t provide access to the Data Registration, so
+application can’t get the list of all the Data Instances. Neither it provides a list of specific
+Data Instances in the Data Registration.</p>
+   <p>To find Data Instances from that Data Registration, application first needs to access parent
+Data Instances from Data Registration which Data Grant referenced by <code>inheritsFromGrant</code> makes accessible. Based on shape tree definition, each parent Data Instance will reference all its
+child Data Instances.</p>
+   <p>Both parent and child Data Registrations have to be in the same Data Registry. Since only one
+Data Registration for specific shape tree can be created in any given Data Registry.
+All parent Data Instances are from one Data Registration and all child Data Instances are from
+one Data Registration.</p>
+   <h4 class="heading settled" data-level="5.2.3" id="data-grant-delegation"><span class="secno">5.2.3. </span><span class="content">Delegation</span><a class="self-link" href="#data-grant-delegation"></a></h4>
+   <p>Application doesn’t need to handle delegated Data Grants in any special way.
+To know if Data Grant was issued by currently logged in user or someone else,
+application should rely on <code>dataOwner</code> information in the Data Grant.</p>
+   <div class="issue no-marker" id="issue-d41d8cd9"><a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a></div>
+   <h2 class="heading settled" data-level="6" id="data-registration"><span class="secno">6. </span><span class="content">Data Registration</span><a class="self-link" href="#data-registration"></a></h2>
+   <p><img class="flowchart-diagram" src="diagrams/pro.alice.example.flow.mmd.png"></p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-10-17T11:42:35.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="6"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- g>&lt;https://solidmin.example/#app></c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="7"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="8"></span><span class="line highlight-line">  <c- nn>ldp</c-><c- p>:</c-><c- f>contains</c-></span><span class="line-no highlight-line" data-line="9"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>ccbd77ae-f769-4e07-b41f-5136501e13e7\#project</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="10"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s data registration for <strong>pro</strong> projects</figcaption>
+   </figure>
+   <dl>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by this Data Registration</p>
+    <dt data-md>iriPrefix
+    <dd data-md>
+     <p>String that should be used as base for creating IRIs for new Data Instances in this registration, by appending a unique string to the <code>iriPrefix</code></p>
+   </dl>
+   <h3 class="heading settled" data-level="6.1" id="data-instance"><span class="secno">6.1. </span><span class="content">Data Instance</span><a class="self-link" href="#data-instance"></a></h3>
+   <p>Data Instances are domain specific data records. They don’t use <code>interop:</code> vocabulary,
+instead they use some domain specific vocabularies.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-pro</c-><c- p>:</c-><c- f>ccbd77ae-f769-4e07-b41f-5136501e13e7\#project</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- s>"P-Ap-1"</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="4"></span><span class="line highlight-line">  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c-></span><span class="line-no highlight-line" data-line="5"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>576520a6-af5a-4cf9-8b40-8b1512b59c73\#task</c-> <c- p>,</c-></span><span class="line-no highlight-line" data-line="6"></span><span class="line highlight-line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>106a82aa-6911-4a7e-a49b-383cbaa9da66\#task</c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s <strong>pro</strong> project 1</figcaption>
+   </figure>
+   <p>As we discussed in <a href="#data-grant-inheritance">§ 5.2.2 Inheritance</a> a Shape Tree will specify how parent data instances
+relate to child data instances. For Project shape three the predicate is <code>pm:hasTask</code>,
+links to child Task data instances.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>alice-pro</c-><c- p>:</c-><c- f>576520a6-af5a-4cf9-8b40-8b1512b59c73\#task</c->
+  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Task</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- s>"T-Ap-1"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s <strong>pro</strong> task 1</figcaption>
+   </figure>
+   <p>When creating or updating data instance with HTTP PUT method. Application should include
+link header linking Data Instance to Data Registration using link relation <code>http://www.w3.org/ns/solid/interop#targetDataRegistration</code></p>
+   <p>Update should include <code>If-Match</code> HTTP header with value of ETag from
+HTTP response when the representation was retreived.</p>
+   <figure>
+<pre class="highlight"><c- nf>PUT</c-> <c- nn>/ccbd77ae-f769-4e07-b41f-5136501e13e7</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>pro.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+<c- e>If-Match</c-><c- o>:</c-> <c- l>"..."</c->
+<c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://pro.alice.example/773605f0-b5bf-4d46-878d-5c167eac8b5d>;</c->
+  <c- l>rel="http://www.w3.org/ns/solid/interop#targetDataRegistration"</c->
+
+</pre>
+    <figcaption>Updating Data Instance with PUT</figcaption>
+   </figure>
+   <p>When creating new data instance client should also include <code>If-None-Match: *</code> header in HTTP request.</p>
+   <figure>
+<pre class="highlight"><c- nf>PUT</c-> <c- nn>/d046dd43-b619-46c8-91f6-a0713d967c0d</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>pro.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+<c- e>If-None-Match</c-><c- o>:</c-> <c- l>*</c->
+<c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://pro.alice.example/773605f0-b5bf-4d46-878d-5c167eac8b5d>;</c->
+  <c- l>rel="http://www.w3.org/ns/solid/interop#targetDataRegistration"</c->
+
+</pre>
+    <figcaption>Creating new Data Instance with PUT</figcaption>
+   </figure>
+  </main>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-sai">[SAI]
+   <dd>Justin Bingham; Eric Prud'hommeaux; elf Pavlik. <a href="https://solid.github.io/data-interoperability-panel/specification/"><cite>Solid Application Interoperability</cite></a>. URL: <a href="https://solid.github.io/data-interoperability-panel/specification/">https://solid.github.io/data-interoperability-panel/specification/</a>
+   <dt id="biblio-sai-js">[SAI-JS]
+   <dd>elf Pavlik; Maciej Samoraj; Ángel Araya. <a href="https://github.com/janeirodigital/sai-js"><cite>Solid Application Interoperability - TypeScript implementation</cite></a>. URL: <a href="https://github.com/janeirodigital/sai-js">https://github.com/janeirodigital/sai-js</a>
+   <dt id="biblio-shapetrees">[SHAPETREES]
+   <dd>Justin Bingham; et al. <a href="https://shapetrees.org/TR/specification/"><cite>Shape Trees</cite></a>. URL: <a href="https://shapetrees.org/TR/specification/">https://shapetrees.org/TR/specification/</a>
+   <dt id="biblio-shex">[SHEX]
+   <dd>Eric Prud'hommeaux; et al. <a href="http://shex.io/shex-semantics/index.html"><cite>Shape Expressions Language 2.1</cite></a>. URL: <a href="http://shex.io/shex-semantics/index.html">http://shex.io/shex-semantics/index.html</a>
+  </dl>

--- a/tag/sai-primer-authorization-agent-v0.1.html
+++ b/tag/sai-primer-authorization-agent-v0.1.html
@@ -1,0 +1,1190 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Solid Application Interoperability - Authorization Agent Primer</title>
+  <meta content="CG-DRAFT" name="w3c-status">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
+  <link href="https://solidproject.org/TR/sai-primer-authorization-agent" rel="canonical">
+  <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
+  <meta content="b1aa5b6d33d362cab931e0fa7c3674b51f45950b" name="revision">
+  <meta content="dark light" name="color-scheme">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css">
+<style>/* Boilerplate: style-autolinks */
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --selflink-text: black;
+        --selflink-bg: silver;
+        --selflink-hover-text: white;
+    }
+}
+</style>
+<style>/* Boilerplate: style-colors */
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text: #ddd;
+        --bg: black;
+
+        --unofficial-watermark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='400'%3E%3Cg fill='%23100808' transform='translate(200 200) rotate(-45) translate(-200 -200)' stroke='%23100808' stroke-width='3'%3E%3Ctext x='50%25' y='220' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EUNOFFICIAL%3C/text%3E%3Ctext x='50%25' y='305' style='font: bold 70px sans-serif; text-anchor: middle; letter-spacing: 6px;'%3EDRAFT%3C/text%3E%3C/g%3E%3C/svg%3E");
+
+        --logo-bg: #1a5e9a;
+        --logo-active-bg: #c00;
+        --logo-text: white;
+
+        --tocnav-normal-text: #999;
+        --tocnav-normal-bg: var(--bg);
+        --tocnav-hover-text: var(--tocnav-normal-text);
+        --tocnav-hover-bg: #080808;
+        --tocnav-active-text: #f44;
+        --tocnav-active-bg: var(--tocnav-normal-bg);
+
+        --tocsidebar-text: var(--text);
+        --tocsidebar-bg: #080808;
+        --tocsidebar-shadow: rgba(255,255,255,.1);
+        --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+        --toclink-text: var(--text);
+        --toclink-underline: #6af;
+        --toclink-visited-text: var(--toclink-text);
+        --toclink-visited-underline: #054572;
+
+        --heading-text: #8af;
+
+        --hr-text: var(--text);
+
+        --algo-border: #456;
+
+        --del-text: #f44;
+        --del-bg: transparent;
+        --ins-text: #4a4;
+        --ins-bg: transparent;
+
+        --a-normal-text: #6af;
+        --a-normal-underline: #555;
+        --a-visited-text: var(--a-normal-text);
+        --a-visited-underline: var(--a-normal-underline);
+        --a-hover-bg: rgba(25%, 25%, 25%, .2);
+        --a-active-text: #f44;
+        --a-active-underline: var(--a-active-text);
+
+        --borderedblock-bg: rgba(255, 255, 255, .05);
+
+        --blockquote-border: silver;
+        --blockquote-bg: var(--borderedblock-bg);
+        --blockquote-text: currentcolor;
+
+        --issue-border: #e05252;
+        --issue-bg: var(--borderedblock-bg);
+        --issue-text: var(--text);
+        --issueheading-text: hsl(0deg, 70%, 70%);
+
+        --example-border: hsl(50deg, 90%, 60%);
+        --example-bg: var(--borderedblock-bg);
+        --example-text: var(--text);
+        --exampleheading-text: hsl(50deg, 70%, 70%);
+
+        --note-border: hsl(120deg, 100%, 35%);
+        --note-bg: var(--borderedblock-bg);
+        --note-text: var(--text);
+        --noteheading-text: hsl(120, 70%, 70%);
+        --notesummary-underline: silver;
+
+        --assertion-border: #444;
+        --assertion-bg: var(--borderedblock-bg);
+        --assertion-text: var(--text);
+
+        --advisement-border: orange;
+        --advisement-bg: #222218;
+        --advisement-text: var(--text);
+        --advisementheading-text: #f84;
+
+        --warning-border: red;
+        --warning-bg: hsla(40,100%,20%,0.95);
+        --warning-text: var(--text);
+
+        --amendment-border: #330099;
+        --amendment-bg: #080010;
+        --amendment-text: var(--text);
+        --amendmentheading-text: #cc00ff;
+
+        --def-border: #8ccbf2;
+        --def-bg: #080818;
+        --def-text: var(--text);
+        --defrow-border: #136;
+
+        --datacell-border: silver;
+
+        --indexinfo-text: #aaa;
+
+        --indextable-hover-text: var(--text);
+        --indextable-hover-bg: #181818;
+
+        --outdatedspec-bg: rgba(255, 255, 255, .5);
+        --outdatedspec-text: black;
+        --outdated-bg: maroon;
+        --outdated-text: white;
+        --outdated-shadow: red;
+
+        --editedrec-bg: darkorange;
+    }
+    /* In case a transparent-bg image doesn't expect to be on a dark bg,
+       which is quite common in practice... */
+    img { background: white; }
+}
+</style>
+<style>/* Boilerplate: style-counters */
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}
+</style>
+<style>/* Boilerplate: style-issues */
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* Boilerplate: style-line-highlighting */
+:root {
+    --highlight-hover-bg: rgba(0, 0, 0, .05);
+}
+.line-numbered {
+    display: grid !important;
+    grid-template-columns: min-content 1fr;
+    grid-auto-flow: rows;
+}
+.line-numbered > *,
+.line-numbered::before,
+.line-numbered::after {
+    grid-column: 1/-1;
+}
+.line-no {
+    grid-column: 1;
+    color: gray;
+}
+.line {
+    grid-column: 2;
+}
+.line.highlight-line {
+    background: var(--highlight-hover-bg);
+}
+.line-no.highlight-line {
+    background: var(--highlight-hover-bg);
+    color: #444;
+    font-weight: bold;
+}
+.line-no.highlight-line[data-line]::before {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line);
+}
+.line-no.highlight-line[data-line-end]::after {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line-end);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --highlight-hover-bg: rgba(255, 255, 255, .05);
+    }
+}
+</style>
+<style>/* Boilerplate: style-md-lists */
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}
+</style>
+<style>/* Boilerplate: style-selflinks */
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+@media (prefers-color-scheme: dark) {
+    .highlight:not(.idl) { background: rgba(255, 255, 255, .05); }
+
+    c-[a] { color: #d33682 } /* Keyword.Declaration */
+    c-[b] { color: #d33682 } /* Keyword.Type */
+    c-[c] { color: #2aa198 } /* Comment */
+    c-[d] { color: #2aa198 } /* Comment.Multiline */
+    c-[e] { color: #268bd2 } /* Name.Attribute */
+    c-[f] { color: #b58900 } /* Name.Tag */
+    c-[g] { color: #cb4b16 } /* Name.Variable */
+    c-[k] { color: #d33682 } /* Keyword */
+    c-[l] { color: #657b83 } /* Literal */
+    c-[m] { color: #657b83 } /* Literal.Number */
+    c-[n] { color: #268bd2 } /* Name */
+    c-[o] { color: #657b83 } /* Operator */
+    c-[p] { color: #657b83 } /* Punctuation */
+    c-[s] { color: #6c71c4 } /* Literal.String */
+    c-[t] { color: #6c71c4 } /* Literal.String.Single */
+    c-[u] { color: #6c71c4 } /* Literal.String.Double */
+    c-[ch] { color: #2aa198 } /* Comment.Hashbang */
+    c-[cp] { color: #2aa198 } /* Comment.Preproc */
+    c-[cpf] { color: #2aa198 } /* Comment.PreprocFile */
+    c-[c1] { color: #2aa198 } /* Comment.Single */
+    c-[cs] { color: #2aa198 } /* Comment.Special */
+    c-[kc] { color: #d33682 } /* Keyword.Constant */
+    c-[kn] { color: #d33682 } /* Keyword.Namespace */
+    c-[kp] { color: #d33682 } /* Keyword.Pseudo */
+    c-[kr] { color: #d33682 } /* Keyword.Reserved */
+    c-[ld] { color: #657b83 } /* Literal.Date */
+    c-[nc] { color: #268bd2 } /* Name.Class */
+    c-[no] { color: #268bd2 } /* Name.Constant */
+    c-[nd] { color: #268bd2 } /* Name.Decorator */
+    c-[ni] { color: #268bd2 } /* Name.Entity */
+    c-[ne] { color: #268bd2 } /* Name.Exception */
+    c-[nf] { color: #268bd2 } /* Name.Function */
+    c-[nl] { color: #268bd2 } /* Name.Label */
+    c-[nn] { color: #268bd2 } /* Name.Namespace */
+    c-[py] { color: #268bd2 } /* Name.Property */
+    c-[ow] { color: #657b83 } /* Operator.Word */
+    c-[mb] { color: #657b83 } /* Literal.Number.Bin */
+    c-[mf] { color: #657b83 } /* Literal.Number.Float */
+    c-[mh] { color: #657b83 } /* Literal.Number.Hex */
+    c-[mi] { color: #657b83 } /* Literal.Number.Integer */
+    c-[mo] { color: #657b83 } /* Literal.Number.Oct */
+    c-[sa] { color: #6c71c4 } /* Literal.String.Affix */
+    c-[sb] { color: #6c71c4 } /* Literal.String.Backtick */
+    c-[sc] { color: #6c71c4 } /* Literal.String.Char */
+    c-[dl] { color: #6c71c4 } /* Literal.String.Delimiter */
+    c-[sd] { color: #6c71c4 } /* Literal.String.Doc */
+    c-[se] { color: #6c71c4 } /* Literal.String.Escape */
+    c-[sh] { color: #6c71c4 } /* Literal.String.Heredoc */
+    c-[si] { color: #6c71c4 } /* Literal.String.Interpol */
+    c-[sx] { color: #6c71c4 } /* Literal.String.Other */
+    c-[sr] { color: #6c71c4 } /* Literal.String.Regex */
+    c-[ss] { color: #6c71c4 } /* Literal.String.Symbol */
+    c-[fm] { color: #268bd2 } /* Name.Function.Magic */
+    c-[vc] { color: #cb4b16 } /* Name.Variable.Class */
+    c-[vg] { color: #cb4b16 } /* Name.Variable.Global */
+    c-[vi] { color: #cb4b16 } /* Name.Variable.Instance */
+    c-[vm] { color: #cb4b16 } /* Name.Variable.Magic */
+    c-[il] { color: #657b83 } /* Literal.Number.Integer.Long */
+}
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">Solid Application Interoperability - Authorization Agent Primer</h1>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2025-09-16">16 September 2025</time></p>
+   <details open>
+    <summary>More details about this document</summary>
+    <div data-fill-with="spec-metadata">
+     <dl>
+      <dt>This version:
+      <dd><a class="u-url" href="https://solidproject.org/TR/tag/sai-primer-authorization-agent-v0.1">https://solidproject.org/TR/tag/sai-primer-authorization-agent-v0.1</a>
+      <dt>Latest published version:
+      <dd><a href="https://solidproject.org/TR/sai-primer-authorization-agent">https://solidproject.org/TR/sai-primer-authorization-agent</a>
+      <dt>Feedback:
+      <dd><a href="https://github.com/solid/data-interoperability-panel/issues/">GitHub</a>
+      <dt class="editor">Editor:
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">elf Pavlik</span>
+      <dt>Version:
+      <dd>0.1
+     </dl>
+    </div>
+   </details>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">Copyright © 2025 the Contributors to the Solid Application Interoperability - Authorization Agent Primer,
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This report was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+  Learn more about <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#shape-tree"><span class="secno">2</span> <span class="content">Shape Tree</span></a>
+    <li><a href="#registry-set"><span class="secno">3</span> <span class="content">Registry Set</span></a>
+    <li>
+     <a href="#data-registry"><span class="secno">4</span> <span class="content">Data Registry</span></a>
+     <ol class="toc">
+      <li><a href="#data-registration"><span class="secno">4.1</span> <span class="content">Data Registration</span></a>
+      <li><a href="#data-instance"><span class="secno">4.2</span> <span class="content">Data Instance</span></a>
+     </ol>
+    <li>
+     <a href="#authorization-registry"><span class="secno">5</span> <span class="content">Authorization Registry</span></a>
+     <ol class="toc">
+      <li><a href="#access-authorization"><span class="secno">5.1</span> <span class="content">Access Authorization</span></a>
+      <li>
+       <a href="#data-authorization"><span class="secno">5.2</span> <span class="content">Data Authorization</span></a>
+       <ol class="toc">
+        <li><a href="#data-authorization-scopes"><span class="secno">5.2.1</span> <span class="content">Scopes</span></a>
+       </ol>
+     </ol>
+    <li>
+     <a href="#agent-registry"><span class="secno">6</span> <span class="content">Agent Registry</span></a>
+     <ol class="toc">
+      <li><a href="#agent-registration"><span class="secno">6.1</span> <span class="content">Agent Registration</span></a>
+      <li>
+       <a href="#social-agent-registration"><span class="secno">6.2</span> <span class="content">Social Agent Registration</span></a>
+       <ol class="toc">
+        <li><a href="#reciprocal-registration"><span class="secno">6.2.1</span> <span class="content">Reciprocal Registration</span></a>
+       </ol>
+      <li><a href="#social-agent-invitation"><span class="secno">6.3</span> <span class="content">Social Agent Invitation</span></a>
+      <li><a href="#application-registration"><span class="secno">6.4</span> <span class="content">Application Registration</span></a>
+      <li><a href="#agent-registration-discovery"><span class="secno">6.5</span> <span class="content">Agent Registration Discovery</span></a>
+      <li><a href="#access-grant"><span class="secno">6.6</span> <span class="content">Access Grant</span></a>
+      <li>
+       <a href="#data-grant"><span class="secno">6.7</span> <span class="content">Data Grant</span></a>
+       <ol class="toc">
+        <li><a href="#data-grant-scopes"><span class="secno">6.7.1</span> <span class="content">Scopes</span></a>
+        <li><a href="#data-grant-inheritance"><span class="secno">6.7.2</span> <span class="content">Inheritance</span></a>
+        <li><a href="#data-grant-delegation"><span class="secno">6.7.3</span> <span class="content">Delegation</span></a>
+       </ol>
+      <li><a href="#access-receipt"><span class="secno">6.8</span> <span class="content">Access Receipt</span></a>
+      <li><a href="#access-need-group"><span class="secno">6.9</span> <span class="content">Access Need Group</span></a>
+      <li><a href="#access-need"><span class="secno">6.10</span> <span class="content">Access Need</span></a>
+     </ol>
+    <li><a href="#gathering-authorizations"><span class="secno">7</span> <span class="content">Gathering Authorizations from the user</span></a>
+    <li><a href="#resource-indication"><span class="secno">8</span> <span class="content">Sharing resources indicated by the application</span></a>
+    <li><a href="#generating-grants-from-authorizations"><span class="secno">9</span> <span class="content">Generating Access Grant from Access Authorization</span></a>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+   </ol>
+  </nav>
+  <main>
+<script type="application/ld+json">
+{
+  "@context": {
+    "spec": "http://www.w3.org/ns/spec#",
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "author": { "@id": "schema:author", "@type": "@id" },
+    "editor": { "@id": "schema:editor", "@type": "@id" }
+  },
+  "@id": "https://solidproject.org/TR/sai-primer-authorization-agent",
+  "@type": "spec:Primer",
+  "name": "SAI Authorization Agent Primer",
+  "author": [
+    "https://elf-pavlik.hackers4peace.net"
+  ],
+  "editor": [
+    "https://elf-pavlik.hackers4peace.net"
+  ]
+}
+</script>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p>This primer is intended to accompany <a data-link-type="biblio" href="#biblio-sai" title="Solid Application Interoperability">[SAI]</a>.
+It is focused on providing a friendly introduction for developers of libraries intended
+for solid authorization agents.</p>
+   <p>This document was developed alongside the open-source TypeScript implementation <a data-link-type="biblio" href="#biblio-sai-js" title="Solid Application Interoperability - TypeScript implementation">[SAI-JS]</a> and open-source Java implementation <a data-link-type="biblio" href="#biblio-sai-java" title="Solid Application Interoperability - Java implementation">[SAI-JAVA]</a>.</p>
+   <h2 class="heading settled" data-level="2" id="shape-tree"><span class="secno">2. </span><span class="content">Shape Tree</span><a class="self-link" href="#shape-tree"></a></h2>
+   <p>Shape Trees <a data-link-type="biblio" href="#biblio-shapetrees" title="Shape Trees">[SHAPETREES]</a> allow  for the definition and validation of data hierarchies
+including which shapes <a data-link-type="biblio" href="#biblio-shex" title="Shape Expressions Language 2.1">[SHEX]</a> should be used to validate data.
+In our examples, we are going to use the following Shapes and Shape Trees.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>references</c-> <c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c-> <c- p>.</c->
+
+<c- nn>uuid</c-><c- p>:</c-><c- f>54b5e4f6-c6b5-4c9a-b885-cbf69d08370d</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>viaShapePath</c->
+    <c- s>"@&lt;https://solidshapes.example/shapes/Project>~&lt;https://vocab.example/project-management/hasTask>"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Project shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Project</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c-> <c- k>IRI</c-> <c- o>*</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Project shape (ShEx)</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidtrees</c-><c- p>:</c-><c- f>Task</c->
+  <c- b>a</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>shapetrees</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>shapetrees</c-><c- p>:</c-><c- f>shape</c-> <c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>.</c->
+</pre>
+    <figcaption>Task shape tree</figcaption>
+   </figure>
+   <figure>
+<pre class="include-code highlight"><c- nn>solidshapes</c-><c- p>:</c-><c- f>Task</c-> <c- p>{</c->
+  <c- k>a</c-> <c- p>[</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Task</c-> <c- p>]</c-> <c- p>;</c->
+  <c- nn>rdfs</c-><c- p>:</c-><c- f>label</c-> <c- nn>xsd</c-><c- p>:</c-><c- f>string</c->
+<c- p>}</c->
+</pre>
+    <figcaption>Task shape (ShEx)</figcaption>
+   </figure>
+   <p class="issue" id="issue-f026f3dd"><a class="self-link" href="#issue-f026f3dd"></a> Reference shape path documentation</p>
+   <h2 class="heading settled" data-level="3" id="registry-set"><span class="secno">3. </span><span class="content">Registry Set</span><a class="self-link" href="#registry-set"></a></h2>
+   <p>Authorization Agent uses a set of different registries to perform its dutes. Specificaly,</p>
+   <ul>
+    <li data-md>
+     <p>one or more <a href="#data-registry">§ 4 Data Registry</a>,</p>
+    <li data-md>
+     <p>one <a href="#authorization-registry">§ 5 Authorization Registry</a>,</p>
+    <li data-md>
+     <p>one <a href="#agent-registry">§ 6 Agent Registry</a>,</p>
+   </ul>
+   <p>each one of them is described in a dedicated section.</p>
+   <p>The Registry Set can be discovered from a social agent’s WebID Profile using <code>interop:hasRegistrySet</code> predicate.</p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>13e60d32-77a6-4239-864d-cfe2c90807c8</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- g>&lt;https://auth.alice.example/></c-> <c- p>.</c-></span></pre>
+    <figcaption>Alice’s WebID document</figcaption>
+   </figure>
+   <p>While WebID Profile is readable to the public, Registry Set should only be readable by its owner
+and their Authorization Agent.</p>
+   <p><img class="flowchart-diagram" src="diagrams/registry-set.flow.mmd.png"></p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>13e60d32-77a6-4239-864d-cfe2c90807c8</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>RegistrySet</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAgentRegistry</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>1cf3e08b-ffe2-465a-ac5b-94ce165cb8f0</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessConsentRegistry</c-> <c- nn>alice-auth</c-><c- p>:</c-><c- f>96feb105-063e-4996-ab74-5e504c6ceae5</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistry</c->
+    <c- nn>alice-pro</c-><c- p>:</c-><c- f>71e96aaa-f3dc-4263-97d6-a5b4c83524cb</c-> <c- p>,</c->
+    <c- nn>alice-home</c-><c- p>:</c-><c- f>2d3d97b4-a26d-434e-afa2-e3bc8e8e2b56</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s Registry Set</figcaption>
+   </figure>
+   <h2 class="heading settled" data-level="4" id="data-registry"><span class="secno">4. </span><span class="content">Data Registry</span><a class="self-link" href="#data-registry"></a></h2>
+   <p>A Data Registry is a collection of Data Registrations, each of which represents a unique type of data,
+identified by a shape tree.</p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-pro</c-><c- p>:</c-><c- f>71e96aaa-f3dc-4263-97d6-a5b4c83524cb</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistration</c->
+    <c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-> <c- p>,</c->
+    <c- nn>alice-pro</c-><c- p>:</c-><c- f>4d594c61-7cff-484a-a1d2-1f353ee4e1e7</c-> <c- p>.</c->
+</pre>
+    <figcaption>one of Alice’s Data Registries</figcaption>
+   </figure>
+   <p>In a Data Registry, there can be at most one Data Registration for any given shape tree.</p>
+   <h3 class="heading settled" data-level="4.1" id="data-registration"><span class="secno">4.1. </span><span class="content">Data Registration</span><a class="self-link" href="#data-registration"></a></h3>
+   <p>Data Registration is a container, which contains Data Instances. Each of those Data Instances conforms to one specific
+shape tree assigned to the Data Registration.</p>
+   <p><img class="flowchart-diagram" src="diagrams/pro.alice.example.flow.mmd.png"></p>
+   <figure>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-10-17T11:42:35.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- g>&lt;https://solidmin.example/#app></c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>ldp</c-><c- p>:</c-><c- f>contains</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>ccbd77ae-f769-4e07-b41f-5136501e13e7\#project</c-> <c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c-></span></pre>
+    <figcaption>Data Registration for projects in one of Alice’s Data Registries</figcaption>
+   </figure>
+   <dl>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by this Data Registration</p>
+   </dl>
+   <h3 class="heading settled" data-level="4.2" id="data-instance"><span class="secno">4.2. </span><span class="content">Data Instance</span><a class="self-link" href="#data-instance"></a></h3>
+   <p>Data Instance is a resource representing something specific, for example, a project or a task.
+An Authorization Agent is not responsible for modifying data instances. Sometimes it still needs to access them
+during <a href="#gathering-authorizations">§ 7 Gathering Authorizations from the user</a> if the user wants to select specific data instances.</p>
+   <h2 class="heading settled" data-level="5" id="authorization-registry"><span class="secno">5. </span><span class="content">Authorization Registry</span><a class="self-link" href="#authorization-registry"></a></h2>
+   <p>Authorization Registry is a container, which contains Access Authorizations.
+Each of those Access Authorizations is created for a specific grantee,
+and groups together one or more Data Authorizations.</p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>96feb105-063e-4996-ab74-5e504c6ceae5</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessConsentRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessConsent</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>eac2c39c-c8b3-4880-8b9f-a3e12f7f6372</c-> <c- p>,</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>75a2ef88-d4d4-4f05-af1e-c2a63af08cab</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s Authorization Registry</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="5.1" id="access-authorization"><span class="secno">5.1. </span><span class="content">Access Authorization</span><a class="self-link" href="#access-authorization"></a></h3>
+   <p>Access Authorization groups one or more <a href="#data-authorization"> data authorizations</a>.
+Together they represent the whole access granted by a social agent to another agent.
+One of the primary responsibilities of the authorization agent is <a href="#generating-grants-from-authorizations">§ 9 Generating Access Grant from Access Authorization</a>.</p>
+   <p>An Access Authorization is immutable, it never gets updated, instead it can be only replaced
+with a newer Access Authorization.</p>
+   <h3 class="heading settled" data-level="5.2" id="data-authorization"><span class="secno">5.2. </span><span class="content">Data Authorization</span><a class="self-link" href="#data-authorization"></a></h3>
+   <p>Data Authorization, similar to <a href="#data-grant">§ 6.7 Data Grant</a>, represents access granted by a specific Social Agent.
+It is always associated with a specific <a href="#shape-tree">§ 2 Shape Tree</a>. Depending on its scope it can apply to all the
+Data Instances in any number of Data Registrations. In that case, <code>interop:hasDataRegistration</code> will not be specified.</p>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>e2765d6c-848a-4fc0-9092-556903730263</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataConsent</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- g>&lt;https://jarvis.alice.example/#agent></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- g>&lt;https://projectron.example/#app></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- g>&lt;https://acme.example/#corp></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Write</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfConsent</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromAgent</c-> <c- p>.</c->
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>6a9feb57-252b-43b2-8470-5a938888b2fa</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromConsent</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>e2765d6c-848a-4fc0-9092-556903730263</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s data authorization for Projectron to ACME’s Projects</figcaption>
+   </figure>
+   <p>A Data Authorization is immutable, it never gets updated, instead it can be only replaced
+with a newer Data Authorization.</p>
+   <h4 class="heading settled" data-level="5.2.1" id="data-authorization-scopes"><span class="secno">5.2.1. </span><span class="content">Scopes</span><a class="self-link" href="#data-authorization-scopes"></a></h4>
+   <p>Data Authorization can have one of five scopes:</p>
+   <dl>
+    <dt data-md>All
+    <dd data-md>
+     <p>All the Data Instances in all the Data Registration the End-user has access to.
+This includes ones owned by the End-user as well as ones owned by others, where End-user has been granted access.</p>
+    <dt data-md>AllFromAgent
+    <dd data-md>
+     <p>All the Data Instances in all the Data Registrations, owned by a specific social agent.
+This could be the End-user themselves or any other social agent who granted access to the End-user.</p>
+   </dl>
+   <p>Plus all the <a href="#data-grant-scopes"> Data Grant Scopes</a></p>
+   <h2 class="heading settled" data-level="6" id="agent-registry"><span class="secno">6. </span><span class="content">Agent Registry</span><a class="self-link" href="#agent-registry"></a></h2>
+   <figure>
+<pre class="include-code highlight">
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>1cf3e08b-ffe2-465a-ac5b-94ce165cb8f0</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AgentRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasSocialAgentRegistration</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>b1f69979-dd47-4709-b2ed-a7119f29b135</c-> <c- p>,</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>5dc3c14e-7830-475f-b8e3-4748d6c0bccb</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasApplicationRegistration</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>bcf22534-0187-4ae4-b88f-fe0f9fa96659</c-> <c- p>,</c->
+    <c- nn>alice-auth</c-><c- p>:</c-><c- f>170c12ac-7d4f-47fe-b36d-7a9944c429d9</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s Authorization Registry</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="6.1" id="agent-registration"><span class="secno">6.1. </span><span class="content">Agent Registration</span><a class="self-link" href="#agent-registration"></a></h3>
+   <p>There can be only one Agent Registration for any given agent in Agent Registry.
+Its main purpose is to make <a href="#access-grant">§ 6.6 Access Grant</a> available to the registered agent.</p>
+   <h3 class="heading settled" data-level="6.2" id="social-agent-registration"><span class="secno">6.2. </span><span class="content">Social Agent Registration</span><a class="self-link" href="#social-agent-registration"></a></h3>
+   <p>Social Agent Registration is created for a Social Agent. Besides <a href="#access-grant">§ 6.6 Access Grant</a> it can also reference a <a href="#reciprocal-registration">§ 6.2.1 Reciprocal Registration</a>.</p>
+   <h4 class="heading settled" data-level="6.2.1" id="reciprocal-registration"><span class="secno">6.2.1. </span><span class="content">Reciprocal Registration</span><a class="self-link" href="#reciprocal-registration"></a></h4>
+   <p>The reference to reciprocal registration can be created after receiving an <a href="#access-receipt">§ 6.8 Access Receipt</a> from another Social Agent and performing <a href="#agent-registration-discovery">§ 6.5 Agent Registration Discovery</a></p>
+   <p>In the case of Social Agent Registration for ACME, created in Alice’s Agent Registry. The reciprocal registration
+will be the Social Agent Reigstration for Alice, created in ACME’s Agent Registry.</p>
+   <p><img class="flowchart-diagram" src="diagrams/reciprocal-registration.flow.mmd.png"></p>
+   <h3 class="heading settled" data-level="6.3" id="social-agent-invitation"><span class="secno">6.3. </span><span class="content">Social Agent Invitation</span><a class="self-link" href="#social-agent-invitation"></a></h3>
+   <p>Social Agent Invitation represents an invitation for a Social Agent. It takes advantage of an existing and secure
+communication channel between two agents to pass a secret link that allows accepting the invitation.
+This flow results in both agents establishing a pair of <a href="#reciprocal-registration">Reciprocal Registrations</a>.
+If the platform supports it, the Authorization Agent of the sender can use <a data-link-type="biblio" href="#biblio-web-share" title="Web Share API">[WEB-SHARE]</a> to pass the secret
+link to the user’s messaging app. On the other side, the Authorization Agent of the recipient can use <a data-link-type="biblio" href="#biblio-web-share-target" title="Web Share Target API">[WEB-SHARE-TARGET]</a> to register with the platform and receive a secret link from the user’s messaging app.
+Independent of the platform, Authorization Agents should always allow a simple copy of the link by the sender
+(e.g., <code>navigator.clipboard.writeText</code>) and paste it by the recipient.</p>
+   <h3 class="heading settled" data-level="6.4" id="application-registration"><span class="secno">6.4. </span><span class="content">Application Registration</span><a class="self-link" href="#application-registration"></a></h3>
+   <p>Application Registrations are created by the End-user for applications they use.
+Since applications do not own or share data, they will never have a [#reciprocal-registration].</p>
+   <h3 class="heading settled" data-level="6.5" id="agent-registration-discovery"><span class="secno">6.5. </span><span class="content">Agent Registration Discovery</span><a class="self-link" href="#agent-registration-discovery"></a></h3>
+   <p>Both Social Agent and Application can discover Agent Registration created for them,
+by performing <code>HEAD</code> or <code>GET</code> request on IRI denoting
+the Authorization Agent. Response will include HTTP Link header relating
+Agent Registration to the agent making the request using <code>http://www.w3.org/ns/solid/interop#registeredAgent</code> as link relation.</p>
+   <p>In a case where End-user using an application performs the discovery on their
+own Authorization Agent. The response will include a link to the Application registration.</p>
+   <figure>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>auth.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://projectron.example/#app>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://auth.alice.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+    <figcaption>HEAD request to and response from End-user’s Authorization Agent</figcaption>
+   </figure>
+   <p>In the case where the client acting on behalf of one social agent, performs the discovery on
+another’s social agent Authorization Agent. The response will include a link to Social Agent Registration.</p>
+   <figure>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>auth.alice.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://bob.example/#id>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://auth.alice.example/92868ad4-a9e6-42df-9cb0-883350c62769";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+    <figcaption>HEAD request to and response from someone else’s Authorization Agent</figcaption>
+   </figure>
+   <h3 class="heading settled" data-level="6.6" id="access-grant"><span class="secno">6.6. </span><span class="content">Access Grant</span><a class="self-link" href="#access-grant"></a></h3>
+   <p>An Access Grant groups together all the Data Grants provided for a specific agent.</p>
+   <p>An Access Grant is immutable — it never gets updated; it can only be replaced, by a newer Access Grant.</p>
+   <h3 class="heading settled" data-level="6.7" id="data-grant"><span class="secno">6.7. </span><span class="content">Data Grant</span><a class="self-link" href="#data-grant"></a></h3>
+   <p>Each Data grant represents access granted by specific Social Agent, to all or selected
+Data Instances in specific Data Registration.</p>
+   <figure>
+<pre class="include-code highlight"><c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- g>&lt;https://alice.example/#id></c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>solidtrees</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Write</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c->
+      <c- nn>alice-pro</c-><c- p>:</c-><c- f>7a130c38-668a-4775-821a-08b38f2306fb\#project</c-> <c- p>.</c->
+
+<c- nn>alice-auth</c-><c- p>:</c-><c- f>9827ae00-2778-4655-9f22-08bb9daaee26</c->
+    <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c->
+      <c- nn>alice-auth</c-><c- p>:</c-><c- f>cd247a67-0879-4301-abd0-828f63abb252</c-> <c- p>.</c->
+
+<c- nn>alice-pro</c-><c- p>:</c-><c- f>773605f0-b5bf-4d46-878d-5c167eac8b5d</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>iriPrefix</c-> <c- s>"https://pro.alice.example/"</c-> <c- p>.</c->
+</pre>
+    <figcaption>Alice’s data grant for Projectron - Pro Projects</figcaption>
+   </figure>
+   <p>A Data Grant is immutable, it never gets updated, instead it can be only replaced
+with a newer Data Grant.</p>
+   <p>Data Grant can be consider as the most important data structure, it provides following information:</p>
+   <dl>
+    <dt data-md>dataOwner
+    <dd data-md>
+     <p>Social Agent who owns the data</p>
+    <dt data-md>grantedBy
+    <dd data-md>
+     <p>Social Agent who granted the access</p>
+    <dt data-md>registeredShapeTree
+    <dd data-md>
+     <p>Shape Tree used by related Data Registration</p>
+    <dt data-md>hasDataRegistration
+    <dd data-md>
+     <p>Data Registration that this Data Grant applies to. As well as <code>iriPrefix</code> of that Data Registration (see <a href="#data-registration">§ 4.1 Data Registration</a>)</p>
+    <dt data-md>accessMode
+    <dd data-md>
+     <p>List of access modes defining what application can do with the data</p>
+    <dt data-md>scopeOfGrant
+    <dd data-md>
+     <p>Defines which instances can be accessed (see <a href="#data-grant-scopes">§ 6.7.1 Scopes</a>)</p>
+    <dt data-md>inheritsFromGrant
+    <dd data-md>
+     <p>If grant has <code>InheritInstances</code> scope, it will be the Data Grant for Data Registraion with parent Data Instances (see <a href="#data-grant-inheritance">§ 6.7.2 Inheritance</a>)</p>
+    <dt data-md>hasDataInstance
+    <dd data-md>
+     <p>If grant has <code>SelectedInstances</code> scope, it will be all the Data Instances that application can access in the Data Registration</p>
+    <dt data-md>delegationOfGrant
+    <dd data-md>
+     <p>If Data Grant is issued by Social Agent other than data owner, it will be the original Data Grant issued by the data owner (see <a href="#data-grant-delegation">§ 6.7.3 Delegation</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="6.7.1" id="data-grant-scopes"><span class="secno">6.7.1. </span><span class="content">Scopes</span><a class="self-link" href="#data-grant-scopes"></a></h4>
+   <p>Data Grant can have one of three scopes:</p>
+   <dl>
+    <dt data-md>AllFromRegistry
+    <dd data-md>
+     <p>All the Data Instances in the Data Registration. Application will be able to access the Data Registration and see the list of all contained instances (see <a href="#data-registration">§ 4.1 Data Registration</a>)</p>
+    <dt data-md>SelectedFromRegistry
+    <dd data-md>
+     <p>Only specific Data Instances in the Data Registration. Application will not be able to access the Data Registration, so it will not see the list al all contained instances. Instad list of selected Data Instances is available via <code>hasDataInstance</code></p>
+    <dt data-md>Inherited
+    <dd data-md>
+     <p>Only those Data Instances in the Data Registration, which are related to parent kData Instances in Data Registration of the Data Grant referenced with <code>inheritsFromGrant</code> (see <a href="#data-grant-inheritance">§ 6.7.2 Inheritance</a>)</p>
+   </dl>
+   <h4 class="heading settled" data-level="6.7.2" id="data-grant-inheritance"><span class="secno">6.7.2. </span><span class="content">Inheritance</span><a class="self-link" href="#data-grant-inheritance"></a></h4>
+   <p><code>InheritInstances</code> Data Grant doesn’t provide access to the Data Registration, so
+application can’t get the list of all the Data Instances. Neither it provides a list of specific
+Data Instances in the Data Registration.</p>
+   <p>To find Data Instances from that Data Registration, application first needs to access parent
+Data Instances from Data Registration which Data Grant referenced by <code>inheritsFromGrant</code> makes accessible. Based on shape tree definition, each parent Data Instance will reference all its
+child Data Instances.</p>
+   <p>Both parent and child Data Registrations have to be in the same Data Registry. Since only one
+Data Registration for specific shape tree can be created in any given Data Registry.
+All parent Data Instances are from one Data Registration and all child Data Instances are from
+one Data Registration.</p>
+   <h4 class="heading settled" data-level="6.7.3" id="data-grant-delegation"><span class="secno">6.7.3. </span><span class="content">Delegation</span><a class="self-link" href="#data-grant-delegation"></a></h4>
+   <p>Application doesn’t need to handle delegated Data Grants in any special way.
+To know if Data Grant was issued by currently logged in user or someone else,
+application should rely on <code>dataOwner</code> information in the Data Grant.</p>
+   <div class="issue no-marker" id="issue-d41d8cd9"><a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a></div>
+   <h3 class="heading settled" data-level="6.8" id="access-receipt"><span class="secno">6.8. </span><span class="content">Access Receipt</span><a class="self-link" href="#access-receipt"></a></h3>
+   <p>Access Receipt helps to establish data sharing between two social agents. Once received the authorization agent
+should prompt the user to approve creating <a href="#social-agent-registration">§ 6.2 Social Agent Registration</a> for that data owner.
+If user approves <a href="#reciprocal-registration">§ 6.2.1 Reciprocal Registration</a> can be associated and subscription for notifications established
+to keep track on the latest <a href="#access-grant">§ 6.6 Access Grant</a>. Once reciprocal registration gets associated there is no
+further need for its data owner to send access receipts to the agent registered in that reciprocal registration.</p>
+   <div class="issue no-marker" id="issue-d41d8cd9①"><a class="self-link" href="#issue-d41d8cd9①"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/238" style="text-transform:none">solid/data-interoperability-panel/238</a><a href="https://github.com/solid/data-interoperability-panel/issues/238">Sharing access between social agents</a></div>
+   <h3 class="heading settled" data-level="6.9" id="access-need-group"><span class="secno">6.9. </span><span class="content">Access Need Group</span><a class="self-link" href="#access-need-group"></a></h3>
+   <p>An Access Need Group is a collection of Access Needs used to communicate an access request to Social Agents.</p>
+   <p>An Authorization Agent uses them during <a href="#gathering-authorizations">§ 7 Gathering Authorizations from the user</a>.</p>
+   <h3 class="heading settled" data-level="6.10" id="access-need"><span class="secno">6.10. </span><span class="content">Access Need</span><a class="self-link" href="#access-need"></a></h3>
+   <p>An Access Need represents the requirement of one specific type of data represented by a shape tree,
+as part of an Access Need Group.</p>
+   <p class="issue" id="issue-a0664d99"><a class="self-link" href="#issue-a0664d99"></a> Complete this section based on implementation of UI for Authorization Agent Service</p>
+   <h2 class="heading settled" data-level="7" id="gathering-authorizations"><span class="secno">7. </span><span class="content">Gathering Authorizations from the user</span><a class="self-link" href="#gathering-authorizations"></a></h2>
+   <p>The most common case is authorizing an application based on its <a href="#access-need">§ 6.10 Access Need</a>.
+The authorization screen should combine those Access Needs with existing <a href="#access-authorization">§ 5.1 Access Authorization</a> if one exists.
+It should also assist the user in composing new Access Authorization, taking into account all their:</p>
+   <ul>
+    <li data-md>
+     <p>Data Registries with Data Registrations and Data Instances</p>
+    <li data-md>
+     <p><a href="#access-grant">§ 6.6 Access Grant</a> with <a href="#data-grant">§ 6.7 Data Grant</a> others issued to them (available via all the <a href="#reciprocal-registration">§ 6.2.1 Reciprocal Registration</a>)</p>
+   </ul>
+   <p><img src="images/authorization-screen.svg" width="100%"></p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice finds an Application called Projectron that she’d like
+            to use to manage her Projects and Tasks.
+      <tr>
+       <td><b>2</b>
+       <td>Alice authenticates to Projectron with her WebID.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron dereferences her WebID and retrieves Authorization Agent from her WebID Profile Document.
+      <tr>
+       <td><b>4</b>
+       <td>Projectron asks Alice’s Authorization Agent whether Alice already has an Application Registration for Projectron.
+      <tr>
+       <td><b>5</b>
+       <td>Alice’s Authorization Agent checks the Agent Registry in Alice’s Pod for a Projectron Application Registration.
+      <tr>
+       <td><b>6</b>
+       <td>No Application Registration for Projectron is found.
+          Projectron now knows that Alice hasn’t given it permission to access her data, so it must ask.
+      <tr>
+       <td><b>7</b>
+       <td>Projectron redirects Alice to her Authorization Agent, supplying its identifier for context.
+      <tr>
+       <td><b>8</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron identifier, retrieving Projectron’s
+          Application profile graph and corresponding Access Need Groups from the WebID Profile Document,
+          as well as <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>9</b>
+       <td>Alice’s Authorization Agent presents the Access Need Groups from Projectron’s Application
+          profile graph, so that Alice understands what kind of data is being requested, and why.
+      <tr>
+       <td><b>10</b>
+       <td>Alice’s chooses the scope of access that Projectron will receive, to the data to 
+          which it has asked for access via the presented Access Needs.
+      <tr>
+       <td><b>11-13</b>
+       <td>Alice’s Authorization Agent records her decision as an Access Authorization in Alice’s
+            Authorization Registry. An Application Registration is created for Projectron in
+            Alice’s Agent Registry. An Access Grant and corresponding Data Grants are generated
+            from the Access Authorization and stored in the Projectron Application Registration. 
+      <tr>
+       <td><b>14</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the appropriate access has been granted.
+      <tr>
+       <td><b>15</b>
+       <td>Projectron again asks Alice’s Authorization Agent for a Projectron Application Registration.
+      <tr>
+       <td><b>16</b>
+       <td>Alice’s Authorization Agent finds the newly created Projectron Application Registration in the Agent Registry in Alice’s Pod.
+      <tr>
+       <td><b>17</b>
+       <td>Alice’s Authorization Agent provides the URI of the Application Registration to Projectron.
+      <tr>
+       <td><b>18</b>
+       <td>Projectron learns what access it received through the Access Grant in Alice’s Projectron Application Registration.
+      <tr>
+       <td><b>19</b>
+       <td>Projectron may now function as intended, within the scope of authorization it was given by Alice.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/application-requests-access-flow.seq.mmd.svg"></p>
+   <h2 class="heading settled" data-level="8" id="resource-indication"><span class="secno">8. </span><span class="content">Sharing resources indicated by the application</span><a class="self-link" href="#resource-indication"></a></h2>
+   <p>When the application has already been registered, and the user wants to
+initiate a sharing-specific <a href="#data-instance">§ 4.2 Data Instance</a>, an authorization flow with resource
+indication is available.</p>
+   <figure>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Step
+       <th>Description
+     <tbody>
+      <tr>
+       <td><b>1</b>
+       <td>Alice’s is authenticated with Projectron.
+      <tr>
+       <td><b>2</b>
+       <td>Alice has already authorized Projectron.
+      <tr>
+       <td><b>3</b>
+       <td>Projectron has read its Access Grant and displayed projects.
+      <tr>
+       <td><b>4</b>
+       <td>Alice initiates sharing of a specific project.
+      <tr>
+       <td><b>5</b>
+       <td>Projectron redirects Alice to her Authorization Agent, indicating the selected project.
+      <tr>
+       <td><b>6-8</b>
+       <td>Alice’s Authorization Agent fetches the indicated project and checks who already has access to it.
+          It also fetches list of all registered social agents to present it to Alice.
+      <tr>
+       <td><b>9</b>
+       <td>Alice chooses all the social agents with which she wants to share the selected project,
+          as well as modes of access for all selected agents. If the shape tree has references (e.g., tasks) she can
+          also select modes of access for each inherited shape tree.
+      <tr>
+       <td><b>10-11</b>
+       <td>Alice’s Authorization Agent records new access authorizations for all the selected agents
+          and regenerates access grants provided in their agent registrations.
+      <tr>
+       <td><b>12</b>
+       <td>Alice’s Authorization Agent dereferences the supplied Projectron WebID, retrieving Projection’s
+          Application profile graph from the WebID Profile Document,
+          to discover the <code>hasAuthorizationCallbackEndpoint</code>.
+      <tr>
+       <td><b>13</b>
+       <td>Alice’s Authorization Agent redirects her back to Projectron, now that the project has been shared.
+      <tr>
+       <td><b>14</b>
+       <td>Alice continues using Projectron.
+    </table>
+   </figure>
+   <p><img class="sequence-diagram" src="diagrams/resource-indication.seq.mmd.svg"></p>
+   <h2 class="heading settled" data-level="9" id="generating-grants-from-authorizations"><span class="secno">9. </span><span class="content">Generating Access Grant from Access Authorization</span><a class="self-link" href="#generating-grants-from-authorizations"></a></h2>
+   <p>Based on an <a href="#access-authorization">§ 5.1 Access Authorization</a>, authorization agent can generate an <a href="#access-grant">§ 6.6 Access Grant</a>.
+For <a href="#data-authorization">§ 5.2 Data Authorization</a> using <code>AllFromRegistry</code>, <code>SelectedFromRegistry</code> scope,
+a single <a href="#data-grant">§ 6.7 Data Grant</a> gets generated. Similar for data authorization using <code>Inherited</code> scope and
+inheriting from data authorization with one of those two scopes. Here a data authorization gets directly
+translated into a data grant, only changing type and all authorization specific properties to grant specific properties.</p>
+   <p>For data authorization using <code>All</code> or <code>AllFromAgent</code>, zero or more data grant gets generated.
+This number depends on a number of Data Registries owned by the social agent giving the authorization,
+as well as number of data grants given to them by other social agents. Data authorization with <code>Inherited</code> scope
+will also have zero or more data grants if it is inheriting from data authorization using one of those two scopes.</p>
+   <p>Example of an implementation can be found in <a data-link-type="biblio" href="#biblio-sai-js" title="Solid Application Interoperability - TypeScript implementation">[SAI-JS]</a> and <a data-link-type="biblio" href="#biblio-sai-java" title="Solid Application Interoperability - Java implementation">[SAI-JAVA]</a></p>
+  </main>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-sai">[SAI]
+   <dd>Justin Bingham; Eric Prud'hommeaux; elf Pavlik. <a href="https://solid.github.io/data-interoperability-panel/specification/"><cite>Solid Application Interoperability</cite></a>. URL: <a href="https://solid.github.io/data-interoperability-panel/specification/">https://solid.github.io/data-interoperability-panel/specification/</a>
+   <dt id="biblio-sai-java">[SAI-JAVA]
+   <dd>Justin Bingham. <a href="https://github.com/janeirodigital/sai-java"><cite>Solid Application Interoperability - Java implementation</cite></a>. URL: <a href="https://github.com/janeirodigital/sai-java">https://github.com/janeirodigital/sai-java</a>
+   <dt id="biblio-sai-js">[SAI-JS]
+   <dd>elf Pavlik; Maciej Samoraj; Ángel Araya. <a href="https://github.com/janeirodigital/sai-js"><cite>Solid Application Interoperability - TypeScript implementation</cite></a>. URL: <a href="https://github.com/janeirodigital/sai-js">https://github.com/janeirodigital/sai-js</a>
+   <dt id="biblio-shapetrees">[SHAPETREES]
+   <dd>Justin Bingham; et al. <a href="https://shapetrees.org/TR/specification/"><cite>Shape Trees</cite></a>. URL: <a href="https://shapetrees.org/TR/specification/">https://shapetrees.org/TR/specification/</a>
+   <dt id="biblio-shex">[SHEX]
+   <dd>Eric Prud'hommeaux; et al. <a href="http://shex.io/shex-semantics/index.html"><cite>Shape Expressions Language 2.1</cite></a>. URL: <a href="http://shex.io/shex-semantics/index.html">http://shex.io/shex-semantics/index.html</a>
+   <dt id="biblio-web-share">[WEB-SHARE]
+   <dd>Marcos Caceres; Eric Willigers; Matt Giuca. <a href="https://w3c.github.io/web-share/"><cite>Web Share API</cite></a>. URL: <a href="https://w3c.github.io/web-share/">https://w3c.github.io/web-share/</a>
+   <dt id="biblio-web-share-target">[WEB-SHARE-TARGET]
+   <dd>Matt Giuca; Eric Willigers. <a href="https://w3c.github.io/web-share-target/"><cite>Web Share Target API</cite></a>. ED. URL: <a href="https://w3c.github.io/web-share-target/">https://w3c.github.io/web-share-target/</a>
+  </dl>

--- a/tag/sai-v0.1.html
+++ b/tag/sai-v0.1.html
@@ -1,0 +1,4127 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+  <title>Solid Application Interoperability</title>
+  <meta content="CG-DRAFT" name="w3c-status">
+  <link href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" rel="stylesheet">
+  <meta content="Bikeshed version b25686b9f, updated Fri Mar 14 14:15:20 2025 -0700" name="generator">
+  <link href="https://solidproject.org/TR/sai" rel="canonical">
+  <link href="https://www.w3.org/2008/site/images/favicon.ico" rel="icon">
+  <meta content="b1aa5b6d33d362cab931e0fa7c3674b51f45950b" name="revision">
+<style>
+table.permissions thead tr {
+  font-size: 12px;
+  text-align: left;
+}
+
+table.permissions th {
+  text-align: left;
+}
+
+table.permissions tbody tr:nth-child(even) {
+  background-color: lightgray;
+  font-size: 10px;
+}
+
+table.permissions tbody td {
+  font-size: 10px;
+  text-align: left;
+}
+
+table.classinfo thead tr th[colspan] {
+  text-align: left;
+  font-size: 15px;
+}
+
+table.classinfo thead tr th {
+  text-align: left;
+  font-size: 14px;
+}
+
+table.classinfo tbody tr:nth-child(odd) {
+  background-color: lightgray;
+  font-size: 12px;
+}
+
+table.classinfo tbody tr td {
+  font-size: 12px;
+}
+
+table.tree thead tr {
+  font-size: 14px;
+}
+
+table.tree tbody tr:nth-child(even) {
+  background-color: lightgray;
+  font-size: 14px;
+}
+
+table.tree tbody td {
+  font-size: 12px;
+}
+
+table.intersecting thead tr {
+  font-size: 14px ;
+}
+
+table.intersecting tbody tr:nth-child(odd) {
+  background-color: lightgray;
+  font-size: 14px;
+}
+
+table.intersecting tbody td {
+  font-size: 13px;
+  vertical-align: top ;
+  text-align: left;
+}
+
+table.intersecting td[colspan] {
+  text-align: left;
+}
+
+pre {
+  font-size: .8em;
+}
+
+figcaption {
+  text-align: left;
+}
+
+a[data-link-type=dfn] {
+  color: #000000;
+}
+
+a[href*=".ttl"] {
+  color: #339966;
+  border-bottom: 1px solid #339966;
+}
+
+a[href*="snippets"] {
+  color: #5a3399;
+  border-bottom: 1px solid #5a3399;
+}
+
+a[href^="#class"] {
+  color: #339966;
+  border-bottom: 1px solid #339966;
+}
+
+a.vocab {
+  color: #339966;
+  border-bottom: 1px solid #339966;
+}
+
+a[href*=".shex"] {
+  color: #cc2900;
+  border-bottom: 1px solid #cc2900;
+}
+
+a[href*=".tree"] {
+  color: #e68a00;
+  border-bottom: 1px solid #e68a00;
+}
+
+.sequence-diagram {
+    max-width: 100%;
+}
+
+.flow-pattern {
+  font-size: 14px;
+}
+
+em.rfc2119 {
+  text-transform: lowercase;
+  font-variant: small-caps;
+  font-style: normal;
+  font-size: 18px;
+  color: #900;
+}
+
+</style>
+<style>/* Boilerplate: style-autolinks */
+.css.css, .property.property, .descriptor.descriptor {
+    color: var(--a-normal-text);
+    font-size: inherit;
+    font-family: inherit;
+}
+.css::before, .property::before, .descriptor::before {
+    content: "‘";
+}
+.css::after, .property::after, .descriptor::after {
+    content: "’";
+}
+.property, .descriptor {
+    /* Don't wrap property and descriptor names */
+    white-space: nowrap;
+}
+.type { /* CSS value <type> */
+    font-style: italic;
+}
+pre .property::before, pre .property::after {
+    content: "";
+}
+[data-link-type="property"]::before,
+[data-link-type="propdesc"]::before,
+[data-link-type="descriptor"]::before,
+[data-link-type="value"]::before,
+[data-link-type="function"]::before,
+[data-link-type="at-rule"]::before,
+[data-link-type="selector"]::before,
+[data-link-type="maybe"]::before {
+    content: "‘";
+}
+[data-link-type="property"]::after,
+[data-link-type="propdesc"]::after,
+[data-link-type="descriptor"]::after,
+[data-link-type="value"]::after,
+[data-link-type="function"]::after,
+[data-link-type="at-rule"]::after,
+[data-link-type="selector"]::after,
+[data-link-type="maybe"]::after {
+    content: "’";
+}
+
+[data-link-type].production::before,
+[data-link-type].production::after,
+.prod [data-link-type]::before,
+.prod [data-link-type]::after {
+    content: "";
+}
+
+[data-link-type=element],
+[data-link-type=element-attr] {
+    font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: .9em;
+}
+[data-link-type=element]::before { content: "<" }
+[data-link-type=element]::after  { content: ">" }
+
+[data-link-type=biblio] {
+    white-space: pre;
+}
+
+</style>
+<style>/* Boilerplate: style-colors */
+/* Any --*-text not paired with a --*-bg is assumed to have a transparent bg */
+:root {
+    color-scheme: light dark;
+
+    --text: black;
+    --bg: white;
+
+    --unofficial-watermark: url(https://www.w3.org/StyleSheets/TR/2016/logos/UD-watermark);
+
+    --logo-bg: #1a5e9a;
+    --logo-active-bg: #c00;
+    --logo-text: white;
+
+    --tocnav-normal-text: #707070;
+    --tocnav-normal-bg: var(--bg);
+    --tocnav-hover-text: var(--tocnav-normal-text);
+    --tocnav-hover-bg: #f8f8f8;
+    --tocnav-active-text: #c00;
+    --tocnav-active-bg: var(--tocnav-normal-bg);
+
+    --tocsidebar-text: var(--text);
+    --tocsidebar-bg: #f7f8f9;
+    --tocsidebar-shadow: rgba(0,0,0,.1);
+    --tocsidebar-heading-text: hsla(203,20%,40%,.7);
+
+    --toclink-text: var(--text);
+    --toclink-underline: #3980b5;
+    --toclink-visited-text: var(--toclink-text);
+    --toclink-visited-underline: #054572;
+
+    --heading-text: #005a9c;
+
+    --hr-text: var(--text);
+
+    --algo-border: #def;
+
+    --del-text: red;
+    --del-bg: transparent;
+    --ins-text: #080;
+    --ins-bg: transparent;
+
+    --a-normal-text: #034575;
+    --a-normal-underline: #bbb;
+    --a-visited-text: var(--a-normal-text);
+    --a-visited-underline: #707070;
+    --a-hover-bg: rgba(75%, 75%, 75%, .25);
+    --a-active-text: #c00;
+    --a-active-underline: #c00;
+
+    --blockquote-border: silver;
+    --blockquote-bg: transparent;
+    --blockquote-text: currentcolor;
+
+    --issue-border: #e05252;
+    --issue-bg: #fbe9e9;
+    --issue-text: var(--text);
+    --issueheading-text: #831616;
+
+    --example-border: #e0cb52;
+    --example-bg: #fcfaee;
+    --example-text: var(--text);
+    --exampleheading-text: #574b0f;
+
+    --note-border: #52e052;
+    --note-bg: #e9fbe9;
+    --note-text: var(--text);
+    --noteheading-text: hsl(120, 70%, 30%);
+    --notesummary-underline: silver;
+
+    --assertion-border: #aaa;
+    --assertion-bg: #eee;
+    --assertion-text: black;
+
+    --advisement-border: orange;
+    --advisement-bg: #fec;
+    --advisement-text: var(--text);
+    --advisementheading-text: #b35f00;
+
+    --warning-border: red;
+    --warning-bg: hsla(40,100%,50%,0.95);
+    --warning-text: var(--text);
+
+    --amendment-border: #330099;
+    --amendment-bg: #F5F0FF;
+    --amendment-text: var(--text);
+    --amendmentheading-text: #220066;
+
+    --def-border: #8ccbf2;
+    --def-bg: #def;
+    --def-text: var(--text);
+    --defrow-border: #bbd7e9;
+
+    --datacell-border: silver;
+
+    --indexinfo-text: #707070;
+
+    --indextable-hover-text: black;
+    --indextable-hover-bg: #f7f8f9;
+
+    --outdatedspec-bg: rgba(0, 0, 0, .5);
+    --outdatedspec-text: black;
+    --outdated-bg: maroon;
+    --outdated-text: white;
+    --outdated-shadow: red;
+
+    --editedrec-bg: darkorange;
+}
+
+</style>
+<style>/* Boilerplate: style-counters */
+body {
+    counter-reset: example figure issue;
+}
+.issue {
+    counter-increment: issue;
+}
+.issue:not(.no-marker)::before {
+    content: "Issue " counter(issue);
+}
+
+.example {
+    counter-increment: example;
+}
+.example:not(.no-marker)::before {
+    content: "Example " counter(example);
+}
+.invalid.example:not(.no-marker)::before,
+.illegal.example:not(.no-marker)::before {
+    content: "Invalid Example" counter(example);
+}
+
+figcaption {
+    counter-increment: figure;
+}
+figcaption:not(.no-marker)::before {
+    content: "Figure " counter(figure) " ";
+}
+</style>
+<style>/* Boilerplate: style-dfn-panel */
+:root {
+    --dfnpanel-bg: #ddd;
+    --dfnpanel-text: var(--text);
+    --dfnpanel-target-bg: #ffc;
+    --dfnpanel-target-outline: orange;
+}
+.dfn-panel {
+    position: absolute;
+    z-index: 35;
+    width: 20em;
+    width: 300px;
+    height: auto;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.75em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--dfnpanel-bg);
+    color: var(--dfnpanel-text);
+    border: outset 0.2em;
+    white-space: normal; /* in case it's moved into a pre */
+}
+.dfn-panel:not(.on) { display: none; }
+.dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+.dfn-panel > b { display: block; }
+.dfn-panel a { color: var(--dfnpanel-text); }
+.dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+.dfn-panel a:focus {
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
+}
+.dfn-panel > b + b { margin-top: 0.25em; }
+.dfn-panel ul { padding: 0 0 0 1em; list-style: none; }
+.dfn-panel li a {
+    max-width: calc(300px - 1.5em - 1em);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dfn-panel.activated {
+    display: inline-block;
+    position: fixed;
+    left: 8px;
+    bottom: 2em;
+    margin: 0 auto;
+    max-width: calc(100vw - 1.5em - .4em - .5em);
+    max-height: 30vh;
+    transition: left 1s ease-out, bottom 1s ease-out;
+}
+
+.dfn-panel .link-item:hover {
+    text-decoration: underline;
+}
+.dfn-panel .link-item .copy-icon {
+    opacity: 0;
+}
+.dfn-panel .link-item:hover .copy-icon,
+.dfn-panel .link-item .copy-icon:focus {
+    opacity: 1;
+}
+
+.dfn-panel .copy-icon {
+    display: inline-block;
+    margin-right: 0.5em;
+    width: 0.85em;
+    height: 1em;
+    border-radius: 3px;
+    background-color: #ccc;
+    cursor: pointer;
+}
+
+.dfn-panel .copy-icon .icon {
+    width: 100%;
+    height: 100%;
+    background-color: #fff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.dfn-panel .copy-icon .icon::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 1px solid black;
+    background-color: #ccc;
+    opacity: 0.25;
+    transform: translate(3px, -3px);
+}
+
+.dfn-panel .copy-icon:active .icon::before {
+    opacity: 1;
+}
+
+.dfn-paneled[role="button"] { cursor: help; }
+
+.highlighted {
+    animation: target-fade 3s;
+}
+
+@keyframes target-fade {
+    from {
+        background-color: var(--dfnpanel-target-bg);
+        outline: 5px solid var(--dfnpanel-target-outline);
+    }
+    to {
+        color: var(--a-normal-text);
+        background-color: transparent;
+        outline: transparent;
+    }
+}
+</style>
+<style>/* Boilerplate: style-issues */
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
+</style>
+<style>/* Boilerplate: style-line-highlighting */
+:root {
+    --highlight-hover-bg: rgba(0, 0, 0, .05);
+}
+.line-numbered {
+    display: grid !important;
+    grid-template-columns: min-content 1fr;
+    grid-auto-flow: rows;
+}
+.line-numbered > *,
+.line-numbered::before,
+.line-numbered::after {
+    grid-column: 1/-1;
+}
+.line-no {
+    grid-column: 1;
+    color: gray;
+}
+.line {
+    grid-column: 2;
+}
+.line.highlight-line {
+    background: var(--highlight-hover-bg);
+}
+.line-no.highlight-line {
+    background: var(--highlight-hover-bg);
+    color: #444;
+    font-weight: bold;
+}
+.line-no.highlight-line[data-line]::before {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line);
+}
+.line-no.highlight-line[data-line-end]::after {
+    padding: 0 .5em 0 .1em;
+    content: attr(data-line-end);
+}
+
+</style>
+<style>/* Boilerplate: style-md-lists */
+/* This is a weird hack for me not yet following the commonmark spec
+   regarding paragraph and lists. */
+[data-md] > :first-child {
+    margin-top: 0;
+}
+[data-md] > :last-child {
+    margin-bottom: 0;
+}
+</style>
+<style>/* Boilerplate: style-ref-hints */
+:root {
+    --ref-hint-bg: #ddd;
+    --ref-hint-text: var(--text);
+}
+
+.ref-hint {
+    display: inline-block;
+    position: absolute;
+    z-index: 35;
+    width: 20em;
+    width: 300px;
+    height: auto;
+    max-height: 500px;
+    overflow: auto;
+    padding: 0.5em 0.5em;
+    font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+    background: var(--ref-hint-bg);
+    color: var(--ref-hint-text);
+    border: outset 0.2em;
+    white-space: normal; /* in case it's moved into a pre */
+}
+
+.ref-hint * { margin: 0; padding: 0; text-indent: 0; }
+
+.ref-hint ul { padding: 0 0 0 1em; list-style: none; }
+</style>
+<style>/* Boilerplate: style-selflinks */
+:root {
+    --selflink-text: white;
+    --selflink-bg: gray;
+    --selflink-hover-text: black;
+}
+.heading, .issue, .note, .example, li, dt {
+    position: relative;
+}
+a.self-link {
+    position: absolute;
+    top: 0;
+    left: calc(-1 * (3.5rem - 26px));
+    width: calc(3.5rem - 26px);
+    height: 2em;
+    text-align: center;
+    border: none;
+    transition: opacity .2s;
+    opacity: .5;
+}
+a.self-link:hover {
+    opacity: 1;
+}
+.heading > a.self-link {
+    font-size: 83%;
+}
+.example > a.self-link,
+.note > a.self-link,
+.issue > a.self-link {
+    /* These blocks are overflow:auto, so positioning outside
+       doesn't work. */
+    left: auto;
+    right: 0;
+}
+li > a.self-link {
+    left: calc(-1 * (3.5rem - 26px) - 2em);
+}
+dfn > a.self-link {
+    top: auto;
+    left: auto;
+    opacity: 0;
+    width: 1.5em;
+    height: 1.5em;
+    background: var(--selflink-bg);
+    color: var(--selflink-text);
+    font-style: normal;
+    transition: opacity .2s, background-color .2s, color .2s;
+}
+dfn:hover > a.self-link {
+    opacity: 1;
+}
+dfn > a.self-link:hover {
+    color: var(--selflink-hover-text);
+}
+
+a.self-link::before            { content: "¶"; }
+.heading > a.self-link::before { content: "§"; }
+dfn > a.self-link::before      { content: "#"; }
+</style>
+<style>/* Boilerplate: style-syntax-highlighting */
+code.highlight { padding: .1em; border-radius: .3em; }
+pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+
+.highlight:not(.idl) { background: rgba(0, 0, 0, .03); }
+c-[a] { color: #990055 } /* Keyword.Declaration */
+c-[b] { color: #990055 } /* Keyword.Type */
+c-[c] { color: #708090 } /* Comment */
+c-[d] { color: #708090 } /* Comment.Multiline */
+c-[e] { color: #0077aa } /* Name.Attribute */
+c-[f] { color: #669900 } /* Name.Tag */
+c-[g] { color: #222222 } /* Name.Variable */
+c-[k] { color: #990055 } /* Keyword */
+c-[l] { color: #000000 } /* Literal */
+c-[m] { color: #000000 } /* Literal.Number */
+c-[n] { color: #0077aa } /* Name */
+c-[o] { color: #999999 } /* Operator */
+c-[p] { color: #999999 } /* Punctuation */
+c-[s] { color: #a67f59 } /* Literal.String */
+c-[t] { color: #a67f59 } /* Literal.String.Single */
+c-[u] { color: #a67f59 } /* Literal.String.Double */
+c-[cp] { color: #708090 } /* Comment.Preproc */
+c-[c1] { color: #708090 } /* Comment.Single */
+c-[cs] { color: #708090 } /* Comment.Special */
+c-[kc] { color: #990055 } /* Keyword.Constant */
+c-[kn] { color: #990055 } /* Keyword.Namespace */
+c-[kp] { color: #990055 } /* Keyword.Pseudo */
+c-[kr] { color: #990055 } /* Keyword.Reserved */
+c-[ld] { color: #000000 } /* Literal.Date */
+c-[nc] { color: #0077aa } /* Name.Class */
+c-[no] { color: #0077aa } /* Name.Constant */
+c-[nd] { color: #0077aa } /* Name.Decorator */
+c-[ni] { color: #0077aa } /* Name.Entity */
+c-[ne] { color: #0077aa } /* Name.Exception */
+c-[nf] { color: #0077aa } /* Name.Function */
+c-[nl] { color: #0077aa } /* Name.Label */
+c-[nn] { color: #0077aa } /* Name.Namespace */
+c-[py] { color: #0077aa } /* Name.Property */
+c-[ow] { color: #999999 } /* Operator.Word */
+c-[mb] { color: #000000 } /* Literal.Number.Bin */
+c-[mf] { color: #000000 } /* Literal.Number.Float */
+c-[mh] { color: #000000 } /* Literal.Number.Hex */
+c-[mi] { color: #000000 } /* Literal.Number.Integer */
+c-[mo] { color: #000000 } /* Literal.Number.Oct */
+c-[sb] { color: #a67f59 } /* Literal.String.Backtick */
+c-[sc] { color: #a67f59 } /* Literal.String.Char */
+c-[sd] { color: #a67f59 } /* Literal.String.Doc */
+c-[se] { color: #a67f59 } /* Literal.String.Escape */
+c-[sh] { color: #a67f59 } /* Literal.String.Heredoc */
+c-[si] { color: #a67f59 } /* Literal.String.Interpol */
+c-[sx] { color: #a67f59 } /* Literal.String.Other */
+c-[sr] { color: #a67f59 } /* Literal.String.Regex */
+c-[ss] { color: #a67f59 } /* Literal.String.Symbol */
+c-[vc] { color: #0077aa } /* Name.Variable.Class */
+c-[vg] { color: #0077aa } /* Name.Variable.Global */
+c-[vi] { color: #0077aa } /* Name.Variable.Instance */
+c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
+
+</style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72"> </a> </p>
+   <h1 class="p-name no-ref" id="title">Solid Application Interoperability</h1>
+   <p id="w3c-state"><a href="https://www.w3.org/standards/types/#CG-DRAFT">Draft Community Group Report</a>, <time class="dt-updated" datetime="2025-09-16">16 September 2025</time></p>
+   <details open>
+    <summary>More details about this document</summary>
+    <div data-fill-with="spec-metadata">
+     <dl>
+      <dt>This version:
+      <dd><a class="u-url" href="https://solidproject.org/TR/tag/sai-v0.1">https://solidproject.org/TR/tag/sai-v0.1</a>
+      <dt>Latest published version:
+      <dd><a href="https://solidproject.org/TR/sai">https://solidproject.org/TR/sai</a>
+      <dt>Feedback:
+      <dd><a href="https://github.com/solid/data-interoperability-panel/issues/">GitHub</a>
+      <dd><a href="#issues-index">Inline In Spec</a>
+      <dt class="editor">Editors:
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">Justin Bingham</span>
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">Eric Prud'hommeaux</span>
+      <dd class="editor p-author h-card vcard"><span class="p-name fn">elf Pavlik</span>
+      <dt>Version:
+      <dd>0.1
+     </dl>
+    </div>
+   </details>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright">Copyright © 2025 the Contributors to the Solid Application Interoperability,
+published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+   <p>This specification details how Social Agents and Applications
+can safely share and interoperate over data in Solid Pods.</p>
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="sotd"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This report was published by the <a href="https://www.w3.org/community/solid/">Solid Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+  Learn more about <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#agents"><span class="secno">2</span> <span class="content">Agents</span></a>
+    <li>
+     <a href="#social-agents"><span class="secno">3</span> <span class="content">Social Agents</span></a>
+     <ol class="toc">
+      <li><a href="#datamodel-registry-set"><span class="secno">3.1</span> <span class="content">Registry Set</span></a>
+     </ol>
+    <li><a href="#app"><span class="secno">4</span> <span class="content">Applications</span></a>
+    <li>
+     <a href="#ar"><span class="secno">5</span> <span class="content">Agent Registrations</span></a>
+     <ol class="toc">
+      <li><a href="#application-registration"><span class="secno">5.1</span> <span class="content">Application Registration</span></a>
+      <li><a href="#social-agent-registration"><span class="secno">5.2</span> <span class="content">Social Agent Registration</span></a>
+      <li><a href="#social-agent-invitation"><span class="secno">5.3</span> <span class="content">Social Agent Invitation</span></a>
+      <li><a href="#ar-registry"><span class="secno">5.4</span> <span class="content">Agent Registry</span></a>
+     </ol>
+    <li>
+     <a href="#dr"><span class="secno">6</span> <span class="content">Data Registrations</span></a>
+     <ol class="toc">
+      <li><a href="#data-registration"><span class="secno">6.1</span> <span class="content">Data Registration</span></a>
+      <li><a href="#data-registry"><span class="secno">6.2</span> <span class="content">Data Registry</span></a>
+     </ol>
+    <li>
+     <a href="#authorization"><span class="secno">7</span> <span class="content">Authorization Flows</span></a>
+     <ol class="toc">
+      <li><a href="#authorization-agent"><span class="secno">7.1</span> <span class="content">Authorization Agent</span></a>
+     </ol>
+    <li>
+     <a href="#needs"><span class="secno">8</span> <span class="content">Access Needs</span></a>
+     <ol class="toc">
+      <li><a href="#access-need-group"><span class="secno">8.1</span> <span class="content">Access Need Group</span></a>
+      <li><a href="#needs-access-need"><span class="secno">8.2</span> <span class="content">Access Need</span></a>
+      <li><a href="#access-descriptions"><span class="secno">8.3</span> <span class="content">Access Descriptions</span></a>
+      <li><a href="#access-request"><span class="secno">8.4</span> <span class="content">Access Request</span></a>
+     </ol>
+    <li>
+     <a href="#authorizations"><span class="secno">9</span> <span class="content">Access Authorizations</span></a>
+     <ol class="toc">
+      <li><a href="#access-authorization"><span class="secno">9.1</span> <span class="content">Access Authorization</span></a>
+      <li><a href="#data-authorization"><span class="secno">9.2</span> <span class="content">Data Authorization</span></a>
+      <li><a href="#access-grant"><span class="secno">9.3</span> <span class="content">Access Grant</span></a>
+      <li><a href="#data-grant"><span class="secno">9.4</span> <span class="content">Data Grant</span></a>
+      <li><a href="#delegated-data-grant"><span class="secno">9.5</span> <span class="content">Delegated Data Grant</span></a>
+      <li><a href="#access-scopes"><span class="secno">9.6</span> <span class="content">Data Access Scopes</span></a>
+      <li><a href="#access-receipt"><span class="secno">9.7</span> <span class="content">Access Receipt</span></a>
+      <li><a href="#access-registry"><span class="secno">9.8</span> <span class="content">Authorization Registry</span></a>
+     </ol>
+    <li>
+     <a href="#security"><span class="secno">10</span> <span class="content">Security</span></a>
+     <ol class="toc">
+      <li><a href="#security-appauthz"><span class="secno">10.1</span> <span class="content">Application Authorization</span></a>
+     </ol>
+    <li><a href="#definitions"><span class="secno">11</span> <span class="content">Definitions</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+      <li><a href="#informative"><span class="secno"></span> <span class="content">Informative References</span></a>
+     </ol>
+    <li><a href="#issues-index"><span class="secno"></span> <span class="content">Issues Index</span></a>
+   </ol>
+  </nav>
+  <main>
+<script type="application/ld+json">
+{
+  "@context": {
+    "doap": "http://usefulinc.com/ns/doap#",
+    "spec": "http://www.w3.org/ns/spec#",
+    "schema": "http://schema.org/",
+    "sai": "https://solidproject.org/TR/sai#",
+    "name": "schema:name",
+    "author": { "@id": "schema:author", "@type": "@id" },
+    "editor": { "@id": "schema:editor", "@type": "@id" },
+    "definesConformanceFor": { "@id": "spec:definesConformanceFor", "@type": "@id" },
+    "ClassOfProduct": { "@id": "spec:ClassOfProduct", "@type": "@id" }
+  },
+  "@id": "https://solidproject.org/TR/sai",
+  "@type": "doap:Specification",
+  "name": "Solid Application Interoperability",
+  "author": [
+    "https://elf-pavlik.hackers4peace.net",
+    "urn:uuid:3b05c17c-f44a-470e-8031-408abee6e2ca",
+    "https://justin.inrupt.net/profile/card#me"
+  ],
+  "editor": [
+    "https://elf-pavlik.hackers4peace.net",
+    "urn:uuid:3b05c17c-f44a-470e-8031-408abee6e2ca",
+    "https://justin.inrupt.net/profile/card#me"
+  ],
+  "definesConformanceFor": [
+    { 
+      "@id": "sai:Application",
+      "@type": "ClassOfProduct",
+      "name": "SAI Application"
+    },
+    { 
+      "@id": "sai:AuthorizationAgent",
+      "@type": "ClassOfProduct",
+      "name": "SAI Authorization Agent"
+    }
+  ]
+}
+</script>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p>Solid affords us the opportunity to create a valuable and
+powerful ecosystem where people and organizations retain control
+of their data, but are also able to put it to work and use it
+to its full potential. The fundamentals of Solid make this possible,
+but further definition of standard methods and mechanisms 
+must be established
+to make it practical, intuitive, and secure.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> See <a data-link-type="biblio" href="#biblio-problems-and-goals" title="Problems and Goals for Interoperability, Collaboration, and Security in a Solid Pod">Problems and Goals for Interoperability in Solid</a> for an explanation of the problem space.</p>
+   <p>This specification details how <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent">Social Agents</a> in the Solid ecosystem
+can read, write, and manage data stored in a Solid pod using
+disparate <a data-link-type="dfn" href="#application" id="ref-for-application">Applications</a>.</p>
+   <p><a href="#ar">§ 5 Agent Registrations</a> details how <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①">Social Agents</a> track and manage the other <a data-link-type="dfn" href="#agents①" id="ref-for-agents①">Agents</a> they interact with.</p>
+   <p><a href="#dr">§ 6 Data Registrations</a> details how <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②">Social Agents</a> register, organize, and
+lookup their data. Data is stored uniformly, avoiding complex 
+physical hierarchies. <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree">Shape trees</a> and <a data-link-type="dfn" href="#shape" id="ref-for-shape">shapes</a> provide strong data validation and
+intuitive data boundaries.</p>
+   <p><a href="#authorization">§ 7 Authorization Flows</a> provides the means for a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③">Social Agent</a> to grant other <a data-link-type="dfn" href="#application" id="ref-for-application①">Applications</a> and <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④">Social Agents</a> access to data in their control.</p>
+   <ul>
+    <li data-md>
+     <p><a href="#needs">§ 8 Access Needs</a> let <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application②">Applications</a> express which data they
+need access to, and patterns to request those needs.</p>
+    <li data-md>
+     <p><a href="#authorizations">§ 9 Access Authorizations</a> let <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥">Social Agents</a> manage and track access they’ve granted
+to other <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①">Agents</a>.</p>
+   </ul>
+   <h2 class="heading settled" data-level="2" id="agents"><span class="secno">2. </span><span class="content">Agents</span><a class="self-link" href="#agents"></a></h2>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="agents①">Agents</dfn> are the primary actors in an interoperable Solid <a data-link-type="dfn" href="#ecosystem" id="ref-for-ecosystem">ecosystem</a>.</p>
+   <p>An <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②">Agent</a> is denoted by an <a data-link-type="dfn" href="#identity" id="ref-for-identity">identity</a>. Dereferencing that <a data-link-type="dfn" href="#identity" id="ref-for-identity①">identity</a> leads to <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document">identity profile document</a>, where a graph of useful information
+about the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③">Agent</a> can be found. This graph is used by the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①④">Agent</a> as a starting point to look up their own data, as well as data that has
+been shared with them.</p>
+   <p>The <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑤">Agent</a> graph in an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document①">identity profile document</a> is designed to be
+publicly accessible, but many of the things the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑥">Agent</a> links to are
+designed to be private, or accessible only by others they have authorized.</p>
+   <p>An <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑦">Agent</a> can dereference the <a data-link-type="dfn" href="#identity" id="ref-for-identity②">identity</a> of another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑧">Agent</a> to obtain
+the public information they need to interact with them.</p>
+   <p><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application③">Applications</a> are specific types of <a data-link-type="dfn" href="#agents①" id="ref-for-agents①⑨">Agents</a> denoted by this specification.</p>
+   <div id="classAgent"></div>
+   <div class="issue no-marker" id="issue-d41d8cd9"><a class="self-link" href="#issue-d41d8cd9"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/210" style="text-transform:none">solid/data-interoperability-panel/210</a><a href="https://github.com/solid/data-interoperability-panel/issues/210">Incorporate profile requirements from solid-oidc for Social Agents and Applications.</a></div>
+   <h2 class="heading settled" data-level="3" id="social-agents"><span class="secno">3. </span><span class="content">Social Agents</span><a class="self-link" href="#social-agents"></a></h2>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="social-agent">Social Agent</dfn> is a strongly identifiable individual, group, or
+organization that can own or be responsible for data, and provide authorization to the
+access of that data by other <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⓪">Agents</a>.</p>
+   <p>Most of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧">Social Agent’s</a> information is stored in <a data-link-type="dfn" href="#registry" id="ref-for-registry">Registries</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="registry">Registry</dfn> is a place where a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨">Social Agent</a> can store and find
+different types of data, often for particular purposes. Each type
+of <a data-link-type="dfn" href="#registry" id="ref-for-registry①">Registry</a> serves a specific purpose or function.</p>
+   <p>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪">Social Agent</a> stores a list of its <a data-link-type="dfn" href="#registry" id="ref-for-registry②">Registries</a> in a <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set">Registry Set</a>,
+which must be a separate resource from the <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document②">identity profile document</a> that the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①">Social Agent</a> graph resides in so that it can be given more
+restrictive (i.e. non-public) permissions.</p>
+   <p>The <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document③">identity profile document</a> <em class="rfc2119">MUST</em> be readable by the public. It <em class="rfc2119">MAY</em> use any resource or subject names.</p>
+   <p><a href="interop.ttl#SocialAgent">Class Definition</a> - <a href="interop.shex#SocialAgentShape">Shape Definition</a> - <a href="interop.tree#SocialAgentTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classSocialAgent">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasRegistrySet
+      <td><a href="#classRegistrySet">RegistrySet</a>
+      <td><a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set①">Registry Set</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①②">Social Agent</a>
+     <tr>
+      <td>hasAuthorizationAgent
+      <td><a href="#classApplication">Application</a>
+      <td>The software used by the Agent to manage access to their data
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①③">Social Agent</a> at https://alice.example/#id - <a href="snippets/alice.example/alice.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- k>PREFIX</c-> <c- nn>rdf:</c-> <c- g>&lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#></c->
+<c- k>PREFIX</c-> <c- nn>rdfs:</c-> <c- g>&lt;http://www.w3.org/2000/01/rdf-schema#></c->
+<c- k>PREFIX</c-> <c- nn>interop:</c-> <c- g>&lt;http://www.w3.org/ns/solid/interop#></c->
+<c- k>PREFIX</c-> <c- nn>alice:</c-> <c- g>&lt;https://alice.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-jarvis:</c-> <c- g>&lt;https://alice.jarvis.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-auth:</c-> <c- g>&lt;https://auth.alice.example/></c->
+
+<c- nn>alice</c-><c- p>:</c-><c- f>\#id</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c->
+  <c- c>######## Registry Sets ########</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice</c-><c- p>:</c-><c- f>registries</c-> <c- p>;</c->
+  <c- c>######## Authorization Agent ########</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- nn>alice-jarvis</c-><c- p>:</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="3.1" id="datamodel-registry-set"><span class="secno">3.1. </span><span class="content">Registry Set</span><a class="self-link" href="#datamodel-registry-set"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="registry-set">Registry Set</dfn> links to all of the <a data-link-type="dfn" href="#registry" id="ref-for-registry③">Registries</a> owned
+by a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①④">Social Agent</a>. A non-public document, it is accessed by or
+on behalf of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑤">Social Agent</a> or their <a data-link-type="dfn">Trusted Agents</a> via trusted <a data-link-type="dfn" href="#application" id="ref-for-application④">Applications</a>.</p>
+   <p>The <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set②">Registry Set</a> <em class="rfc2119">MAY</em> use any resource or
+subject names. It <em class="rfc2119">SHOULD NOT</em> be readable
+by the public. It <em class="rfc2119">SHOULD</em> be accessible
+and manageable by the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑥">Social Agent</a> that owns it, or other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑦">Social Agents</a> that have received appropriate authorization, via
+authorized <a data-link-type="dfn" href="#application" id="ref-for-application⑤">Applications</a>.</p>
+   <p><a href="interop.ttl#RegistrySet">Class Definition</a> - <a href="interop.shex#RegistrySetShape">Shape Definition</a> - <a href="interop.tree#RegistrySetTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classRegistrySet">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAgentRegistry
+      <td><a href="#classAgentRegistry">AgentRegistry</a>
+      <td><a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry">Agent Registry</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑧">Social Agent</a>
+     <tr>
+      <td>hasAuthorizationRegistry
+      <td><a href="#classAuthorizationRegistry">AuthorizationRegistry</a>
+      <td><a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry">Authorization Registry</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⑨">Social Agent</a>
+     <tr>
+      <td>hasDataRegistry
+      <td><a href="#classDataRegistry">DataRegistry</a>
+      <td><a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①">Data Registry</a> for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⓪">Social Agent</a>
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set③">Registry Set</a> at https://alice.example/registries - <a href="snippets/alice.example/registries.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- k>PREFIX</c-> <c- nn>interop:</c-> <c- g>&lt;http://www.w3.org/ns/solid/interop#></c->
+<c- k>PREFIX</c-> <c- nn>alice:</c-> <c- g>&lt;https://alice.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-work:</c-> <c- g>&lt;https://work.alice.example/></c->
+<c- k>PREFIX</c-> <c- nn>alice-personal:</c-> <c- g>&lt;https://personal.alice.example/></c->
+
+<c- nn>alice</c-><c- p>:</c-><c- f>registries</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>RegistrySet</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAgentRegistry</c-> <c- nn>alice</c-><c- p>:</c-><c- f>agents\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationRegistry</c-> <c- nn>alice</c-><c- p>:</c-><c- f>authorization\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistry</c->
+    <c- nn>alice-work</c-><c- p>:</c-><c- f>data\/</c-> <c- p>,</c->
+    <c- nn>alice-personal</c-><c- p>:</c-><c- f>data\/</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h2 class="heading settled" data-level="4" id="app"><span class="secno">4. </span><span class="content">Applications</span><a class="self-link" href="#app"></a></h2>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application">Application</dfn> is a software-based <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①①">Agent</a> that a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②①">Social Agent</a> uses to access, manipulate, and manage the data in 
+their control, as well as the data they’ve been granted access to.</p>
+   <p>The information in the <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document④">identity profile document</a> of an <a data-link-type="dfn" href="#application" id="ref-for-application⑥">Application</a> is used during <a href="#authorization">§ 7 Authorization Flows</a> to help <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②②">Social Agents</a> determine whether 
+they want to use that <a data-link-type="dfn" href="#application" id="ref-for-application⑦">Application</a>. It lets them know what kind of 
+data the <a data-link-type="dfn" href="#application" id="ref-for-application⑧">Application</a> needs access to and why. This lets the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②③">Social Agent</a> make an informed choice.</p>
+   <p>An <a data-link-type="dfn" href="#application" id="ref-for-application⑨">Application</a> identifies the types of data it requires access to
+by linking to <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①">Access Need Groups</a>.</p>
+   <p>The <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑤">identity profile document</a> of an <a data-link-type="dfn" href="#application" id="ref-for-application①⓪">Application</a> <em class="rfc2119">MUST</em> be readable by the public, along with
+its thumbnail and any identified <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①">Access Need Groups</a>. 
+They <em class="rfc2119">MAY</em> use any resource or subject names.</p>
+   <p><a href="interop.ttl#Application">Class Definition</a> - <a href="interop.shex#ApplicationShape">Shape Definition</a> - <a href="interop.tree#ApplicationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classApplication">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>applicationName
+      <td>xsd:string
+      <td>Name of the <a data-link-type="dfn" href="#application" id="ref-for-application①①">Application</a>
+     <tr>
+      <td>applicationDescription
+      <td>xsd:string
+      <td>Description of the <a data-link-type="dfn" href="#application" id="ref-for-application①②">Application</a>
+     <tr>
+      <td>applicationAuthor
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②④">Social Agent</a> that authored the <a data-link-type="dfn" href="#application" id="ref-for-application①③">Application</a>
+     <tr>
+      <td>applicationThumbnail
+      <td>binary image
+      <td>Thumbnail for the <a data-link-type="dfn" href="#application" id="ref-for-application①④">Application</a>
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②">Access Need Group</a> representing types of data the <a data-link-type="dfn" href="#application" id="ref-for-application①⑤">Application</a> needs to operate
+     <tr>
+      <td>hasAuthorizationCallbackEndpoint
+      <td>IRI
+      <td>URI used to redirect back from <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①">Authorization Agent</a> to the application, after completing authorization
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#application" id="ref-for-application①⑥">Application</a> at https://projectron.example/#id - <a href="snippets/projectron.example/projectron.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Application</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationName</c-> <c- s>"Projectron"</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationDescription</c-> <c- s>"Manage projects with ease"</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationAuthor</c-> <c- nn>acme</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>applicationThumbnail</c-> <c- nn>acme</c-><c- p>:</c-><c- f>thumb.svg</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>needs</c-><c- p>:</c-><c- f>need-group-pm</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationCallbackEndpoint</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>redirect</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h2 class="heading settled" data-level="5" id="ar"><span class="secno">5. </span><span class="content">Agent Registrations</span><a class="self-link" href="#ar"></a></h2>
+   <p><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑤">Social Agents</a> manage the other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑥">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application①⑦">Applications</a> they interact with
+by registering these <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①②">Agents</a> in their <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①">Agent Registry</a>.</p>
+   <p>When a given <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①③">Agent</a> is the subject of an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①">Access Authorization</a>,
+an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①">Access Grant</a> is generated and <a href="#ar-hierarchy">stored</a> in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations">Agent Registration</a> for that <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①④">Agent</a>.</p>
+   <h3 class="heading settled" data-level="5.1" id="application-registration"><span class="secno">5.1. </span><span class="content">Application Registration</span><a class="self-link" href="#application-registration"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application-registration①">Application Registration</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑦">Social Agent</a> with a place to maintain metadata, state, preferences, and
+other application-specific data associated with a given <a data-link-type="dfn" href="#application" id="ref-for-application①⑧">Application</a> they
+have elected to use.</p>
+   <p><a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①">Application Registrations</a> are stored in an <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry②">Agent Registry</a>.</p>
+   <p><a href="interop.ttl#ApplicationRegistration">Class Definition</a> - <a href="interop.shex#ApplicationRegistrationShape">Shape Definition</a> - <a href="interop.tree#ApplicationRegistrationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classApplicationRegistration">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑧">Social Agent</a> that registered the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①①">Application Registration</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application①⑨">Application</a> used to create the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①②">Application Registration</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①③">Application Registration</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①④">Application Registration</a> was updated
+     <tr>
+      <td>registeredAgent
+      <td><a href="#classApplication">Application</a>
+      <td>The <a data-link-type="dfn" href="#application" id="ref-for-application②⓪">Application</a> that was registered
+     <tr>
+      <td>hasAccessGrant
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①">Access Grant</a> describing the access that has been
+      granted to the <code>registeredAgent</code>
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①⑤">Application Registration</a> for Projectron at
+  https://alice.pod.example/agents/2f2f3628/ - <a href="snippets/alice.example/2f2f3628.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c-><c- f>2f2f3628\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>ApplicationRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAgent</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrant</c-> <c- nn>alice-agents</c-><c- p>:</c-><c- f>2f2f3628\/27eae14b</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="5.2" id="social-agent-registration"><span class="secno">5.2. </span><span class="content">Social Agent Registration</span><a class="self-link" href="#social-agent-registration"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="social-agent-registration①">Social Agent Registration</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent②⑨">Social Agent</a> with a place to track and manage other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⓪">Social Agents</a> they
+interact with.</p>
+   <p><a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①">Social Agent Registrations</a> are stored in an <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry③">Agent Registry</a>.</p>
+   <p><a href="interop.ttl#SocialAgentRegistration">Class Definition</a> - <a href="interop.shex#SocialAgentRegistrationShape">Shape Definition</a> - <a href="interop.tree#SocialAgentRegistrationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classSocialAgentRegistration">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③①">Social Agent</a> that registered the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①">Social Agent Registration</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application②①">Application</a> used to create the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①②">Social Agent Registration</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①③">Social Agent Registration</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①④">Social Agent Registration</a> was updated
+     <tr>
+      <td>registeredAgent
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③②">Social Agent</a> that was registered
+     <tr>
+      <td>reciprocalRegistration
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td>The <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑤">Social Agent Registration</a> that <code>registeredAgent</code> maintains
+      for the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③③">Social Agent</a> that owns this <a data-link-type="dfn" href="#registry" id="ref-for-registry④">Registry</a>
+     <tr>
+      <td>hasAccessGrant
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①②">Access Grant</a> describing the access that has been
+      granted to the <code>registeredAgent</code>
+     <tr>
+      <td>skos:prefLabel
+      <td>xsd:string
+      <td>Human readable label assigned by the user creating the registration
+     <tr>
+      <td>skos:note
+      <td>xsd:string
+      <td>Optional note which can further help with recognising the agent
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑥">Social Agent Registration</a> for Bob at
+  https://alice.pod.example/agents/c4562da9/ - <a href="snippets/alice.example/c4562da9.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c-><c- f>c4562da9\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SocialAgentRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAgent</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>reciprocalRegistration</c-> <c- nn>bob-agents</c-><c- p>:</c-><c- f>255aa181\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessGrant</c-> <c- nn>alice-agents</c-><c- p>:</c-><c- f>c4562da9\/b6e125b8</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="5.3" id="social-agent-invitation"><span class="secno">5.3. </span><span class="content">Social Agent Invitation</span><a class="self-link" href="#social-agent-invitation"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="social-agent-invitation①">Social Agent Invitation</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③④">Social Agent</a> with a simple and secure way to establish data sharing with other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑤">Social Agents</a>.</p>
+   <p><a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①">Social Agent Invitations</a> are stored in an <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry④">Agent Registry</a>.</p>
+   <p><a href="interop.ttl#SocialAgentInvitation">Class Definition</a> - <a href="interop.shex#SocialAgentInvitationShape">Shape Definition</a> - <a href="interop.tree#SocialAgentInvitationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classSocialAgentInvitation">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑥">Social Agent</a> that registered the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①①">Social Agent Invitation</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application②②">Application</a> used to create the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①②">Social Agent Invitation</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①③">Social Agent Invitation</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①④">Social Agent Invitation</a> was updated
+     <tr>
+      <td>capabilityUrl
+      <td><a data-link-type="biblio" href="#biblio-capability-urls" title="Good Practices for Capability URLs">Capability URL</a>
+      <td>Secure link used to accept the invitation
+     <tr>
+      <td>skos:prefLabel
+      <td>xsd:string
+      <td>Human readable label assigned by the user creating the invitation
+     <tr>
+      <td>skos:note
+      <td>xsd:string
+      <td>Optional note which can further help with understanding who is being invited
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑤">Social Agent Invitation</a> for Yori at
+  https://alice.pod.example/agents/a1umr5yx/ - <a href="snippets/alice.example/a1umr5yx.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c-><c- f>a1umr5yx\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SocialAgentInvitation</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>capabilityUrl</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>invitations\/z8tms2zzq3d9vfpo1a6yk5jkgn5y4aem</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Yori"</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>note</c-> <c- s>"A friend from my D&amp;D club"</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <p><a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①">Authorization Agent</a> accepting an authenticated request, targeting the <code>capabilityUrl</code> from a <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑥">Social Agent Invitation</a></p>
+   <ul>
+    <li data-md>
+     <p>MUST respond with the <a data-link-type="biblio" href="#biblio-webid" title="WebID 1.0">[WEBID]</a> of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑦">Social Agent</a> who created the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑦">Social Agent Invitation</a>, using <code>Content-Type: text/plain</code></p>
+    <li data-md>
+     <p>MUST use the identity of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑧">Social Agent</a>, from the incoming request,
+as the <code>registeredAgent</code> for newly created <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑦">Social Agent Registration</a>.</p>
+    <li data-md>
+     <p>SHOULD use the <code>skos:prefLabel</code> from the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑧">Social Agent Invitation</a> for the new <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑧">Social Agent Registration</a>.</p>
+    <li data-md>
+     <p>SHOULD use the <code>skos:note</code> from the <a data-link-type="dfn" href="#social-agent-invitation①" id="ref-for-social-agent-invitation①⑨">Social Agent Invitation</a> for the new <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①⑨">Social Agent Registration</a>.</p>
+    <li data-md>
+     <p>SHOULD schedule <a href="#agent-registration-discovery">§ 7.1.4 Agent Registration Discovery</a> on the <code>registeredAgent</code> from the new <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①⓪">Social Agent Registration</a>.
+After the successful discovery, add it as <code>reciprocalRegistration</code></p>
+   </ul>
+   <p class="note" role="note"><span class="marker">Note:</span> Commonly the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①②">Authorization Agent</a>, making the request on behalf of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent③⑨">Social Agent</a> accepting the invitation,
+    will create corresponding <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①①">Social Agent Registration</a> after receiving the <a data-link-type="biblio" href="#biblio-webid" title="WebID 1.0">[WEBID]</a> in the response,
+    which means that it is not available before receiving the response.</p>
+   <h3 class="heading settled" data-level="5.4" id="ar-registry"><span class="secno">5.4. </span><span class="content">Agent Registry</span><a class="self-link" href="#ar-registry"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="agent-registry">Agent Registry</dfn> is a collection of <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="agent-registrations">Agent Registrations</dfn>.</p>
+   <p>Each <a data-link-type="dfn" href="#application" id="ref-for-application②③">Application</a> a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⓪">Social Agent</a> interacts with has an <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①⑥">Application Registration</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④①">Social Agent</a> a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④②">Social Agent</a> interacts with has a <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①②">Social Agent Registration</a>.</p>
+   <p>The <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑤">Agent Registry</a> is linked to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④③">Social Agent</a> via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set④">Registry Set</a>.</p>
+   <p><a href="interop.ttl#AgentRegistry">Class Definition</a> - <a href="interop.shex#AgentRegistryShape">Shape Definition</a> - <a href="interop.tree#AgentRegistryTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAgentRegistry">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasSocialAgentRegistration
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td>Link to an associated <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①③">Social Agent Registration</a> for 
+      a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④④">Social Agent</a>
+     <tr>
+      <td>hasApplicationRegistration
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td>Link to an associated <a data-link-type="dfn" href="#application-registration①" id="ref-for-application-registration①⑦">Application Registration</a> for 
+      a given <a data-link-type="dfn" href="#application" id="ref-for-application②④">Application</a>
+   </table>
+   <figure>
+    <figcaption>An <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑥">Agent Registry</a> at https://alice.example/agents/ - <a href="snippets/alice.example/agents.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- nn>alice-agents</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AgentRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasSocialAgentRegistration</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>c4562da9\/</c-> <c- p>,</c->         <c- c># Bob</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>b49afcdf\/</c-> <c- p>,</c->         <c- c># Sarah</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>4ae3abf8\/</c-> <c- p>;</c->         <c- c># Jose</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasApplicationRegistration</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>2f2f3628\/</c-> <c- p>,</c->         <c- c># Projectron</c->
+    <c- nn>alice-agents</c-><c- p>:</c-><c- f>b5eea7bb\/</c-> <c- p>,</c->         <c- c># Jarvis</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="5.4.1" id="ar-hierarchy"><span class="secno">5.4.1. </span><span class="content">Resource Hierarchy</span><a class="self-link" href="#ar-hierarchy"></a></h4>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Resource
+      <th>Class
+      <th>Shape
+      <th>Shape Tree
+    <tbody>
+     <tr>
+      <td><code><a href="snippets/alice.example/agents.ttl">agents/</a></code>
+      <td><a href="#classAgentRegistry">AgentRegistry</a>
+      <td><a href="interop.shex#AgentRegistryShape">AgentRegistryShape</a>
+      <td><a href="interop.tree#AgentRegistryTree">AgentRegistryTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/c4562da9.ttl">c4562da9/</a></code>
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td><a href="interop.shex#SocialAgentRegistrationShape">SocialAgentRegistrationShape</a>
+      <td><a href="interop.tree#SocialAgentRegistrationTree">SocialAgentRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/b6e125b8.ttl">b6e125b8/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/b42228af.ttl">b42228af/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/95ff7580.ttl">95ff7580/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/b49afcdf.ttl">b49afcdf/</a></code>
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td><a href="interop.shex#SocialAgentRegistrationShape">SocialAgentRegistrationShape</a>
+      <td><a href="interop.tree#SocialAgentRegistrationTree">SocialAgentRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/731b43ec.ttl">731b43ec/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/d85fd1f5.ttl">d85fd1f5/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/8fac3576.ttl">8fac3576/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/4ae3abf8.ttl">4ae3abf8/</a></code>
+      <td><a href="#classSocialAgentRegistration">SocialAgentRegistration</a>
+      <td><a href="interop.shex#SocialAgentRegistrationShape">SocialAgentRegistrationShape</a>
+      <td><a href="interop.tree#SocialAgentRegistrationTree">SocialAgentRegistrationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/2f2f3628.ttl">2f2f3628/</a></code>
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td><a href="interop.shex#ApplicationRegistrationShape">ApplicationRegistrationShape</a>
+      <td><a href="interop.tree#ApplicationRegistrationTree">ApplicationRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/27eae14b.ttl">27eae14b/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/40d038ea.ttl">40d038ea/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/0945218b.ttl">0945218b/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/fe818190.ttl">fe818190/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/017d6a07.ttl">017d6a07/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/90b0f5ad.ttl">90b0f5ad/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/1912239c.ttl">1912239c/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/b5eea7bb.ttl">b5eea7bb/</a></code>
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td><a href="interop.shex#ApplicationRegistrationShape">ApplicationRegistrationShape</a>
+      <td><a href="interop.tree#ApplicationRegistrationTree">ApplicationRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/5ad22737.ttl">5ad22737/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/b0dc6c78.ttl">b0dc6c78/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/6ef722af.ttl">6ef722af/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/c2328cdd.ttl">c2328cdd/</a></code>
+      <td><a href="#classApplicationRegistration">ApplicationRegistration</a>
+      <td><a href="interop.shex#ApplicationRegistrationShape">ApplicationRegistrationShape</a>
+      <td><a href="interop.tree#ApplicationRegistrationTree">ApplicationRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/2ae35a57.ttl">2ae35a57/</a></code>
+      <td><a href="#classAccessGrant">AccessGrant</a>
+      <td><a href="interop.shex#AccessGrantShape">AccessGrantShape</a>
+      <td><a href="interop.tree#AccessGrantTree">AccessGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/a8a224e6.ttl">a8a224e6/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/244dfe3e.ttl">244dfe3e/</a></code>
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a href="interop.shex#DataGrantShape">DataGrantShape</a>
+      <td><a href="interop.tree#DataGrantTree">DataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/efc426c9.ttl">efc426c9/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/391f526b.ttl">391f526b/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/cc8f2f69.ttl">cc8f2f69/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/alice.example/6da10e5b.ttl">6da10e5b/</a></code>
+      <td><a href="#classDelegatedDataGrant">DelegatedDataGrant</a>
+      <td><a href="interop.shex#DelegatedDataGrantShape">DelegatedDataGrantShape</a>
+      <td><a href="interop.tree#DelegatedDataGrantTree">DelegatedDataGrantTree</a>
+   </table>
+   <p>The <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑦">Agent Registry</a> MAY use any resource or subject name.</p>
+   <p>The resource name for an <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations①">Agent Registration</a> <em class="rfc2119">SHOULD</em> be unpredictable.</p>
+   <p>The <code>interop:registeredAgent</code> of a given <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations②">Agent Registration</a> <em class="rfc2119">SHOULD</em> have <code>acl:Read</code> access to that <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations③">Agent Registration</a>.</p>
+   <h2 class="heading settled" data-level="6" id="dr"><span class="secno">6. </span><span class="content">Data Registrations</span><a class="self-link" href="#dr"></a></h2>
+   <p>Data Registrations let <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑤">Social Agents</a> store and manage the
+data they control. Data of various types is organized and stored in a 
+uniform way to aid validation, authorization, 
+discovery, and more.</p>
+   <p>Complex hierarchies that hinder interoperability are avoided
+by storing data in a relatively flat hierarchy. This creates natural
+data boundaries that make data storage and authorization more intuitive.</p>
+   <h3 class="heading settled" data-level="6.1" id="data-registration"><span class="secno">6.1. </span><span class="content">Data Registration</span><a class="self-link" href="#data-registration"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-registration①">Data Registration</dfn> provides the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑥">Social Agent</a> with a place to store <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance">Data Instances</a> that conform to the
+registered <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①">shape tree</a> of that registration. <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①">Data Registrations</a> are 
+stored in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①">Data Registry</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-instance">Data Instance</dfn> is a unique, stored instance of data
+in a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①">Data Registration</a> that conforms to it’s <code>interop:registeredShapeTree</code>.</p>
+   <p>Each <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①">Data Instance</a> is linked to the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②">Data Registration</a> via the <a class="vocab" href="https://www.w3.org/ns/ldp#contains">ldp:contains</a> property.</p>
+   <p><a href="interop.ttl#DataRegistration">Class Definition</a> - <a href="interop.shex#DataRegistrationShape">Shape Definition</a> - <a href="interop.tree#DataRegistrationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataRegistration">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑦">Social Agent</a> that registered the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③">Data Registration</a>
+     <tr>
+      <td>registeredWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application②⑤">Application</a> used to create the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①④">Data Registration</a>
+     <tr>
+      <td>registeredAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑤">Data Registration</a> was created
+     <tr>
+      <td>updatedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑥">Data Registration</a> was updated
+     <tr>
+      <td>registeredShapeTree
+      <td><a class="vocab" href="https://www.w3.org/ns/shapetrees#ShapeTree">st:ShapeTree</a>
+      <td>The <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②">Shape Tree</a> that was registered
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑦">Data Registration</a> for Projects at https://work.alice.example/data/8501f084/ - <a href="snippets/work.alice.example/8501f084.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetree</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="6.2" id="data-registry"><span class="secno">6.2. </span><span class="content">Data Registry</span><a class="self-link" href="#data-registry"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-registry①">Data Registry</dfn> is a collection of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑧">Data Registrations</a>, each
+of which represents a unique type of data, identified by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree③">shape tree</a>.</p>
+   <p>A <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②">Data Registry</a> can be used for basic discovery, but it is not
+designed nor intended to be an efficient means to query or index data.
+However, it is <em>intended</em> to be used as reliable source data for different
+query engines or indexing schemes.</p>
+   <p>A <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①③">Data Registry</a> is linked to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑧">Social Agent</a> via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑤">Registry Set</a>.</p>
+   <p><a href="interop.ttl#DataRegistry">Class Definition</a> - <a href="interop.shex#DataRegistryShape">Shape Definition</a> - <a href="interop.tree#DataRegistryTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataRegistry">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasDataRegistration
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td>Link to an associated <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①⑨">Data Registration</a>
+   </table>
+   <figure>
+    <figcaption>A <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①④">Data Registry</a> at https://work.alice.example/data/ 
+  linking to <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⓪">Data Registrations</a> for Projects and Tasks - <a href="snippets/work.alice.example/data-registry.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-work-data</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistry</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c->
+    <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>,</c->
+    <c- nn>alice-work-data</c-><c- p>:</c-><c- f>df4ab227\/</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="6.2.1" id="dr-hierarchy"><span class="secno">6.2.1. </span><span class="content">Resource Hierarchy</span><a class="self-link" href="#dr-hierarchy"></a></h4>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Resource
+      <th>Class
+      <th>Shape
+      <th>Shape Tree
+    <tbody>
+     <tr>
+      <td><code><a href="snippets/work.alice.example/data-registry.ttl">data/</a></code>
+      <td><a href="#classDataRegistry">DataRegistry</a>
+      <td><a href="interop.shex#DataRegistry">DataRegistryShape</a>
+      <td><a href="interop.tree#DataRegistry">DataRegistryTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/work.alice.example/8501f084.ttl">8501f084/</a></code>
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td><a href="interop.shex#DataRegistration">DataRegistrationShape</a>
+      <td><a href="interop.tree#DataRegistration">DataRegistrationTree</a>, <a href="snippets/data.example/pm-shapetrees.tree#ProjectRegistrationTree">ProjectRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/16e1eae9.ttl">16e1eae9</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Project">Project</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#ProjectShape">ProjectShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a>
+     <tr>
+      <td><code>------ 886785d2</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Project">Project</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#ProjectShape">ProjectShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a>
+     <tr>
+      <td><code>------ dae5015c</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Project">Project</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#ProjectShape">ProjectShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/work.alice.example/df4ab227.ttl">df4ab227/</a></code>
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td><a href="interop.shex#DataRegistration">DataRegistrationShape</a>
+      <td><a href="interop.tree#DataRegistration">DataRegistrationTree</a>, <a href="snippets/data.example/pm-shapetrees.tree#TaskRegistrationTree">TaskRegistrationTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/9b60a354.ttl">9b60a354</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/6e545b74.ttl">6e545b74</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ <a href="snippets/work.alice.example/d33e01c8.ttl">d33e01c8</a></code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ 927108fa</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+     <tr>
+      <td><code>------ 180dda0b</code>
+      <td><a href="snippets/data.example/pm-vocab.ttl#Task">Task</a>
+      <td><a href="snippets/data.example/pm-shapes.shex#TaskShape">TaskShape</a>
+      <td><a href="snippets/data.example/pm-shapetrees.tree#TaskTree">TaskTree</a>
+   </table>
+   <p>The <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑤">Data Registry</a> resource <em class="rfc2119">MAY</em> use any
+resource or subject name.</p>
+   <p>The resource names for <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①①">Data Registrations</a> and <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②">Data Instances</a> <em class="rfc2119">SHOULD</em> be unpredictable.</p>
+   <p>A <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①②">Data Registration</a> container <em class="rfc2119">MUST</em> contain conformant instances of the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree④">shape tree</a> associated with the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①③">Data Registration</a> via <a href="#classDataRegistration">interop:registeredShapeTree</a>.</p>
+   <p>Two complementary <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑤">shape trees</a> <em class="rfc2119">MUST</em> be assigned
+to the same <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①④">Data Registration</a> container to ensure that it conforms
+to general validation requirements, and to ensure
+that it only contains <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③">Data Instances</a> of the registered <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑥">shape tree</a> identified by <a href="#classDataRegistration">interop:registeredShapeTree</a>.</p>
+   <p>In the <a href="#fig-datareg-intersecting">figure below</a>, the
+combination of a <a href="interop.tree#DataRegistration">DataRegistrationTree</a> and <a href="snippets/data.example/pm-shapetrees.tree#ProjectRegistrationTree">ProjectRegistrationTree</a> on the
+same <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑤">Data Registration</a> can be observed. Furthermore, an example of
+a contained <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④">Data Instance</a> is provided, which conforms
+to <a href="snippets/data.example/pm-shapetrees.tree#ProjectTree">ProjectTree</a> per the directive in <a href="snippets/data.example/pm-shapetrees.tree#ProjectRegistrationTree">ProjectRegistrationTree</a>.</p>
+   <figure id="fig-datareg-intersecting">
+    <figcaption>Intersecting <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑦">shape trees</a> for a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑥">Data Registration</a> and the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑧">shape tree</a> registered with it </figcaption>
+    <table align="left" class="data intersecting">
+     <colgroup>
+      <col>
+      <col>
+     <tbody>
+      <tr>
+       <td colspan="2"> <code>-- 8501f084/</code> 
+      <tr>
+       <td>
+         Contents of the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑦">Data Registration</a> 
+<pre class="include-code highlight"><c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataRegistration</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>updatedAt</c-> <c- s>"2020-04-04T21:11:33.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetree</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>.</c->
+</pre>
+       <td>
+         Ensure the container resource for the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑧">Data Registration</a> conforms to <code>interops#DataRegistrationShape</code>. 
+<pre class="include-code highlight">  <c- nn>st</c-><c- p>:</c-><c- f>shape</c->          <c- nn>interops</c-><c- p>:</c-><c- f>DataGrantShape</c-> <c- p>.</c->
+
+<c- c># Data Registry</c->
+<c- c>##########################################################</c->
+</pre>
+        <p>And also ensure the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①①⑨">Data Registration</a> only
+          contains resources that conform to <code>pm:ProjectTree</code>.</p>
+<pre class="include-code highlight"><c- g>&lt;#ProjectRegistrationTree></c->
+  <c- b>a</c-> <c- nn>st</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>st</c-><c- p>:</c-><c- f>Container</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>contains</c-> <c- g>&lt;#ProjectTree></c-> <c- p>.</c->
+</pre>
+      <tr>
+       <td colspan="2"> <code>------ 16e1eae9</code> 
+      <tr>
+       <td>
+         Contents of the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑤">Data Instance</a> 
+<pre class="include-code highlight">
+<c- nn>alice-work-projects</c-><c- p>:</c-><c- f>16e1eae9</c->
+  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>id</c-> <c- mi>6</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>name</c-> <c- s>"Solid Project"</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>created_at</c-> <c- s>"2021-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>9b60a354</c-> <c- p>,</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>6e545b74</c-> <c- p>,</c->
+</pre>
+       <td>
+         Ensure the resource for the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑥">Data Instance</a> conforms to <code>pm:ProjectTree</code>. 
+<pre class="include-code highlight"><c- g>&lt;#ProjectTree></c->
+  <c- b>a</c-> <c- nn>st</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>st</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>shape</c-> <c- nn>pm-shex</c-><c- p>:</c-><c- f>ProjectShape</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>references</c-> <c- p>[</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- g>&lt;#TaskTree></c-> <c- p>;</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>viaPredicate</c-> <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+  <c- p>]</c-> <c- p>.</c->
+</pre>
+    </table>
+   </figure>
+   <h2 class="heading settled" data-level="7" id="authorization"><span class="secno">7. </span><span class="content">Authorization Flows</span><a class="self-link" href="#authorization"></a></h2>
+   <p>Authorization represents several key elements that
+work together to grant, adjust, and rescind access to data controlled
+by a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent④⑨">Social Agent</a>.</p>
+   <p>Key authorization flows are facilitated by an <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①③">Authorization Agent</a> on behalf of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⓪">Social Agent</a>.</p>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Flow
+      <th>Scenario
+    <tbody>
+     <tr>
+      <td><b>Application Requests Access</b>
+      <td>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤①">Social Agent</a> elects to use a new <a data-link-type="dfn" href="#application" id="ref-for-application②⑥">Application</a>. The <a data-link-type="dfn" href="#application" id="ref-for-application②⑦">Application</a> prompts the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤②">Social Agent</a> for access to data in their control. <a data-link-type="dfn" href="#access-need" id="ref-for-access-need">Access Needs</a> are provided by the <a data-link-type="dfn" href="#application" id="ref-for-application②⑧">Application</a>. 
+     <tr>
+      <td><b>Another Social Agent Requests Access</b>
+      <td>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤③">Social Agent</a> requests access to data owned
+        by another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤④">Social Agent</a>. <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①">Access Needs</a> are provided
+        in an <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①">Access Request</a>. Resultant notification is
+        provided through an <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①">Access Receipt</a>.
+     <tr>
+      <td><b>Social Agent Shares Access</b>
+      <td>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑤">Social Agent</a> using an <a data-link-type="dfn" href="#application" id="ref-for-application②⑨">Application</a> elects to share
+        access to data in their control with another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑥">Social Agent</a> that did not request it. <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②">Access Needs</a> are provided by <a data-link-type="dfn" href="#application" id="ref-for-application③⓪">Application</a>. Notification that access was shared is provided
+        through an <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①①">Access Receipt</a>.
+   </table>
+   <div class="assertion">
+    <p><b>Each authorization flow listed above uses the following pattern:</b></p>
+    <ol>
+     <li data-md>
+      <p>A requesting <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑤">Agent</a> expresses
+their <a href="#needs">Access Needs</a> to a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑦">Social Agent</a> for data in their control.</p>
+     <li data-md>
+      <p><a href="#needs">Access Needs</a> are processed and presented to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑧">Social Agent</a> by their <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①④">Authorization Agent</a>.</p>
+     <li data-md>
+      <p>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑤⑨">Social Agent’s</a> access decisions are captured and enacted
+through <a href="#authorizations">§ 9 Access Authorizations</a>.</p>
+     <li data-md>
+      <p>The requesting <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑥">Agent</a> looks for an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①③">Access Grant</a> stored in a corresponding <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations④">Agent Registration</a> in the <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑧">Agent Registry</a> of the
+data owner. This <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①④">Access Grant</a> tells them exactly what they have access to.</p>
+    </ol>
+   </div>
+   <p>Slight variations concerning where <a data-link-type="dfn" href="#access-need" id="ref-for-access-need③">Access Needs</a> are sourced from, and
+how notification of access is provided, are the only differences from
+one flow to another.</p>
+   <h3 class="heading settled" data-level="7.1" id="authorization-agent"><span class="secno">7.1. </span><span class="content">Authorization Agent</span><a class="self-link" href="#authorization-agent"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-agent①">Authorization Agent</dfn> is an <a data-link-type="dfn" href="#application" id="ref-for-application③①">Application</a> designated by
+a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⓪">Social Agent</a> to be responsible for managing the access to data
+under their control, linked via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑥">Registry Set</a>.</p>
+   <p>Any requests for access to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥①">Social Agent</a> are processed by the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑤">Authorization Agent</a>.
+Similarly, any decisions by the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥②">Social Agent</a> to share data with another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑦">Agent</a> are processed by the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑥">Authorization Agent</a>.</p>
+   <table align="left" class="classinfo data" id="classAuthorizationAgent">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAuthorizationRedirectEndpoint
+      <td>IRI
+      <td>URI used to redirect to the Authorization Agent
+      from an <a data-link-type="dfn" href="#application" id="ref-for-application③②">Application</a> for authorization
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑦">Authorization Agent</a> at https://auth.alice.example/ - <a href="snippets/alice.jarvis.example/alice.jarvis.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-jarvis</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AuthorizationAgent</c-> <c- p>;</c->
+  <c- c>######## Authorization Redirect Endpoint ########</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationRedirectEndpoint</c-> <c- nn>alice-jarvis</c-><c- p>:</c-><c- f>redirect</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="7.1.1" id="authorization-redirect-endpoint"><span class="secno">7.1.1. </span><span class="content">Authorization Redirect Endpoint</span><a class="self-link" href="#authorization-redirect-endpoint"></a></h4>
+   <p>An <a data-link-type="dfn" href="#application" id="ref-for-application③③">Application</a> capable of redirecting, should redirect the user to the
+Authorization Redirect Endpoint advertised by the user’s <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑧">Authorization Agent</a>.</p>
+   <p>The following query parameters are defined:</p>
+   <table align="left" class="classinfo data">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Parameter
+      <th>Required
+      <th>Description
+    <tbody>
+     <tr>
+      <td>client_id
+      <td>Yes
+      <td>URI used to identify the <a data-link-type="dfn" href="#application" id="ref-for-application③④">Application</a> requesting the authorization
+     <tr>
+      <td>resource
+      <td>No
+      <td>URI used to indicate the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑦">Data Instance</a>.
+      Used for <a href="#resource-indication">§ 7.1.2 Resource Indication</a>
+   </table>
+   <figure>
+    <figcaption>Example redirect</figcaption>
+<pre class="highlight"><c- nf>GET</c-> <c- nn>/redirect?client_id=https%3A%2F%2Fprojectron.example%2F%23id</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>alice.jarvis.example</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="7.1.2" id="resource-indication"><span class="secno">7.1.2. </span><span class="content">Resource Indication</span><a class="self-link" href="#resource-indication"></a></h4>
+   <p>When the <code>resource</code> query parameter is used, the Authorization Agent will use it
+as an indication that access to a specific data instance is intended to be shared.</p>
+   <h4 class="heading settled" data-level="7.1.3" id="authorization-agent-discovery"><span class="secno">7.1.3. </span><span class="content">Authorization Agent Discovery</span><a class="self-link" href="#authorization-agent-discovery"></a></h4>
+   <p>The <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①⑨">Authorization Agent</a> for a given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥③">Social Agent</a> can be discovered
+by de-referencing the <a data-link-type="dfn" href="#identity" id="ref-for-identity③">identity</a> of that <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥④">Social Agent</a>, and extracting
+the object value of the <code>interop:hasAuthorizationAgent</code> statement from the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑤">Social Agent</a> graph in the returned <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑥">identity profile document</a>.</p>
+   <p>The extracted <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①⓪">Authorization Agent</a> IRI <em class="rfc2119">MUST</em> be
+unique to that <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑥">Social Agent</a>. In scenarios where the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①①">Authorization Agent</a> services multiple <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑦">Social Agents</a>, this may be facilitated through
+a unique sub-domain (see example below) or path.</p>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑧">Social Agent</a> at https://alice.example/#id - <a href="snippets/alice.example/alice.example.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Agent</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- c>######## Registry Sets ########</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasRegistrySet</c-> <c- nn>alice</c-><c- p>:</c-><c- f>registries</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- c>######## Authorization Agent ########</c-></span><span class="line-no highlight-line" data-line="13"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasAuthorizationAgent</c-> <c- nn>alice-jarvis</c-><c- p>:</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①"><a class="self-link" href="#issue-d41d8cd9①"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/171" style="text-transform:none">solid/data-interoperability-panel/171</a><a href="https://github.com/solid/data-interoperability-panel/issues/171">Authorization Agent URI should be distinct for each user</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9②"><a class="self-link" href="#issue-d41d8cd9②"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/232" style="text-transform:none">solid/data-interoperability-panel/232</a><a href="https://github.com/solid/data-interoperability-panel/issues/232">Multiple authorisation apps per social agent</a></div>
+   <h4 class="heading settled" data-level="7.1.4" id="agent-registration-discovery"><span class="secno">7.1.4. </span><span class="content">Agent Registration Discovery</span><a class="self-link" href="#agent-registration-discovery"></a></h4>
+   <p>An <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑧">Agent</a> that needs to discover whether a target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑥⑨">Social Agent</a> has
+a corresponding <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑤">Agent Registration</a> for them can query the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①②">Authorization Agent</a> for that target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⓪">Social Agent</a>.</p>
+   <p>To discover a corresponding <a data-link-type="dfn">Agent Regsitration</a> the requesting <a data-link-type="dfn" href="#agents①" id="ref-for-agents①①⑨">Agent</a> may perform an HTTP <code>HEAD</code> or HTTP <code>GET</code> request on the IRI of the <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①③">Authorization Agent</a> for the target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦①">Social Agent</a>.</p>
+   <p>The response will include an <code>HTTP Link</code> header relating the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑥">Agent Registration</a> to the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⓪">Agent</a> making the request via the <code>http://www.w3.org/ns/solid/interop#registeredAgent</code> link relation.</p>
+   <figure>
+    <figcaption>HEAD request to and response from Authorization Agent</figcaption>
+<pre class="highlight"><c- nf>HEAD</c-> <c- nn>/</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>alice.jarvis.example</c->
+<c- e>Authorization</c-><c- o>:</c-> <c- l>DPoP ....</c->
+</pre>
+<pre class="highlight line-numbered"><span class="line-no"></span><span class="line"><c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c-> <c- m>200</c-> <c- ne>OK</c-></span><span class="line-no"></span><span class="line"><c- e>Link</c-><c- o>:</c-> <c- l>&lt;https://projectron.example/#app>;</c-></span><span class="line-no highlight-line" data-line="3"></span><span class="line highlight-line">  <c- l>anchor="https://alice.jarvis.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";</c-></span><span class="line-no"></span><span class="line">  <c- l>rel="http://www.w3.org/ns/solid/interop#registeredAgent"</c-></span></pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9③"><a class="self-link" href="#issue-d41d8cd9③"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/252" style="text-transform:none">solid/data-interoperability-panel/252</a><a href="https://github.com/solid/data-interoperability-panel/issues/252">Should we restrict Social Agent Reigstration discovery to AA of that social agent?</a></div>
+   <h2 class="heading settled" data-level="8" id="needs"><span class="secno">8. </span><span class="content">Access Needs</span><a class="self-link" href="#needs"></a></h2>
+   <p><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦②">Social Agents</a> and <a data-link-type="dfn" href="#application" id="ref-for-application③⑤">Applications</a> in the <a data-link-type="dfn" href="#ecosystem" id="ref-for-ecosystem①">ecosystem</a> often
+require access to data controlled by some other <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦③">Social Agent</a>.
+Consequently, a common way to explain
+and communicate data needs between these parties is required.</p>
+   <p>A given <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦④">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application③⑥">Application</a> expresses their access needs by
+providing one or more <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①③">Access Need Groups</a> to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑤">Social Agent</a> controlling the data they require access to. The channels through which
+these may be communicated are detailed in <a href="#authorization">§ 7 Authorization Flows</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①④">Access Need Group</a> is associated with one or more <a data-link-type="dfn" href="#access-need" id="ref-for-access-need④">Access Needs</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑤">Access Needs</a> represent a request to access a particular type of data
+identified by <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree⑨">shape tree</a> type, corresponding with <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⓪">Data Registrations</a> in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑥">Data Registry</a>, an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑦">Identity Profile Document</a>, or a <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑦">Registry Set</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑤">Access Need Groups</a> are essential to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑥">Social Agent’s</a> decision-making
+when determining whether to grant access.</p>
+   <h3 class="heading settled" data-level="8.1" id="access-need-group"><span class="secno">8.1. </span><span class="content">Access Need Group</span><a class="self-link" href="#access-need-group"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need-group①">Access Need Group</dfn> is a collection of <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑥">Access Needs</a> used to communicate an access request to <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑦">Social Agents</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑥">Access Need Groups</a> are immutable. If an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑦">Access Need Group</a> needs to change,
+it should be replaced.</p>
+   <p>If an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑧">Access Need Group</a> is replaced, history may be retained by linking
+to it from the replacement <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①⑨">Access Need Group</a> via <code>interop:replaces</code>.</p>
+   <p><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⓪">Access Need Groups</a> are described using language-specific <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①">Access Need Group Descriptions</a>.</p>
+   <p><a href="interop.ttl#AccessNeedGroup">Class Definition</a> - <a href="interop.shex#AccessNeedGroupShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeedGroup">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAccessDescriptionSet
+      <td><a href="#classAccessDescriptionSet">AccessDescriptionSet</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①">Access Description Set</a> containing <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①①">Access Need Group Descriptions</a> and <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①">Access Need Descriptions</a> in the preferred language of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑧">Social Agent</a>
+     <tr>
+      <td>accessNecessity
+      <td><code>interop:AccessRequired</code>, <code>interop:AccessOptional</code>
+      <td>Necessity of the access to the requesting party
+     <tr>
+      <td>accessScenario
+      <td><code>interop:PersonalAccess</code>, <code>interop:SharedAccess</code>
+      <td>Context in which the access group should be presented
+     <tr>
+      <td>authenticatesAs
+      <td><code>interop:SocialAgent</code> or <code>interop:Application</code>
+      <td>Access will be granted to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑦⑨">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application③⑦">Application</a>
+     <tr>
+      <td>hasAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Link to an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑦">Access Need</a>
+     <tr>
+      <td>replaces
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>Previous <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①①">Access Need Group</a> replaced by current instance
+   </table>
+   <figure>
+    <figcaption>An example <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①②">Access Need Group</a> for Projectron - <a href="snippets/projectron.example/needs.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#need-group-pm></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedGroup</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessScenario</c-> <c- nn>interop</c-><c- p>:</c-><c- f>PersonalAccess</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>authenticatesAs</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SocialAgent</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessDescriptionSet</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-en</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-es</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-nl</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-fr</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-ru</c-> <c- p>,</c->
+    <c- nn>projectron</c-><c- p>:</c-><c- f>access-ko</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- g>&lt;#need-project></c-> <c- p>.</c->
+
+<c- g>&lt;#need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>.</c->
+
+<c- g>&lt;#need-task></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromNeed</c-> <c- g>&lt;#need-project></c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="8.2" id="needs-access-need"><span class="secno">8.2. </span><span class="content">Access Need</span><a class="self-link" href="#needs-access-need"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need">Access Need</dfn> represents the requirement of one specific type
+of data represented by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⓪">shape tree</a>, as part of an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①③">Access Need Group</a>.</p>
+   <p>It is often the case that a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①①">shape tree</a> associated with an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑧">Access Need</a> references other <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①②">shape trees</a>, providing a
+path to request access to related types. Consequently, <a data-link-type="dfn" href="#access-need" id="ref-for-access-need⑨">Access Needs</a> can be specified that <em>inherit</em> from other <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⓪">Access Needs</a> through a shape tree reference.</p>
+   <p>Specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑧">Data Instances</a> may be requested by explicitly
+associating them with the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①①">Access Need</a>.</p>
+   <p><a data-link-type="dfn" href="#access-need" id="ref-for-access-need①②">Access Needs</a> are immutable. If an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①③">Access Need</a> needs to change, it should be replaced.</p>
+   <p><a data-link-type="dfn" href="#access-need" id="ref-for-access-need①④">Access Needs</a> are described using language-specific <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①①">Access Need Descriptions</a>.</p>
+   <p><a href="interop.ttl#AccessNeed">Class Definition</a> - <a href="interop.shex#AccessNeedGroup">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeed">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>registeredShapeTree
+      <td><code>st:ShapeTree</code>
+      <td>The <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①③">shape tree</a> requested by the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑤">Access Need</a>
+     <tr>
+      <td>accessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Requested modes of access for the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑥">Access Need</a>
+     <tr>
+      <td>creatorAccessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Requested mode of access for the creator of a Data Instance.
+        Adds to the set of modes linked via <code>interop:accessMode</code>. Only valid when <code>accessMode</code> includes <code>acl:Create</code>, <code>acl:Write</code>, or <code>acl:Append</code>
+     <tr>
+      <td>accessNecessity
+      <td><code>interop:AccessRequired</code>, <code>interop:AccessOptional</code>
+      <td>Necessity of the access to the requesting party
+     <tr>
+      <td>hasDataInstance
+      <td><a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance⑨">Data Instance</a>
+      <td>Request specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⓪">Data Instance</a> of the registered <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①④">shape tree</a>. Requires advance knowledge of the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①①">Data Instance</a>
+     <tr>
+      <td>inheritsFromNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Links to another <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑦">Access Need</a> whose registeredShapeTree
+      references the shape tree associated with the current <a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑧">Access Need</a>.
+   </table>
+   <figure>
+    <figcaption><a data-link-type="dfn" href="#access-need" id="ref-for-access-need①⑨">Access Needs</a> for Projects and Tasks in an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①④">Access Need Group</a> for Projectron - <a href="snippets/projectron.example/needs.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>.</c->
+
+<c- g>&lt;#need-task></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeed</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessNecessity</c-> <c- nn>interop</c-><c- p>:</c-><c- f>accessRequired</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromNeed</c-> <c- g>&lt;#need-project></c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9④"><a class="self-link" href="#issue-d41d8cd9④"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/243" style="text-transform:none">solid/data-interoperability-panel/243</a><a href="https://github.com/solid/data-interoperability-panel/issues/243">Access Needs for Public Resources</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9⑤"><a class="self-link" href="#issue-d41d8cd9⑤"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/237" style="text-transform:none">solid/data-interoperability-panel/237</a><a href="https://github.com/solid/data-interoperability-panel/issues/237">Access needs for pod browser apps</a></div>
+   <h3 class="heading settled" data-level="8.3" id="access-descriptions"><span class="secno">8.3. </span><span class="content">Access Descriptions</span><a class="self-link" href="#access-descriptions"></a></h3>
+   <h4 class="heading settled" data-level="8.3.1" id="access-need-group-description"><span class="secno">8.3.1. </span><span class="content">Access Need Group Description</span><a class="self-link" href="#access-need-group-description"></a></h4>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need-group-description①">Access Need Group Description</dfn> provides a short label or
+title and a more in-depth description that explains why a given <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑤">Access Need Group</a> is being requested of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⓪">Social Agent</a>.</p>
+   <p><a href="interop.ttl#AccessNeedGroupDescription">Class Definition</a> - <a href="interop.shex#AccessNeedGroupDescriptionShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeedGroupDescription">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>inAccessDescriptionSet
+      <td><a href="#classAccessDescriptionSet">AccessDescriptionSet</a>
+      <td><a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①①">Access Description Set</a> the description is part of
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td><a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑥">Access Need Group</a> the description applies to
+     <tr>
+      <td>skos:preflabel
+      <td><code>xsd:string</code>
+      <td>Short label (title) for the <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑦">Access Need Group</a>
+     <tr>
+      <td>skos:definition
+      <td><code>xsd:string</code>
+      <td>Description of why the <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑧">Access Need Group</a> requires the
+      access it is requesting.
+   </table>
+   <figure>
+    <figcaption>English <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①②">Access Need Group Description</a> for Projectron - <a href="snippets/projectron.example/access-en.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#en-need-group-pm></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedGroupDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-group-pm</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Read and Contribute to Projects"</c-><c- o>@</c->en <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>definition</c-> <c- s>"Allow Projectron to read the Projects you select, and create new ones. Projectron won't modify existing data, but can add more."</c-><c- o>@</c->en <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="8.3.2" id="access-need-description"><span class="secno">8.3.2. </span><span class="content">Access Need Description</span><a class="self-link" href="#access-need-description"></a></h4>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-need-description①">Access Need Description</dfn> provides a specific
+explanation of why that data type is being requested by
+a given <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②⓪">Access Need</a>.</p>
+   <p><a href="interop.ttl#AccessNeedDescription">Class Definition</a> - <a href="interop.shex#AccessNeedDescriptionShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessNeedDescription">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>inAccessDescriptionSet
+      <td><a href="#classAccessDescriptionSet">AccessDescriptionSet</a>
+      <td><a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①②">Access Description Set</a> the description is part of
+     <tr>
+      <td>hasAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td><a data-link-type="dfn" href="#access-need" id="ref-for-access-need②①">Access Need</a> the description applies to
+     <tr>
+      <td>skos:prefLabel
+      <td><code>xsd:string</code>
+      <td>Specific explanation of why that data type is being requested
+   </table>
+   <figure>
+    <figcaption>English <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①②">Access Need Description</a> for Projects - <a href="snippets/projectron.example/access-en.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;#en-need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-project</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Access to Projects is essential for Projectron to perform its core function of Project Management"</c-><c- o>@</c->en <c- p>.</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="8.3.3" id="access-description-set"><span class="secno">8.3.3. </span><span class="content">Access Description Set</span><a class="self-link" href="#access-description-set"></a></h4>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-description-set①">Access Description Set</dfn> is a collection of <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①③">Access Need Group Descriptions</a> and <a data-link-type="dfn" href="#access-need-description①" id="ref-for-access-need-description①③">Access Need Descriptions</a>.</p>
+   <p><a href="interop.ttl#AccessDescriptionSet">Class Definition</a> - <a href="interop.shex#AccessDescriptionSetShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessDescriptionSet">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>usesLanguage
+      <td><code>xsd:language</code>
+      <td>Language that the <a data-link-type="dfn" href="#access-need-group-description①" id="ref-for-access-need-group-description①④">Access Need Group Descriptions</a> and <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②②">Access Needs</a> in the Set use
+   </table>
+   <figure>
+    <figcaption>English <a data-link-type="dfn" href="#access-description-set①" id="ref-for-access-description-set①③">Access Description Set</a> for Projectron - <a href="snippets/projectron.example/access-en.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- g>&lt;></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessDescriptionSet</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>usesLanguage</c-> <c- s>"en"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>language</c-> <c- p>.</c->
+
+<c- g>&lt;#en-need-group-pm></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedGroupDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-group-pm</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Read and Contribute to Projects"</c-><c- o>@</c->en <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>definition</c-> <c- s>"Allow Projectron to read the Projects you select, and create new ones. Projectron won't modify existing data, but can add more."</c-><c- o>@</c->en <c- p>.</c->
+
+<c- g>&lt;#en-need-project></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-project</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Access to Projects is essential for Projectron to perform its core function of Project Management"</c-><c- o>@</c->en <c- p>.</c->
+
+<c- g>&lt;#en-need-task></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessNeedDescription</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inAccessDescriptionSet</c-> <c- g>&lt;></c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>need-task</c-> <c- p>;</c->
+  <c- nn>skos</c-><c- p>:</c-><c- f>prefLabel</c-> <c- s>"Access to Tasks allows Projectron to identify and manage the work to be done in a given Project."</c-><c- o>@</c->en <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="8.4" id="access-request"><span class="secno">8.4. </span><span class="content">Access Request</span><a class="self-link" href="#access-request"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-request①">Access Request</dfn> is used to send <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①①⑨">Access Need Groups</a> from
+one <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②①">Agent</a> to another.</p>
+   <p><a href="interop.ttl#AccessRequest">Class Definition</a> - <a href="interop.shex#AccessRequestShape">Shape Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessRequest">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>fromSocialAgent
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧①">Social Agent</a> who sent the <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①①">Access Request</a>
+     <tr>
+      <td>toSocialAgent
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧②">Social Agent</a> the <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①②">Access Request</a> is meant for
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>One or more <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②⓪">Access Need Groups</a> detailing the access requested
+   </table>
+   <figure>
+    <figcaption>An <a data-link-type="dfn" href="#access-request①" id="ref-for-access-request①③">Access Request</a> sent from one agent to another</figcaption>
+<pre class="include-code highlight"><c- g>&lt;></c-> <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessRequest</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>fromSocialAgent</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>toSocialAgent</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#need-group-pm</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9⑥"><a class="self-link" href="#issue-d41d8cd9⑥"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/214" style="text-transform:none">solid/data-interoperability-panel/214</a><a href="https://github.com/solid/data-interoperability-panel/issues/214">Use invitation to validate the source of an incoming request</a></div>
+   <h2 class="heading settled" data-level="9" id="authorizations"><span class="secno">9. </span><span class="content">Access Authorizations</span><a class="self-link" href="#authorizations"></a></h2>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①">Access Authorizations</a> record a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧③">Social Agent’s</a> decision to grant access to
+some portion of the data in their control to another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧④">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application③⑧">Application</a>. <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②">Access Authorizations</a> are not shared with a grantee.</p>
+   <p><a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑤">Access Grants</a> are generated from <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①③">Access Authorizations</a>. They are shared
+with a given <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②②">Agent</a> to communicate the scope of access that has been
+granted to them.</p>
+   <h3 class="heading settled" data-level="9.1" id="access-authorization"><span class="secno">9.1. </span><span class="content">Access Authorization</span><a class="self-link" href="#access-authorization"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-authorization①">Access Authorization</dfn> records the decision of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑤">Social Agent</a> to grant access to some portion of data in their control to
+another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②③">Agent</a>.</p>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①④">Access Authorizations</a> should not be shared with the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②④">Agent</a> that
+has been granted access. <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑥">Access Grants</a> are generated from <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑤">Access Authorizations</a>, and are appropriate to share with the grantee.</p>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑥">Access Authorizations</a> are recorded in a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑥">Social Agent’s</a> <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry①">Authorization Registry</a>.</p>
+   <p><a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑦">Access Authorizations</a> are immutable. If an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑧">Access Authorization</a> for an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑤">Agent</a> needs to change, it should be replaced.</p>
+   <p>If an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①⑨">Access Authorization</a> is replaced, history may be retained by unlinking the
+previous <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⓪">Access Authorization</a> from the <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry②">Authorization Registry</a>, and linking
+to it from the replacement <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①①">Access Authorization</a> via <code>interop:replaces</code>.</p>
+   <p><a href="interop.ttl#AccessAuthorization">Class Definition</a> - <a href="interop.shex#AccessAuthorizationShape">Shape Definition</a> - <a href="interop.tree#AccessAuthorizationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessAuthorization">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑦">Social Agent</a> that granted the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①②">Access Authorization</a>
+     <tr>
+      <td>grantedWith
+      <td><a href="#classApplication">Application</a>
+      <td><a data-link-type="dfn" href="#application" id="ref-for-application③⑨">Application</a> used to grant the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①③">Access Authorization</a>
+     <tr>
+      <td>grantedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①④">Access Authorization</a> was granted
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑧">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④⓪">Application</a> that has received
+      authorization
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>An <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②①">Access Need Group</a> used to communicate the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②③">Access Needs</a> that the <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑤">Access Authorization</a> is
+      satisfying
+     <tr>
+      <td>hasDataAuthorization
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td>Authorization for a specific type of data
+     <tr>
+      <td>replaces
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td>Previous <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑥">Access Authorization</a> replaced by current instance
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑦">Access Authorization</a> for Projectron at
+    https://alice.example/authorization/e2765d6c - <a href="snippets/alice.example/e2765d6c.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>e2765d6c</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#d8219b1f</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataAuthorization</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-> <c- p>,</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e4cb692</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑧">Access Authorization</a> for Bob at
+    https://alice.example/authorization/4460dce3 - <a href="snippets/alice.example/4460dce3.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>4460dce3</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedWith</c-> <c- nn>jarvis</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#d8219b1f</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataAuthorization</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>f800b10c</c-> <c- p>,</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>ec6057d9</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9⑦"><a class="self-link" href="#issue-d41d8cd9⑦"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/177" style="text-transform:none">solid/data-interoperability-panel/177</a><a href="https://github.com/solid/data-interoperability-panel/issues/177">Should a copy of access needs be retained when consent is granted?</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9⑧"><a class="self-link" href="#issue-d41d8cd9⑧"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/221" style="text-transform:none">solid/data-interoperability-panel/221</a><a href="https://github.com/solid/data-interoperability-panel/issues/221">Document pattern of using local group as grantee of consent</a></div>
+   <div class="issue no-marker" id="issue-d41d8cd9⑨"><a class="self-link" href="#issue-d41d8cd9⑨"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/256" style="text-transform:none">solid/data-interoperability-panel/256</a><a href="https://github.com/solid/data-interoperability-panel/issues/256">Resource Owner restricting their own access</a></div>
+   <h3 class="heading settled" data-level="9.2" id="data-authorization"><span class="secno">9.2. </span><span class="content">Data Authorization</span><a class="self-link" href="#data-authorization"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-authorization①">Data Authorization</dfn> records the decision of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑧⑨">Social Agent</a> to grant access to a specific type of data in their control, identified
+by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑤">Shape Tree</a>. They are always associated with a single <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①①⑨">Access Authorization</a>.</p>
+   <p><a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①">Data Authorizations</a> should not be shared with the <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑥">Agent</a> that has
+been granted access. <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①">Data Grants</a> are generated from <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①">Data Authorizations</a>,
+and are appropriate to share with the grantee.</p>
+   <p><a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②">Data Authorizations</a> are immutable. If a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①③">Data Authorization</a> needs to change, it should be replaced.</p>
+   <p><a href="interop.ttl#DataAuthorization">Class Definition</a> - <a href="interop.shex#DataAuthorizationShape">Shape Definition</a> - <a href="interop.tree#DataAuthorizationTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataAuthorization">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⓪">Social Agent</a> that granted the <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①④">Data Authorization</a>
+     <tr>
+      <td>dataOwner
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨①">Social Agent</a> that owns the data being authorized
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨②">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④①">Application</a> that has received
+      authorization
+     <tr>
+      <td>registeredShapeTree
+      <td><a class="vocab" href="https://www.w3.org/ns/shapetrees#ShapeTree">st:ShapeTree</a>
+      <td><a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑥">Shape Tree</a> representing the type of data being authorized
+     <tr>
+      <td>accessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Modes of access granted to the authorized data
+     <tr>
+      <td>creatorAccessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Additional access mode assigned to the creator of a
+        data instance. Adds to the set of modes linked via <code>interop:accessMode</code>. Only valid when <code>accessMode</code> includes <code>acl:Create</code>, <code>acl:Write</code>, or <code>acl:Append</code>
+     <tr>
+      <td>scopeOfAuthorization
+      <td>interop:All, interop:AllFromAgent, interop:AllFromRegistry,
+      interop:SelectedFromRegistry, interop:Inherited
+      <td>Identifies the <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope">access scope</a> of the <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑤">Data Authorization</a>
+     <tr>
+      <td>hasDataRegistration
+      <td>A <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②①">Data Registration</a> for <code>registeredShapeTree</code>
+      <td>Links to a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②②">Data Registration</a> of registeredShapeTree in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑦">Data Registry</a> that is a subject of the current <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑥">Data Authorization</a>.
+     <tr>
+      <td>hasDataInstance
+      <td><a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①②">Data instance</a> of <code>registeredShapeTree</code>
+      <td>Links to a <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①③">Data Instance</a> of registeredShapeTree in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑧">Data Registry</a>.
+     <tr>
+      <td>satisfiesAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Links to the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②④">Access Need</a> satisfied by the <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑦">Data Authorization</a>
+     <tr>
+      <td>inheritsFromAuthorization
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td>Links to a parent <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑧">Data Authorization</a> whose registeredShapeTree
+      references the shape tree associated with the current <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①⑨">Data Authorization</a>.
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⓪">Data Authorization</a> for Projectron to access Projects
+    at https://alice.example/authorization/54a1b6a0 - <a href="snippets/alice.example/54a1b6a0.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>All</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①①">Data Authorization</a> for Projectron to access Tasks
+    at https://alice.example/authorization/0e4cb692 - <a href="snippets/alice.example/0e4cb692.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e4cb692</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromAuthorization</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="9.3" id="access-grant"><span class="secno">9.3. </span><span class="content">Access Grant</span><a class="self-link" href="#access-grant"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-grant①">Access Grant</dfn> provides an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑦">Agent</a> with a detailed
+description of access that has been granted to them. <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑦">Access Grants</a> are generated from <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②⓪">Access Authorizations</a>, and are stored in the <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry⑨">Agent Registry</a> of the <a data-link-type="dfn">Data Owner</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑧">Access Grant</a> has one or more <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①">Data Grants</a>, each of which
+represents access granted to a specific type of data.</p>
+   <p><a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①⑨">Access Grants</a> are immutable. If an <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①⓪">Access Grant</a> needs to change, it must be replaced.</p>
+   <p><a href="interop.ttl#AccessGrant">Class Definition</a> - <a href="interop.shex#AccessGrantShape">Shape Definition</a> - <a href="interop.tree#AccessGrantTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessGrant">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨③">Social Agent</a> that granted the <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①①">Access Grant</a>
+     <tr>
+      <td>grantedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①②">Access Grant</a> was granted
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>Links to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨④">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④②">Application</a> that was granted access.
+     <tr>
+      <td>hasAccessNeedGroup
+      <td><a href="#classAccessNeedGroup">AccessNeedGroup</a>
+      <td>Links to an <a data-link-type="dfn" href="#access-need-group①" id="ref-for-access-need-group①②②">Access Need Group</a> associated with the Access Grant.
+     <tr>
+      <td>hasDataGrant
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td>Links to a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②">Data Grant</a> associated with the Access Grant.
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①③">Access Grant</a> to Projectron, stored in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑦">Agent Registration</a> for Projectron in her <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①⓪">Agent Registry</a> at
+  https://alice.pod.example/agents/2f2f3628/27eae14b - <a href="snippets/alice.example/27eae14b.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>27eae14b</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedAt</c-> <c- s>"2020-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessNeedGroup</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#d8219b1f</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataGrant</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-> <c- p>,</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>0945218b</c-> <c- p>,</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c-> <c- p>,</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>017d6a07</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <h3 class="heading settled" data-level="9.4" id="data-grant"><span class="secno">9.4. </span><span class="content">Data Grant</span><a class="self-link" href="#data-grant"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="data-grant①">Data Grant</dfn> provides an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑧">Agent</a> with a detailed description
+of access that has been granted to them for a specific type of data,
+identified by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑦">Shape Tree</a>. Each <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③">Data Grant</a> is associated with
+a single <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①④">Access Grant</a>.</p>
+   <p>A <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①④">Data Grant</a> may inherit from another <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑤">Data Grant</a>, when the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑧">shape tree</a> associated with the "parent" <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑥">Data Grant</a> has one or
+more <a data-link-type="dfn" href="#shape-tree-reference" id="ref-for-shape-tree-reference">Shape Tree References</a>.</p>
+   <p>Each <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑦">Data Grant</a> has an assigned scope (<code>interop:scopeOfGrant</code>), which
+determines how permissions are assigned.</p>
+   <p>When creating a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑧">Data Grant</a>, there should be an <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②⑤">Access Need</a> linked
+via <code>interop:satisfiesAccessNeed</code> with the same <code>interop:registeredShapeTree</code>.</p>
+   <p>When a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑤">Social Agent</a> grants another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①②⑨">Agent</a> access to data that was shared
+with them, a <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①">Delegated Data Grant</a> is used instead.</p>
+   <p><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①⑨">Data Grants</a> are immutable. If a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⓪">Data Grant</a> needs to change, it should be replaced.</p>
+   <p><a href="interop.ttl#DataGrant">Class Definition</a> - <a href="interop.shex#DataGrantShape">Shape Definition</a> - <a href="interop.tree#DataGrantTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDataGrant">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>dataOwner
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑥">Social Agent</a> that owns the data being granted
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑦">Social Agent</a> that granted the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①①">Data Grant</a>
+     <tr>
+      <td>grantee
+      <td><a href="#classAgent">Agent</a>
+      <td>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑧">Social Agent</a> or <a data-link-type="dfn" href="#application" id="ref-for-application④③">Application</a> that was granted access.
+     <tr>
+      <td>registeredShapeTree
+      <td>st:ShapeTree
+      <td><a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②③">Data Registration</a> for the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree①⑨">shape tree</a> that access
+      will be granted to
+     <tr>
+      <td>hasDataRegistration
+      <td><a href="#classDataRegistration">DataRegistration</a>
+      <td><a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②④">Data Registration</a> for <code>registeredShapeTree</code> that the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①②">Data Grant</a> applies to
+     <tr>
+      <td>accessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Modes of access granted to the target data at hasDataRegistration
+     <tr>
+      <td>creatorAccessMode
+      <td><code>acl:Read, acl:Write, acl:Update, acl:Create, acl:Delete, acl:Append</code>
+      <td>Additional access mode assigned to the creator of a
+        data instance. Adds to the set of modes linked via <code>interop:accessMode</code>. Only valid when <code>accessMode</code> includes <code>acl:Create</code>, <code>acl:Write</code>, or <code>acl:Append</code>
+     <tr>
+      <td>scopeOfGrant
+      <td>interop:All, interop:AllFromAgent, interop:AllFromRegistry,
+      interop:SelectedFromRegistry, interop:Inherited
+      <td>Identifies the <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope①">access scope</a> of the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①③">Data Grant</a>
+     <tr>
+      <td>satisfiesAccessNeed
+      <td><a href="#classAccessNeed">AccessNeed</a>
+      <td>Links to the <a data-link-type="dfn" href="#access-need" id="ref-for-access-need②⑥">Access Need</a> satisfied by the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①④">Data Grant</a>
+     <tr>
+      <td>hasDataInstance
+      <td>Instance of registeredShapeTree
+      <td>Links to a <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①④">Data Instance</a> of registeredShapeTree.
+     <tr>
+      <td>inheritsFromGrant
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td>Links to another <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑤">Data Grant</a> whose registeredShapeTree
+      references the shape tree associated with the current <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑥">Data Grant</a>.
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑦">Data Grant</a> for Projectron to access Projects at
+  https://alice.example/agents/2f2f3628/40d038ea - <a href="snippets/alice.example/40d038ea.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑧">Data Grant</a> for Projectron to access Tasks at
+  https://alice.example/agents/2f2f3628/0945218b - <a href="snippets/alice.example/0945218b.ttl">View</a> </figcaption>
+<pre class="include-code highlight">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>df4ab227\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c->
+    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①⓪"><a class="self-link" href="#issue-d41d8cd9①⓪"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/223" style="text-transform:none">solid/data-interoperability-panel/223</a><a href="https://github.com/solid/data-interoperability-panel/issues/223">Address Issuer restrection in data grants, plus RO Client constraints</a></div>
+   <h3 class="heading settled" data-level="9.5" id="delegated-data-grant"><span class="secno">9.5. </span><span class="content">Delegated Data Grant</span><a class="self-link" href="#delegated-data-grant"></a></h3>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="delegated-data-grant①">Delegated Data Grant</dfn> is a sub-class of <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①①⑨">Data Grant</a> used when a grantee re-shares or "delegates" access they’ve
+received to another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⓪">Agent</a>. The most common use case
+is when Alice shares access with Bob, and Bob delegates
+that access to his project management application.</p>
+   <p><a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①①">Delegated Data Grants</a> are immutable. If a <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①②">Delegated Data Grant</a> needs to change, it should be replaced.</p>
+   <p><a href="interop.ttl#DelegatedDataGrant">Class Definition</a> - <a href="interop.shex#DelegatedDataGrantShape">Shape Definition</a> - <a href="interop.tree#DelegatedDataGrantTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classDelegatedDataGrant">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>delegationOfGrant
+      <td><a href="#classDataGrant">DataGrant</a>
+      <td><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⓪">Data Grant</a> that is being delegated
+   </table>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①③">Delegated Data Grant</a> for Projectron to access Projects
+  that Bob shared with her at https://alice.example/agents/2f2f3628/fe818190 - <a href="snippets/alice.example/fe818190.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c->
+    <c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①④">Delegated Data Grant</a> for Projectron to access Tasks
+  that Bob shared with her at https://alice.example/agents/2f2f3628/017d6a07 - <a href="snippets/alice.example/017d6a07.ttl">View</a> </figcaption>
+<pre class="include-code highlight"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>017d6a07</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>45e092cf\/</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c-> <c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c->
+    <c- nn>bob-alice</c-><c- p>:</c-><c- f>d5b5760c</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①①"><a class="self-link" href="#issue-d41d8cd9①①"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a></div>
+   <h3 class="heading settled" data-level="9.6" id="access-scopes"><span class="secno">9.6. </span><span class="content">Data Access Scopes</span><a class="self-link" href="#access-scopes"></a></h3>
+   <p>Each <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①②">Data Authorization</a> applies to a specific type of data,
+identified by a <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②⓪">shape tree</a>. The amount of access authorized for data
+of that type is specified by the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-scope">Access Scope</dfn>, via <code>interop:scopeOfAuthorization</code>.</p>
+   <p><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②①">Data Grants</a> are generated from a given <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①③">Data Authorization</a> based on <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope②">access scope</a> and other supporting criteria detailed below.</p>
+   <p>Each <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②②">Data Grant</a> corresponds to a specific <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑤">Data Registration</a> in a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①⑨">Data Registry</a>, and has an associated <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope③">access scope</a> and <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode">access modes</a>.</p>
+   <p class="issue" id="issue-a2fe1e29"><a class="self-link" href="#issue-a2fe1e29"></a> This specification uses some access modes in the <code>acl:</code> namespace that
+have not been adopted to demonstrate the most secure and accurate
+expression of a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent⑨⑨">Social Agent’s</a> authorization. <a href="https://github.com/solid/authorization-panel/issues/253">Discussions are underway</a> to add these modes.</p>
+   <p class="issue" id="issue-5157d1cb"><a class="self-link" href="#issue-5157d1cb"></a> <a data-link-type="biblio" href="#biblio-wac" title="Web Access Control">[WAC]</a> does not have any mechanism to extend or modify
+inherited permissions.</p>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Scope
+      <th>Authorization
+      <th>Grant
+      <th>Description
+    <tbody>
+     <tr>
+      <td><a href="#scope-all"><b><code>All</code></b></a>
+      <td>Yes
+      <td><b>No</b>
+      <td>All of the owner’s data of a specified type, and all data shared with the owner of that type, across the owner’s registries
+     <tr>
+      <td><a href="#scope-fromagent"><b><code>AllFromAgent</code></b></a>
+      <td>Yes
+      <td><b>No</b>
+      <td>All data of a given type shared by a specified <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⓪">Social Agent</a> with the owner, across that <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪①">Social Agent’s</a> registries
+     <tr>
+      <td><a href="#scope-fromregistry"><b><code>AllFromRegistry</code></b></a>
+      <td>Yes
+      <td>Yes
+      <td>All of the data owner’s data of a specified type in a specified <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⓪">Data Registry</a>
+     <tr>
+      <td><a href="#scope-selected"><b><code>SelectedFromRegistry</code></b></a>
+      <td>Yes
+      <td>Yes
+      <td>Only specified <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑤">Data Instances</a> of the data owner’s of a given type in a specified <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①①">Data Registry</a>
+     <tr>
+      <td><a href="#scope-inherited"><b><code>Inherited</code></b></a>
+      <td>Yes
+      <td>Yes
+      <td>Only <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑥">Data Instances</a> of the data owner’s that are associated with <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑦">Data Instances</a> allowed by another authorization or grant
+   </table>
+   <h4 class="heading settled" data-level="9.6.1" id="scope-all"><span class="secno">9.6.1. </span><span class="content"><code>All</code></span><a class="self-link" href="#scope-all"></a></h4>
+   <p>The <code>interop:All</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope④">access scope</a> includes all data of a specified type
+belonging to a given data owner, and all data of that same type shared with the data
+owner, across all of the data owner’s registries.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationAllShape">DataAuthorizationAllShape</a></p>
+   <p>The follow example illustrates <em>Alice’s</em> authorization to give <em>Projectron</em> access to
+data of type <code>pm-shapetrees:ProjectTree</code> with a scope of <code>interop:All</code>. Since
+Alice has two <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①②">Data Registries</a> and Bob has shared projects with her, several <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②③">Data Grants</a> will be generated from this <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①④">Data Authorization</a> and shared
+with Projectron.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> <code>interop:All</code> is only valid for a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑤">Data Authorization</a>.
+Generated <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②④">Data Grants</a> use the more specific <code>interop:AllFromRegistry</code> for each unique <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①③">Data Registry</a>, including Bob’s.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑥">Data Authorization</a> for Projectron to access Projects
+    at https://alice.example/authorization/54a1b6a0 - <a href="snippets/alice.example/54a1b6a0.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>All</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑤">Data Grant</a> for Projectron to access Projects in her
+  Work <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①④">Data Registry</a> at
+  https://alice.example/agents/2f2f3628/40d038ea - <a href="snippets/alice.example/40d038ea.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑥">Data Grant</a> for Projectron to access her Projects in
+  her Personal <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑤">Data Registry</a> at
+  https://alice.example/agents/2f2f3628/a0623c8f - <a href="snippets/alice.example/a0623c8f.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>a0623c8f</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-personal-data</c-><c- p>:</c-><c- f>fe7a8e7b\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①⑤">Delegated Data Grant</a> for Projectron to access Projects
+  that Bob shared with her at https://alice.example/agents/2f2f3628/fe818190 - <a href="snippets/alice.example/fe818190.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>fe818190</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c-></span><span class="line-no"></span><span class="line">    <c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <h4 class="heading settled" data-level="9.6.2" id="scope-fromagent"><span class="secno">9.6.2. </span><span class="content"><code>AllFromAgent</code></span><a class="self-link" href="#scope-fromagent"></a></h4>
+   <p>The <code>interop:AllFromAgent</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑤">access scope</a> includes all data of a given type
+owned and shared by a specified <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪②">Social Agent</a>, across all of their <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑥">Data Registries</a>. Essentially, Alice can use this scope to delegate
+any access that she has been given to another <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪③">Social Agent’s</a> data (e.g. Bob), to another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③①">Agent</a> of her choosing.</p>
+   <p>The <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪④">Social Agent</a> whose access is being shared is identified via <code>interop:dataOwner</code>.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationAllFromAgentShape">DataAuthorizationAllFromAgentShape</a></p>
+   <p>The following example illustrates <em>Alice’s</em> authorization to give Performchart access to
+data of type <code>pm-shapetrees:ProjectTree</code> with a scope of <code>interop:AllFromAgent</code> and an <code>interop:dataOwner</code> of <em>Bob</em>.</p>
+   <p class="note" role="note"><span class="marker">Note:</span> While Bob has granted Alice the ability to manipulate his project data,
+Alice grants Performchart a narrower scope of read-only access.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑦">Data Authorization</a> for Performchart to access Projects
+    that Bob shared with her at https://alice.example/authorization/0e36ba8f - <a href="snippets/alice.example/0e36ba8f.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e36ba8f</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromAgent</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>Bob has shared data of this type with Alice from
+only one <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑦">Data Registry</a>, which he shared with her previously
+through her <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑧">Agent Registration</a> in his <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①①">Agent Registry</a>.</p>
+   <figure>
+    <figcaption>Bob’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑦">Data Grant</a> for Alice to access Projects
+  at https://bob.example/agents/255aa181/b2b6a645 - <a href="snippets/bob.example/b2b6a645.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>Alice generates one <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①⑥">Delegated Data Grant</a> for Performchart to access
+the Project data that Bob shared with her, which she stores in
+the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations⑨">Agent Registration</a> for Performchart in her <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①②">Agent Registry</a>.
+It is marked as a delegation of Bob’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑧">Data Grant</a> via <code>interop:delegationOfGrant</code>.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#delegated-data-grant①" id="ref-for-delegated-data-grant①⑦">Delegated Data Grant</a> for Performchart to access Projects
+  that Bob shared with her at https://alice.example/agents/c2328cdd/efc426c9 - <a href="snippets/alice.example/efc426c9.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>alice-performchart</c-><c- p>:</c-><c- f>efc426c9</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DelegatedDataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>performchart</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>delegationOfGrant</c-></span><span class="line-no"></span><span class="line">    <c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <h4 class="heading settled" data-level="9.6.3" id="scope-fromregistry"><span class="secno">9.6.3. </span><span class="content"><code>AllFromRegistry</code></span><a class="self-link" href="#scope-fromregistry"></a></h4>
+   <p>The <code>interop:AllFromRegistry</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑥">access scope</a> includes all
+data of a specified type in a specified <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑧">Data Registry</a> of a given data owner.
+Since a <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①①⑨">Data Registry</a> can only have one <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑥">Data Registration</a> per <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②①">shape tree</a>,
+this scope provide access to all <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑧">Data Instances</a> in the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑦">Data Registration</a> of the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②②">shape tree</a> specified via <code>interop:registeredShapeTree</code>.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationAllFromRegistryShape">DataAuthorizationAllFromRegistryShape</a> - <a href="interop.shex#DataGrantAllFromRegistryShape">DataGrantAllFromRegistryShape</a></p>
+   <p>The following example illustrates <em>Bob’s</em> authorization to give Alice access to
+all data of type <code>pm-shapetrees:ProjectTree</code> in the <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②⓪">Data Registry</a> he uses
+for his professional work.</p>
+   <figure>
+    <figcaption>Bob’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑧">Data Authorization</a> at https://bob.example/authorization/e4b1b154
+  for Alice to access his Project data - <a href="snippets/bob.example/e4b1b154.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>bob-authorization</c-><c- p>:</c-><c- f>e4b1b154</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span><span class="line-no"></span><span class="line"></span></pre>
+   </figure>
+   <p>The following <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①②⑨">Data Grant</a> is generated for Alice based on the above <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①①⑨">Data Authorization</a>, and stored in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations①⓪">Agent Registration</a> for Alice in
+Bob’s <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①③">Agent Registry</a>.</p>
+   <figure>
+    <figcaption>Bob’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⓪">Data Grant</a> at https://bob.example/agents/255aa181/b2b6a645
+  for Alice to access his work Project data - <a href="snippets/bob.example/b2b6a645.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>bob-alice</c-><c- p>:</c-><c- f>b2b6a645</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>bob</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>bob-work-data</c-><c- p>:</c-><c- f>08a99a10\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="22"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>When a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③①">Data Grant</a> is assigned the <code>interop:AllFromRegistry</code> scope, the <code>interop:grantee</code> is authorized to access all <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance①⑨">Data Instances</a> in the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑧">Data Registration</a> linked via <code>interop:hasDataRegistration</code>,
+limited by the <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode①">access modes</a> linked via <code>interop:accessMode</code>.</p>
+   <p>In the above example, Bob would be giving Alice the following access to <code>pm-shapetrees:ProjectTree</code> <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⓪">Data Instances</a> (Projects) in the <code>bob-work-data:08a99a10</code> <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①②⑨">Data Registration</a>:</p>
+   <ul>
+    <li data-md>
+     <p>Read the Data Registration</p>
+    <li data-md>
+     <p>List all Projects</p>
+    <li data-md>
+     <p>Read all Projects</p>
+    <li data-md>
+     <p>Create a new Project</p>
+    <li data-md>
+     <p>Read a Project she creates</p>
+    <li data-md>
+     <p>Delete a Project she creates</p>
+    <li data-md>
+     <p>Create resources in a Project she creates</p>
+    <li data-md>
+     <p>Modify existing resources in a Project she creates</p>
+   </ul>
+   <figure>
+    <figcaption>Interpreting <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode②">access modes</a> for a <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⓪">Data Registration</a> with
+  AllFromRegistry scope</figcaption>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Mode
+       <th>Description
+     <tbody>
+      <tr>
+       <td><code>acl:Create</code>
+       <td>Create new <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②①">Data Instances</a>. <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode③">Access modes</a> assigned to
+        the creator on the created <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②②">Data Instance</a> should be a union of <code>interop:accessMode</code> and <code>interop:createAccessMode</code> modes. <b>acl:Create is not currently supported.
+        Substitute with acl:Write or acl:Append, but may exceed intended scope
+        of access.</b>
+      <tr>
+       <td><code>acl:Read</code>
+       <td>Read <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③①">Data Registration</a>. List and read all <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②③">Data Instances</a>
+      <tr>
+       <td><code>acl:Update</code>
+       <td>Modify <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②④">Data Instances</a>. Modification of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③②">Data Registration</a> graph
+        not permitted. <b><code>acl:Update</code> is not currently supported. Substitute with <code>acl:Write</code> or <code>acl:Append</code>, but may exceed intended scope of access.</b>
+      <tr>
+       <td><code>acl:Delete</code>
+       <td>Delete <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑤">Data Instances</a>. Deletion of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③③">Data Registration</a> not permitted. <b><code>acl:Delete</code> is not currently supported. Substitute with <code>acl:Write</code>, but
+        may exceed intended scope of access.</b>
+    </table>
+   </figure>
+   <h4 class="heading settled" data-level="9.6.4" id="scope-selected"><span class="secno">9.6.4. </span><span class="content"><code>SelectedFromRegistry</code></span><a class="self-link" href="#scope-selected"></a></h4>
+   <p>The <code>interop:SelectedFromRegistry</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑦">access scope</a> includes only
+specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑥">Data Instances</a> of the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②③">shape tree</a> specified via <code>interop:registeredShapeTree</code> in the <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②①">Data Registry</a> of a given
+data owner.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationSelectedFromRegistryShape">DataAuthorizationSelectedFromRegistryShape</a> - <a href="interop.shex#DataGrantSelectedFromRegistryShape">DataGrantSelectedFromRegistryShape</a></p>
+   <p>The following example illustrates <em>Jose’s</em> authorization for Alice to access
+two specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑦">Data Instances</a> of <code>pm-shapetrees:ProjectTree</code> in the <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②②">Data Registry</a> he uses for his professional work.</p>
+   <figure>
+    <figcaption>Jose’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⓪">Data Authorization</a> at https://jose.example/authorization/69095550
+  for Alice to access his Project data - <a href="snippets/jose.example/69095550.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"></span><span class="line-no"></span><span class="line"><c- nn>jose-authorization</c-><c- p>:</c-><c- f>69095550</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="20"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/9355352a</c-> <c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/3d3dc323</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>The following <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③②">Data Grant</a> is generated for Alice based on the above <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②①">Data Authorization</a>, and stored in the <a data-link-type="dfn" href="#agent-registrations" id="ref-for-agent-registrations①①">Agent Registration</a> for Alice in
+Jose’s <a data-link-type="dfn" href="#agent-registry" id="ref-for-agent-registry①④">Agent Registry</a>.</p>
+   <figure>
+    <figcaption>Jose’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③③">Data Grant</a> at https://jose.example/agents/efba320e/2aa21a8c
+  to share specific work projects with Alice - <a href="snippets/jose.example/2aa21a8c.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>jose</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="23"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>SelectedFromRegistry</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataInstance</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/9355352a</c-> <c- p>,</c-></span><span class="line-no"></span><span class="line">    <c- nn>jose-work-data</c-><c- p>:</c-><c- f>c3feca8c\/3d3dc323</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>When a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③④">Data Grant</a> is assigned the <code>interop:SelectedFromRegistry</code> scope, the <code>interop:grantee</code> is authorized to access only the specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑧">Data Instances</a> linked via <code>interop:hasDataInstance</code> in the <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③④">Data Registration</a> linked via <code>interop:hasDataRegistration</code>,
+limited by the <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode④">access modes</a> linked via <code>interop:accessMode</code>.</p>
+   <figure>
+    <figcaption>Valid <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑤">access modes</a> for a <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance②⑨">Data Instance</a></figcaption>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Mode
+       <th>Description
+     <tbody>
+      <tr>
+       <td><code>acl:Create</code>
+       <td>Create new resources within the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⓪">Data Instances</a> where applicable. <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑥">Access modes</a> assigned to
+        the creator on a created resource should be a union of <code>interop:accessMode</code> and <code>interop:createAccessMode</code> modes. <b>acl:Create is not currently supported.
+        Substitute with acl:Write or acl:Append, but may exceed intended scope
+        of access.</b>
+      <tr>
+       <td><code>acl:Read</code>
+       <td>Read <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③①">Data Instance</a> and any contained resources where applicable.
+      <tr>
+       <td><code>acl:Update</code>
+       <td>Modify <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③②">Data Instance</a> and any contained resources where applicable. <b><code>acl:Update</code> is not currently supported. Substitute with <code>acl:Write</code> or <code>acl:Append</code>, but may exceed intended scope of access.</b>
+      <tr>
+       <td><code>acl:Append</code>
+       <td>Add new data to resources in the <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③③">Data Instance</a>, without changing any
+        existing data.
+      <tr>
+       <td><code>acl:Delete</code>
+       <td>Delete <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③④">Data Instance</a> or any contained resources where applicable. <b><code>acl:Delete</code> is not currently supported. Substitute with <code>acl:Write</code>, but
+        may exceed intended scope of access.</b>
+    </table>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①②"><a class="self-link" href="#issue-d41d8cd9①②"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/186" style="text-transform:none">solid/data-interoperability-panel/186</a><a href="https://github.com/solid/data-interoperability-panel/issues/186">Human readable labels for Data Instances, needed when selecting instances on consent screen. </a></div>
+   <h4 class="heading settled" data-level="9.6.5" id="scope-inherited"><span class="secno">9.6.5. </span><span class="content"><code>Inherited</code></span><a class="self-link" href="#scope-inherited"></a></h4>
+   <p>The <code>interop:Inherited</code> <a data-link-type="dfn" href="#access-scope" id="ref-for-access-scope⑧">access scope</a> is unique in that it depends
+on the existence of another <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②②">Data Authorization</a> with a scope of <code>interop:All</code>, <code>interop:AllFromAgent</code>, <code>interop:AllFromRegistry</code>, or <code>interop:SelectedFromRegistry</code>.</p>
+   <p>When a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②③">Data Authorization</a> exists with
+one of those scopes, and its <code>interop:registeredShapeTree</code> specifies
+one or more virtual hierarchies via <code>st:references</code>, a corresponding <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②④">Data Authorization</a> with a scope of <code>interop:Inherited</code> can be created
+for each distinct reference.</p>
+   <p><b>Shapes:</b> <a href="interop.shex#DataAuthorizationInheritedShape">DataAuthorizationInheritedShape</a> - <a href="interop.shex#DataGrantInheritedShape">DataGrantInheritedShape</a></p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑤">Data Authorization</a> for Projectron to access Projects
+    at https://alice.example/authorization/54a1b6a0 - <a href="snippets/alice.example/54a1b6a0.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>All</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>The <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②④">shape tree</a> <code>pm-shapetrees:ProjectTree</code> specifies one virtual hierarchy
+via <code>st:references</code>, indicating that a Project <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑤">Data Instance</a> virtually
+includes Task instances of <code>pm-shapetrees:TaskTree</code> through the
+predicate <code>pm:hasTask</code>.</p>
+   <figure>
+    <figcaption> ProjectTree definition at https://data.example/shapetrees/pm-shapetrees.tree - <a href="snippets/data.example/pm-shapetrees.tree">View Definition</a> </figcaption>
+<pre class="include-code highlight"><c- g>&lt;#ProjectTree></c->
+  <c- b>a</c-> <c- nn>st</c-><c- p>:</c-><c- f>ShapeTree</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>expectsType</c-> <c- nn>st</c-><c- p>:</c-><c- f>Resource</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>shape</c-> <c- nn>pm-shex</c-><c- p>:</c-><c- f>ProjectShape</c-> <c- p>;</c->
+  <c- nn>st</c-><c- p>:</c-><c- f>references</c-> <c- p>[</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>hasShapeTree</c-> <c- g>&lt;#TaskTree></c-> <c- p>;</c->
+    <c- nn>st</c-><c- p>:</c-><c- f>viaPredicate</c-> <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+  <c- p>]</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <p>Consequently, a <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑥">Data Authorization</a> with <code>interop:Inherited</code> scope can be created
+for <code>pm-shapetrees:TaskTree</code>.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑦">Data Authorization</a> for Projectron to access Tasks
+    at https://alice.example/authorization/0e4cb692 - <a href="snippets/alice.example/0e4cb692.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-authorization</c-><c- p>:</c-><c- f>0e4cb692</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataAuthorization</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="19"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfAuthorization</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromAuthorization</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>54a1b6a0</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p><a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑤">Data Grants</a> for Projects and their associated Tasks can then be generated
+for Projectron based on the above <a data-link-type="dfn" href="#data-authorization①" id="ref-for-data-authorization①②⑧">Data Authorizations</a>.</p>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑥">Data Grant</a> for Projectron to access Projects in her
+  Work <a data-link-type="dfn" href="#data-registry①" id="ref-for-data-registry①②③">Data Registry</a> at
+  https://alice.example/agents/2f2f3628/40d038ea - <a href="snippets/alice.example/40d038ea.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>ProjectTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>8501f084\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#ac54ff1e</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AllFromRegistry</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <figure>
+    <figcaption>Alice’s <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑦">Data Grant</a> for Projectron to access Tasks associated
+  with authorized Work Projects at
+  https://alice.example/agents/2f2f3628/0945218b - <a href="snippets/alice.example/0945218b.ttl">View</a> </figcaption>
+<pre class="include-code highlight line-numbered"><span class="line-no"></span><span class="line"><c- nn>alice-projectron</c-><c- p>:</c-><c- f>0945218b</c-></span><span class="line-no"></span><span class="line">  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>DataGrant</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>dataOwner</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>grantee</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#id</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>registeredShapeTree</c-> <c- nn>pm-shapetrees</c-><c- p>:</c-><c- f>TaskTree</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>hasDataRegistration</c-> <c- nn>alice-work-data</c-><c- p>:</c-><c- f>df4ab227\/</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>satisfiesAccessNeed</c-> <c- nn>projectron</c-><c- p>:</c-><c- f>\#9462959c</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>accessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Read</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Create</c-> <c- p>;</c-></span><span class="line-no highlight-line" data-line="21"></span><span class="line highlight-line">  <c- nn>interop</c-><c- p>:</c-><c- f>creatorAccessMode</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Update</c-><c- p>,</c-> <c- nn>acl</c-><c- p>:</c-><c- f>Delete</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>scopeOfGrant</c-> <c- nn>interop</c-><c- p>:</c-><c- f>Inherited</c-> <c- p>;</c-></span><span class="line-no"></span><span class="line">  <c- nn>interop</c-><c- p>:</c-><c- f>inheritsFromGrant</c-></span><span class="line-no"></span><span class="line">    <c- nn>alice-projectron</c-><c- p>:</c-><c- f>40d038ea</c-> <c- p>.</c-></span></pre>
+   </figure>
+   <p>When a <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑧">Data Grant</a> is assigned the <code>interop:Inherited</code> scope, the <code>interop:grantee</code> is authorized to access only the specific <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑥">Data Instances</a> linked via <code>st:references</code> in the <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②⑤">shape tree</a> of the <a data-link-type="dfn" href="#data-grant①" id="ref-for-data-grant①③⑨">Data Grant</a> linked via <code>interop:inheritsFromGrant</code></p>
+   <p>In the example above, Alice grants Projectron the following access to <b>only the</b> <code>pm-shapetrees:TaskTree</code> <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑦">Data Instances</a> (Tasks) in the <code>alice-work-data:df4ab227</code> <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑤">Data Registration</a> that are linked
+to <code>pm-shapetrees:ProjectTree</code> <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑧">Data Instances</a> (Projects) in the <code>alice-work-data:8501f084</code> <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑥">Data Registration</a>.</p>
+   <p>For example, the three Tasks linked from the Project <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance③⑨">Data Instance</a> below via <code>pm:hasTask</code> would be included in the <code>interop:Inherited</code> scope.</p>
+   <figure>
+    <figcaption>A Project <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④⓪">Data Instance</a> in <code>alice-work-data:8501f084</code> - <a href="snippets/work.alice.example/16e1eae9.ttl">View</a> </figcaption>
+<pre class="include-code highlight">
+<c- nn>alice-work-projects</c-><c- p>:</c-><c- f>16e1eae9</c->
+  <c- b>a</c-> <c- nn>pm</c-><c- p>:</c-><c- f>Project</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>id</c-> <c- mi>6</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>name</c-> <c- s>"Solid Project"</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>created_at</c-> <c- s>"2021-04-04T20:15:47.000Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>pm</c-><c- p>:</c-><c- f>hasTask</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>9b60a354</c-> <c- p>,</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>6e545b74</c-> <c- p>,</c->
+    <c- nn>alice-work-tasks</c-><c- p>:</c-><c- f>d33e01c8</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <figure>
+    <figcaption>Valid <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑦">access modes</a> on <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑦">Data Registration</a> with Inherited scope</figcaption>
+    <table align="left" class="data tree">
+     <colgroup>
+      <col>
+      <col>
+     <thead>
+      <tr>
+       <th>Mode
+       <th>Description
+     <tbody>
+      <tr>
+       <td><code>acl:Create</code>
+       <td>Create new <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④①">Data Instances</a> linked by shape tree reference. <a data-link-type="dfn" href="#access-mode" id="ref-for-access-mode⑧">Access modes</a> assigned to
+        the creator on the created <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④②">Data Instance</a> should be a union of <code>interop:accessMode</code> and <code>interop:createAccessMode</code> modes. <b>acl:Create is not currently supported.
+        Substitute with acl:Write or acl:Append, but may exceed intended scope
+        of access.</b>
+      <tr>
+       <td><code>acl:Read</code>
+       <td>Read <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④③">Data Instances</a> linked by shape tree reference
+      <tr>
+       <td><code>acl:Update</code>
+       <td>Modify <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④④">Data Instances</a> linked by shape tree reference. <b><code>acl:Update</code> is not currently supported. Substitute with <code>acl:Write</code> or <code>acl:Append</code>, but may exceed intended scope of access.</b>
+      <tr>
+       <td><code>acl:Append</code>
+       <td>Add new data to <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④⑤">Data Instances</a> linked by shape tree reference,
+        without changing any existing data.
+      <tr>
+       <td><code>acl:Delete</code>
+       <td>Delete <a data-link-type="dfn" href="#data-instance" id="ref-for-data-instance④⑥">Data Instances</a> linked by shape tree reference. Deletion of <a data-link-type="dfn" href="#data-registration①" id="ref-for-data-registration①③⑧">Data Registration</a> not permitted. <b><code>acl:Delete</code> is not currently supported. Substitute with <code>acl:Write</code>, but
+        may exceed intended scope of access.</b>
+    </table>
+   </figure>
+   <div class="issue no-marker" id="issue-d41d8cd9①③"><a class="self-link" href="#issue-d41d8cd9①③"></a><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/174" style="text-transform:none">solid/data-interoperability-panel/174</a><a href="https://github.com/solid/data-interoperability-panel/issues/174">Determine how to dynamically authorize access to reference lists on inherited instances</a></div>
+   <h3 class="heading settled" data-level="9.7" id="access-receipt"><span class="secno">9.7. </span><span class="content">Access Receipt</span><a class="self-link" href="#access-receipt"></a></h3>
+   <p>A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑤">Social Agent</a> provides an <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-receipt①">Access Receipt</dfn> to another <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③②">Agent</a> after granting them access to some scope of data
+in an <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②①">Access Authorization</a>.</p>
+   <p><a href="interop.ttl#AccessReceipt">Class Definition</a> - <a href="interop.shex#AccessReceiptShape">Shape Definition</a> - <a href="interop.tree#AccessReceiptTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAccessReceipt">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>providedAt
+      <td>xsd:dateTime
+      <td>Date and time the <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①②">Access Receipt</a> was provided
+     <tr>
+      <td>grantedBy
+      <td><a href="#classSocialAgent">SocialAgent</a>
+      <td><a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑥">Social Agent</a> who granted access and delivered the <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①③">Access Receipt</a>.
+   </table>
+   <figure>
+    <figcaption>An example <a data-link-type="dfn" href="#access-receipt①" id="ref-for-access-receipt①④">Access Receipt</a> from Alice to Bob</figcaption>
+<pre class="include-code highlight"><c- g>&lt;></c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AccessReceipt</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>providedAt</c-> <c- s>"2020-09-05T06:15:01Z"</c-><c- p>^^</c-><c- nn>xsd</c-><c- p>:</c-><c- f>dateTime</c-> <c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>grantedBy</c-> <c- nn>alice</c-><c- p>:</c-><c- f>\#id</c-> <c- p>.</c->
+</pre>
+   </figure>
+   <p>The <a data-link-type="dfn" href="#authorization-agent①" id="ref-for-authorization-agent①①④">Authorization Agent</a> of the recipient can use <a href="#agent-registration-discovery">§ 7.1.4 Agent Registration Discovery</a> to discover the <a data-link-type="dfn" href="#social-agent-registration①" id="ref-for-social-agent-registration①①④">Social Agent Registration</a> created for them. It should use the value of <code>grantedBy</code> as the target <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑦">Social Agent</a>.</p>
+   <h3 class="heading settled" data-level="9.8" id="access-registry"><span class="secno">9.8. </span><span class="content">Authorization Registry</span><a class="self-link" href="#access-registry"></a></h3>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-registry">Authorization Registry</dfn> is a collection of <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②②">Access Authorizations</a>.</p>
+   <p>The <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry③">Authorization Registry</a> is linked to a <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑧">Social Agent</a> via their <a data-link-type="dfn" href="#registry-set" id="ref-for-registry-set⑧">Registry Set</a>.</p>
+   <p>An <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry④">Authorization Registry</a> links to any number of registered <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②③">Access Authorizations</a>.</p>
+   <p><a href="interop.ttl#AuthorizationRegistry">Class Definition</a> - <a href="interop.shex#AuthorizationRegistryShape">Shape Definition</a> - <a href="interop.tree#AuthorizationRegistryTree">Shape Tree Definition</a></p>
+   <table align="left" class="classinfo data" id="classAuthorizationRegistry">
+    <colgroup>
+    <colgroup>
+    <colgroup>
+    <thead>
+     <tr>
+      <th>Property
+      <th>Range
+      <th>Description
+    <tbody>
+     <tr>
+      <td>hasAccessAuthorization
+      <td><a href="interop.ttl#AccessAuthorization">AccessAuthorization</a>
+      <td>Link to associated <a data-link-type="dfn" href="#access-authorization①" id="ref-for-access-authorization①②④">Access Authorizations</a>
+   </table>
+   <figure>
+    <figcaption>An <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry⑤">Authorization Registry</a> at
+  https://alice.example/authorization/ - <a href="snippets/alice.example/authorization.ttl">View</a></figcaption>
+<pre class="include-code highlight"><c- nn>alice-authorization</c-><c- p>:</c->
+  <c- b>a</c-> <c- nn>interop</c-><c- p>:</c-><c- f>AuthorizationRegistry</c-><c- p>;</c->
+  <c- nn>interop</c-><c- p>:</c-><c- f>hasAccessAuthorization</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>e2765d6c</c-> <c- p>,</c->   <c- c># projectron</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>47e07897</c-> <c- p>,</c->   <c- c># jarvis</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>d577d117</c-> <c- p>,</c->   <c- c># sarah</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>4460dce3</c-> <c- p>,</c->   <c- c># bob</c->
+    <c- nn>alice-authorization</c-><c- p>:</c-><c- f>cce01253</c-> <c- p>.</c->   <c- c># performchart</c->
+</pre>
+   </figure>
+   <h4 class="heading settled" data-level="9.8.1" id="access-hierarchy"><span class="secno">9.8.1. </span><span class="content">Resource Hierarchy</span><a class="self-link" href="#access-hierarchy"></a></h4>
+   <table align="left" class="data tree">
+    <colgroup>
+     <col>
+     <col>
+     <col>
+     <col>
+    <thead>
+     <tr>
+      <th>Resource
+      <th>Class
+      <th>Shape
+      <th>Shape Tree
+    <tbody>
+     <tr>
+      <td><code><a href="snippets/alice.example/authorization.ttl">authorizations/</a></code>
+      <td><a href="#classAuthorizationRegistry">AuthorizationRegistry</a>
+      <td><a href="interop.shex#AuthorizationRegistryShape">AuthorizationRegistryShape</a>
+      <td><a href="interop.tree#AuthorizationRegistryTree">AuthorizationRegistryTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/e2765d6c.ttl">e2765d6c/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/54a1b6a0.ttl">54a1b6a0/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/0e4cb692.ttl">0e4cb692/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/47e07897.ttl">47e07897/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/55363f56.ttl">55363f56/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/935458cf.ttl">935458cf/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/d577d117.ttl">d577d117/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/2d1568fb.ttl">2d1568fb/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/5ca4692b.ttl">5ca4692b/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/4460dce3.ttl">4460dce3/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/f800b10c.ttl">f800b10c/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/ec6057d9.ttl">ec6057d9/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/cce01253.ttl">cce01253/</a></code>
+      <td><a href="#classAccessAuthorization">AccessAuthorization</a>
+      <td><a href="interop.shex#AccessAuthorizationShape">AccessAuthorizationShape</a>
+      <td><a href="interop.tree#AccessAuthorizationTree">AccessAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/8f178288.ttl">8f178288/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/6531c8e2.ttl">6531c8e2/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/0e36ba8f.ttl">0e36ba8f/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/ca14a518.ttl">ca14a518/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/3e94161f.ttl">3e94161f/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+     <tr>
+      <td><code>-- <a href="snippets/alice.example/60e37fe3.ttl">60e37fe3/</a></code>
+      <td><a href="#classDataAuthorization">DataAuthorization</a>
+      <td><a href="interop.shex#DataAuthorizationShape">DataAuthorizationShape</a>
+      <td><a href="interop.tree#DataAuthorizationTree">DataAuthorizationTree</a>
+   </table>
+   <p>The <a data-link-type="dfn" href="#authorization-registry" id="ref-for-authorization-registry⑥">Authorization Registry</a> resources MAY use any resource or subject name.</p>
+   <p>The resource names for <a data-link-type="dfn" href="#access-grant①" id="ref-for-access-grant①①⑤">Access Grants</a> <em class="rfc2119">SHOULD</em> be unpredictable.</p>
+   <h2 class="heading settled" data-level="10" id="security"><span class="secno">10. </span><span class="content">Security</span><a class="self-link" href="#security"></a></h2>
+   <h3 class="heading settled" data-level="10.1" id="security-appauthz"><span class="secno">10.1. </span><span class="content">Application Authorization</span><a class="self-link" href="#security-appauthz"></a></h3>
+   <p>For authorization purposes, client <a data-link-type="dfn" href="#application" id="ref-for-application④④">Applications</a> in use today fall into
+two buckets:</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="strongly-identifiable-applications">Strongly identifiable applications</dfn> can be identified by
+third parties independently from the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①⓪⑨">Social Agent</a> controlling them.
+Only <a data-link-type="dfn" href="#server-side-application" id="ref-for-server-side-application">server-side applications</a> are
+strongly identifiable. As confidential clients, they can keep secrets
+and can present attestations and third-party credentials
+via DNS / domain certificates.</p>
+   <p>In the case of a <a data-link-type="dfn" href="#strongly-identifiable-applications" id="ref-for-strongly-identifiable-applications">strongly identifiable application</a>, the <a data-link-type="dfn" href="#application" id="ref-for-application④⑤">Application</a> has its own <a data-link-type="dfn" href="#identity" id="ref-for-identity④">identity</a>. A <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①⓪">Social Agent</a> can authorize a given <a data-link-type="dfn" href="#application" id="ref-for-application④⑥">Application</a> to access data based solely on the <a data-link-type="dfn" href="#identity" id="ref-for-identity⑤">identity</a> of that <a data-link-type="dfn" href="#application" id="ref-for-application④⑦">Application</a>.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="weakly-identifiable-applications">Weakly identifiable applications</dfn> include in-browser Javascript <a data-link-type="dfn" href="#application" id="ref-for-application④⑧">Applications</a> and native desktop or mobile <a data-link-type="dfn" href="#application" id="ref-for-application④⑨">Applications</a>. They are
+considered weakly identifiable because they
+are not able to keep secrets on an instance level. They are often referred to
+as public clients. Native apps should be strongly-identifiable in theory
+(since they are able to keep secrets on an instance level), but not in
+practice because the OS manufacturers do not make their trust
+infrastructure available. Weakly identifiable clients are only strongly
+identifiable to the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①①">Social Agent</a> controlling them.</p>
+   <p>In the case of <a data-link-type="dfn" href="#weakly-identifiable-applications" id="ref-for-weakly-identifiable-applications">Weakly identifiable applications</a>, the ability for a Solid
+pod to limit access to data by the <a data-link-type="dfn" href="#application" id="ref-for-application⑤⓪">Application</a> in use is only as strong as
+the trustworthiness of the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①②">Social Agent</a> piloting that <a data-link-type="dfn" href="#application" id="ref-for-application⑤①">Application</a>, along with
+their ability to avoid using malicious <a data-link-type="dfn" href="#application" id="ref-for-application⑤②">Applications</a>. The <a data-link-type="dfn" href="#identity" id="ref-for-identity⑥">identity</a> of the <a data-link-type="dfn" href="#application" id="ref-for-application⑤③">Application</a> can be manipulated
+by the <a data-link-type="dfn" href="#social-agent" id="ref-for-social-agent①①③">Social Agent</a> in control. This means that Alice can strongly control
+the <a data-link-type="dfn" href="#application" id="ref-for-application⑤④">Applications</a> that she uses to access her own data, but has
+limited ability to control the <a data-link-type="dfn" href="#application" id="ref-for-application⑤⑤">Applications</a> that Bob uses to access the data
+she shares with him.</p>
+   <h2 class="heading settled" data-level="11" id="definitions"><span class="secno">11. </span><span class="content">Definitions</span><a class="self-link" href="#definitions"></a></h2>
+   <p><b>All definitions as stated below should be considered in the context of
+an interoperable <a data-link-type="dfn" href="#ecosystem" id="ref-for-ecosystem②">ecosystem</a> for <a data-link-type="dfn" href="#solid" id="ref-for-solid">Solid</a>, whether explicitly stated
+or not.</b></p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="solid">Solid</dfn> is a protocol made up of a number of open web standards
+aimed at decentralizing data on the web.</p>
+   <p>A Solid <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="pod">pod</dfn> is a place for storing and accessing data via
+the <a data-link-type="dfn" href="#solid" id="ref-for-solid①">Solid</a> protocol, with mechanisms for controlling who or what can
+access that data.</p>
+   <p>An interoperable <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="ecosystem">ecosystem</dfn> is
+a collection of <a data-link-type="dfn" href="#solid" id="ref-for-solid②">Solid</a> compatible <a data-link-type="dfn" href="#application" id="ref-for-application⑤⑥">applications</a> developed by one or more
+entities, used by a community of users, that can safely access and manipulate
+the same kinds of data in <a data-link-type="dfn" href="#pod" id="ref-for-pod">pods</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="server-side-application">server-side application</dfn> runs on a dedicated server. They may
+also act as autonomous <a data-link-type="dfn" href="#authenticated-agent" id="ref-for-authenticated-agent">authenticated agents</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="user-piloted-application">user-piloted application</dfn> runs on a user’s device, with the user
+as the <a data-link-type="dfn" href="#authenticated-agent" id="ref-for-authenticated-agent①">authenticated agent</a>. They include in-browser javascript
+applications, native desktop applications, and mobile applications.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authenticated-agent">authenticated agent</dfn> is an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③③">agent</a> that has strongly
+authenticated their <a data-link-type="dfn" href="#identity" id="ref-for-identity⑦">identity</a> by proving control of the <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑧">identity profile document</a> via an authentication protocol such as <a data-link-type="biblio" href="#biblio-solid-oidc" title="Solid-OIDC Specification">[SOLID-OIDC]</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="identity">identity</dfn> is a unique URI that can be dereferenced
+to return an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document⑨">identity profile document</a>. Compatible
+identity systems include <a data-link-type="dfn" href="#webid" id="ref-for-webid">WebID</a> and <a data-link-type="dfn" href="#did" id="ref-for-did">DID</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="identity-profile-document">identity profile document</dfn> is a linked data document obtained by
+dereferencing the URI for a given <a data-link-type="dfn" href="#identity" id="ref-for-identity⑧">identity</a>. It provides information that
+can be used to prove that a given <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③④">Agent</a> controls the document.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="webid">WebID</dfn> is a web resource at an HTTP URI which refers to an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑤">agent</a>. An <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document①⓪">identity profile document</a> can be accessed by
+dereferencing the WebID. <a data-link-type="biblio" href="#biblio-webid" title="WebID 1.0">[WEBID]</a></p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="did">DID</dfn> is a URI that associates a DID subject (e.g. an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑥">agent</a>,
+thing, data model, abstract entity, etc.) with a DID document,
+equivalent to an <a data-link-type="dfn" href="#identity-profile-document" id="ref-for-identity-profile-document①①">identity profile document</a>, to allow trustable
+interactions with that subject. <a data-link-type="biblio" href="#biblio-did" title="Decentralized Identifiers (DIDs) v1.0">[DID]</a></p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application-identity">application identity</dfn> is a web resource at an HTTP URI
+that uniquely identifies a given <a data-link-type="dfn" href="#application" id="ref-for-application⑤⑦">Application</a>, and dereferences to an <a data-link-type="dfn" href="#application-profile-document" id="ref-for-application-profile-document">application profile document</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="application-profile-document">application profile document</dfn> is a linked data document
+obtained by dereferencing the URI for a given <a data-link-type="dfn" href="#application-identity" id="ref-for-application-identity">application identity</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="acl-resource">acl resource</dfn> as defined by <a data-link-type="biblio" href="#biblio-wac" title="Web Access Control">[WAC]</a> may be directly
+associated with a resource or indirectly associated with a resource
+through inheritance. It determines which <a data-link-type="dfn" href="#authorization-subject" id="ref-for-authorization-subject">authorization subjects</a> can
+access a resource, and the modes of access they have for it.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="access-mode">access mode</dfn> denotes operations (e.g. read, write)
+that a given <a data-link-type="dfn" href="#authorization-subject" id="ref-for-authorization-subject①">authorization subject</a> can perform on a resource.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-subject">authorization subject</dfn> is the target of a given authorization
+statement in an <a data-link-type="dfn" href="#acl-resource" id="ref-for-acl-resource">acl resource</a>. It is either an <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑦">Agent</a> (individual,
+group, <a data-link-type="dfn" href="#server-side-application" id="ref-for-server-side-application①">server-side application</a>), a <a data-link-type="dfn" href="#user-piloted-application" id="ref-for-user-piloted-application">User-Piloted Application</a> in use by <em>any</em> <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑧">Agent</a>, or a combination of
+a specific <a data-link-type="dfn" href="#agents①" id="ref-for-agents①③⑨">Agent</a> using a specific <a data-link-type="dfn" href="#user-piloted-application" id="ref-for-user-piloted-application①">User-Piloted Application</a>.</p>
+   <p>An <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="authorization-statement">authorization statement</dfn> is ...</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape">shape</dfn> provides a schema that RDF data graphs must meet in order
+to be considered conformant. A shape associated with a given resource in a <a data-link-type="dfn" href="#pod" id="ref-for-pod①">pod</a> ensures that any data stored in that resource must conform to the
+associated shape. Shape languages include <a data-link-type="biblio" href="#biblio-shex" title="Shape Expressions Language 2.1">[SHEX]</a> and <a data-link-type="biblio" href="#biblio-shacl" title="Shapes Constraint Language (SHACL)">[SHACL]</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape-tree">Shape Tree</dfn> defines a prospective tree of related resources
+which can be read and written by applications. The shape tree associates
+each of these resources with a shape. This allows one to treat a set of
+related resources as a single grouping, and apply that to a range of
+operations including access control, data organization, data validation,
+and data migration. <a data-link-type="biblio" href="#biblio-shapetrees" title="Shape Trees">[SHAPETREES]</a></p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape-tree-decorator">Shape Tree Decorator</dfn> provides additional human-readable
+description and context for a given <a data-link-type="dfn" href="#shape-tree" id="ref-for-shape-tree②⑥">shape tree</a>.</p>
+   <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="shape-tree-reference">Shape Tree Reference</dfn> provides the necessary context to
+associate instances of related shape trees via a ShapePath</p>
+  </main>
+  <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#access-authorization①">Access Authorization</a><span>, in § 9.1</span>
+   <li><a href="#access-description-set①">Access Description Set</a><span>, in § 8.3.3</span>
+   <li><a href="#access-grant①">Access Grant</a><span>, in § 9.3</span>
+   <li><a href="#access-mode">access mode</a><span>, in § 11</span>
+   <li><a href="#access-need">Access Need</a><span>, in § 8.2</span>
+   <li><a href="#access-need-description①">Access Need Description</a><span>, in § 8.3.2</span>
+   <li><a href="#access-need-group①">Access Need Group</a><span>, in § 8.1</span>
+   <li><a href="#access-need-group-description①">Access Need Group Description</a><span>, in § 8.3.1</span>
+   <li><a href="#access-receipt①">Access Receipt</a><span>, in § 9.7</span>
+   <li><a href="#access-request①">Access Request</a><span>, in § 8.4</span>
+   <li><a href="#access-scope">Access Scope</a><span>, in § 9.6</span>
+   <li><a href="#acl-resource">acl resource</a><span>, in § 11</span>
+   <li><a href="#agent-registrations">Agent Registrations</a><span>, in § 5.4</span>
+   <li><a href="#agent-registry">Agent Registry</a><span>, in § 5.4</span>
+   <li><a href="#agents①">Agents</a><span>, in § 2</span>
+   <li><a href="#application">Application</a><span>, in § 4</span>
+   <li><a href="#application-identity">application identity</a><span>, in § 11</span>
+   <li><a href="#application-profile-document">application profile document</a><span>, in § 11</span>
+   <li><a href="#application-registration①">Application Registration</a><span>, in § 5.1</span>
+   <li><a href="#authenticated-agent">authenticated agent</a><span>, in § 11</span>
+   <li><a href="#authorization-agent①">Authorization Agent</a><span>, in § 7.1</span>
+   <li><a href="#authorization-registry">Authorization Registry</a><span>, in § 9.8</span>
+   <li><a href="#authorization-statement">authorization statement</a><span>, in § 11</span>
+   <li><a href="#authorization-subject">authorization subject</a><span>, in § 11</span>
+   <li><a href="#data-authorization①">Data Authorization</a><span>, in § 9.2</span>
+   <li><a href="#data-grant①">Data Grant</a><span>, in § 9.4</span>
+   <li><a href="#data-instance">Data Instance</a><span>, in § 6.1</span>
+   <li><a href="#data-registration①">Data Registration</a><span>, in § 6.1</span>
+   <li><a href="#data-registry①">Data Registry</a><span>, in § 6.2</span>
+   <li><a href="#delegated-data-grant①">Delegated Data Grant</a><span>, in § 9.5</span>
+   <li><a href="#did">DID</a><span>, in § 11</span>
+   <li><a href="#ecosystem">ecosystem</a><span>, in § 11</span>
+   <li><a href="#identity">identity</a><span>, in § 11</span>
+   <li><a href="#identity-profile-document">identity profile document</a><span>, in § 11</span>
+   <li><a href="#pod">pod</a><span>, in § 11</span>
+   <li><a href="#registry">Registry</a><span>, in § 3</span>
+   <li><a href="#registry-set">Registry Set</a><span>, in § 3.1</span>
+   <li><a href="#server-side-application">server-side application</a><span>, in § 11</span>
+   <li><a href="#shape">shape</a><span>, in § 11</span>
+   <li><a href="#shape-tree">Shape Tree</a><span>, in § 11</span>
+   <li><a href="#shape-tree-decorator">Shape Tree Decorator</a><span>, in § 11</span>
+   <li><a href="#shape-tree-reference">Shape Tree Reference</a><span>, in § 11</span>
+   <li><a href="#social-agent">Social Agent</a><span>, in § 3</span>
+   <li><a href="#social-agent-invitation①">Social Agent Invitation</a><span>, in § 5.3</span>
+   <li><a href="#social-agent-registration①">Social Agent Registration</a><span>, in § 5.2</span>
+   <li><a href="#solid">Solid</a><span>, in § 11</span>
+   <li><a href="#strongly-identifiable-applications">Strongly identifiable applications</a><span>, in § 10.1</span>
+   <li><a href="#user-piloted-application">user-piloted application</a><span>, in § 11</span>
+   <li><a href="#weakly-identifiable-applications">Weakly identifiable applications</a><span>, in § 10.1</span>
+   <li><a href="#webid">WebID</a><span>, in § 11</span>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-capability-urls">[CAPABILITY-URLS]
+   <dd>Jeni Tennison. <a href="https://w3ctag.github.io/capability-urls/"><cite>Good Practices for Capability URLs</cite></a>. URL: <a href="https://w3ctag.github.io/capability-urls/">https://w3ctag.github.io/capability-urls/</a>
+   <dt id="biblio-wac">[WAC]
+   <dd><a href="https://solid.github.io/specification/wac/"><cite>Web Access Control</cite></a>. URL: <a href="https://solid.github.io/specification/wac/">https://solid.github.io/specification/wac/</a>
+   <dt id="biblio-webid">[WEBID]
+   <dd>Tim Berners-Lee; Henry Story; Andrei Sambra. <a href="https://www.w3.org/2005/Incubator/webid/spec/identity/"><cite>WebID 1.0</cite></a>. URL: <a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">https://www.w3.org/2005/Incubator/webid/spec/identity/</a>
+  </dl>
+  <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
+  <dl>
+   <dt id="biblio-did">[DID]
+   <dd>Drummond Reed; et al. <a href="https://www.w3.org/TR/did-core/"><cite>Decentralized Identifiers (DIDs) v1.0</cite></a>. URL: <a href="https://www.w3.org/TR/did-core/">https://www.w3.org/TR/did-core/</a>
+   <dt id="biblio-problems-and-goals">[PROBLEMS-AND-GOALS]
+   <dd>Justin Bingham; et al. <a href="https://github.com/solid/data-interoperability-panel/blob/master/problems-and-goals.md"><cite>Problems and Goals for Interoperability, Collaboration, and Security in a Solid Pod</cite></a>. URL: <a href="https://github.com/solid/data-interoperability-panel/blob/master/problems-and-goals.md">https://github.com/solid/data-interoperability-panel/blob/master/problems-and-goals.md</a>
+   <dt id="biblio-shacl">[SHACL]
+   <dd>Holger Knublauch; Dimitris Kontokostas. <a href="https://www.w3.org/TR/shacl/"><cite>Shapes Constraint Language (SHACL)</cite></a>. URL: <a href="https://www.w3.org/TR/shacl/">https://www.w3.org/TR/shacl/</a>
+   <dt id="biblio-shapetrees">[SHAPETREES]
+   <dd>Justin Bingham; Eric Prud'hommeaux. <a href="https://shapetrees.org/TR/specification/"><cite>Shape Trees</cite></a>. URL: <a href="https://shapetrees.org/TR/specification/">https://shapetrees.org/TR/specification/</a>
+   <dt id="biblio-shex">[SHEX]
+   <dd>Eric Prud'hommeaux; et al. <a href="http://shex.io/shex-semantics/index.html"><cite>Shape Expressions Language 2.1</cite></a>. URL: <a href="http://shex.io/shex-semantics/index.html">http://shex.io/shex-semantics/index.html</a>
+   <dt id="biblio-solid-oidc">[SOLID-OIDC]
+   <dd>Dmitri Zagidulin; Aaron Coburn; elf Pavlik. <a href="https://solid.github.io/solid-oidc/"><cite>Solid-OIDC Specification</cite></a>. URL: <a href="https://solid.github.io/solid-oidc/">https://solid.github.io/solid-oidc/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="issues-index"><span class="content">Issues Index</span><a class="self-link" href="#issues-index"></a></h2>
+  <div style="counter-reset:issue">
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/210" style="text-transform:none">solid/data-interoperability-panel/210</a><a href="https://github.com/solid/data-interoperability-panel/issues/210">Incorporate profile requirements from solid-oidc for Social Agents and Applications.</a> <a class="issue-return" href="#issue-d41d8cd9" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/171" style="text-transform:none">solid/data-interoperability-panel/171</a><a href="https://github.com/solid/data-interoperability-panel/issues/171">Authorization Agent URI should be distinct for each user</a> <a class="issue-return" href="#issue-d41d8cd9①" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/232" style="text-transform:none">solid/data-interoperability-panel/232</a><a href="https://github.com/solid/data-interoperability-panel/issues/232">Multiple authorisation apps per social agent</a> <a class="issue-return" href="#issue-d41d8cd9②" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/252" style="text-transform:none">solid/data-interoperability-panel/252</a><a href="https://github.com/solid/data-interoperability-panel/issues/252">Should we restrict Social Agent Reigstration discovery to AA of that social agent?</a> <a class="issue-return" href="#issue-d41d8cd9③" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/243" style="text-transform:none">solid/data-interoperability-panel/243</a><a href="https://github.com/solid/data-interoperability-panel/issues/243">Access Needs for Public Resources</a> <a class="issue-return" href="#issue-d41d8cd9④" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/237" style="text-transform:none">solid/data-interoperability-panel/237</a><a href="https://github.com/solid/data-interoperability-panel/issues/237">Access needs for pod browser apps</a> <a class="issue-return" href="#issue-d41d8cd9⑤" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/214" style="text-transform:none">solid/data-interoperability-panel/214</a><a href="https://github.com/solid/data-interoperability-panel/issues/214">Use invitation to validate the source of an incoming request</a> <a class="issue-return" href="#issue-d41d8cd9⑥" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/177" style="text-transform:none">solid/data-interoperability-panel/177</a><a href="https://github.com/solid/data-interoperability-panel/issues/177">Should a copy of access needs be retained when consent is granted?</a> <a class="issue-return" href="#issue-d41d8cd9⑦" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/221" style="text-transform:none">solid/data-interoperability-panel/221</a><a href="https://github.com/solid/data-interoperability-panel/issues/221">Document pattern of using local group as grantee of consent</a> <a class="issue-return" href="#issue-d41d8cd9⑧" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/256" style="text-transform:none">solid/data-interoperability-panel/256</a><a href="https://github.com/solid/data-interoperability-panel/issues/256">Resource Owner restricting their own access</a> <a class="issue-return" href="#issue-d41d8cd9⑨" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/223" style="text-transform:none">solid/data-interoperability-panel/223</a><a href="https://github.com/solid/data-interoperability-panel/issues/223">Address Issuer restrection in data grants, plus RO Client constraints</a> <a class="issue-return" href="#issue-d41d8cd9①⓪" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/222" style="text-transform:none">solid/data-interoperability-panel/222</a><a href="https://github.com/solid/data-interoperability-panel/issues/222">Support longer delegation chains</a> <a class="issue-return" href="#issue-d41d8cd9①①" title="Jump to section">↵</a></div>
+   <div class="issue"> This specification uses some access modes in the <code>acl:</code> namespace that
+have not been adopted to demonstrate the most secure and accurate
+expression of a <a data-link-type="dfn" href="#social-agent">Social Agent’s</a> authorization. <a href="https://github.com/solid/authorization-panel/issues/253">Discussions are underway</a> to add these modes. <a class="issue-return" href="#issue-a2fe1e29" title="Jump to section">↵</a></div>
+   <div class="issue"> <a data-link-type="biblio" href="#biblio-wac" title="Web Access Control">[WAC]</a> does not have any mechanism to extend or modify
+inherited permissions. <a class="issue-return" href="#issue-5157d1cb" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/186" style="text-transform:none">solid/data-interoperability-panel/186</a><a href="https://github.com/solid/data-interoperability-panel/issues/186">Human readable labels for Data Instances, needed when selecting instances on consent screen. </a> <a class="issue-return" href="#issue-d41d8cd9①②" title="Jump to section">↵</a></div>
+   <div class="issue no-marker"><a class="marker" href="https://github.com/solid/data-interoperability-panel/issues/174" style="text-transform:none">solid/data-interoperability-panel/174</a><a href="https://github.com/solid/data-interoperability-panel/issues/174">Determine how to dynamically authorize access to reference lists on inherited instances</a> <a class="issue-return" href="#issue-d41d8cd9①③" title="Jump to section">↵</a></div>
+  </div>
+<script>/* Boilerplate: script-dom-helper */
+"use strict";
+function query(sel) { return document.querySelector(sel); }
+
+function queryAll(sel) { return [...document.querySelectorAll(sel)]; }
+
+function iter(obj) {
+	if(!obj) return [];
+	var it = obj[Symbol.iterator];
+	if(it) return it;
+	return Object.entries(obj);
+}
+
+function mk(tagname, attrs, ...children) {
+	const el = document.createElement(tagname);
+	for(const [k,v] of iter(attrs)) {
+		if(k.slice(0,3) == "_on") {
+			const eventName = k.slice(3);
+			el.addEventListener(eventName, v);
+		} else if(k[0] == "_") {
+			// property, not attribute
+			el[k.slice(1)] = v;
+		} else {
+			if(v === false || v == null) {
+        continue;
+      } else if(v === true) {
+        el.setAttribute(k, "");
+        continue;
+      } else {
+  			el.setAttribute(k, v);
+      }
+		}
+	}
+	append(el, children);
+	return el;
+}
+
+/* Create shortcuts for every known HTML element */
+[
+  "a",
+  "abbr",
+  "acronym",
+  "address",
+  "applet",
+  "area",
+  "article",
+  "aside",
+  "audio",
+  "b",
+  "base",
+  "basefont",
+  "bdo",
+  "big",
+  "blockquote",
+  "body",
+  "br",
+  "button",
+  "canvas",
+  "caption",
+  "center",
+  "cite",
+  "code",
+  "col",
+  "colgroup",
+  "datalist",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "dialog",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "embed",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "font",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "head",
+  "header",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "html",
+  "i",
+  "iframe",
+  "img",
+  "input",
+  "ins",
+  "kbd",
+  "label",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "map",
+  "mark",
+  "meta",
+  "meter",
+  "nav",
+  "nobr",
+  "noscript",
+  "object",
+  "ol",
+  "optgroup",
+  "option",
+  "output",
+  "p",
+  "param",
+  "pre",
+  "progress",
+  "q",
+  "s",
+  "samp",
+  "script",
+  "section",
+  "select",
+  "small",
+  "source",
+  "span",
+  "strike",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "video",
+  "wbr",
+  "xmp",
+].forEach(tagname=>{
+	mk[tagname] = (...args) => mk(tagname, ...args);
+});
+
+function* nodesFromChildList(children) {
+	for(const child of children.flat(Infinity)) {
+		if(child instanceof Node) {
+			yield child;
+		} else {
+			yield new Text(child);
+		}
+	}
+}
+function append(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		if(el instanceof Node) el.appendChild(child);
+		else el.push(child);
+	}
+	return el;
+}
+
+function insertAfter(el, ...children) {
+	for(const child of nodesFromChildList(children)) {
+		el.parentNode.insertBefore(child, el.nextSibling);
+	}
+	return el;
+}
+
+function clearContents(el) {
+	el.innerHTML = "";
+	return el;
+}
+
+function parseHTML(markup) {
+	if(markup.toLowerCase().trim().indexOf('<!doctype') === 0) {
+		const doc = document.implementation.createHTMLDocument("");
+		doc.documentElement.innerHTML = markup;
+		return doc;
+	} else {
+		const el = mk.template({});
+		el.innerHTML = markup;
+		return el.content;
+	}
+}</script>
+<script>/* Boilerplate: script-dfn-panel */
+"use strict";
+{
+let dfnPanelData = {
+"access-authorization①": {"dfnID":"access-authorization\u2460","dfnText":"Access Authorization","external":false,"refSections":[{"refs":[{"id":"ref-for-access-authorization\u2460"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2460"},{"id":"ref-for-access-authorization\u2460\u2461"},{"id":"ref-for-access-authorization\u2460\u2462"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2463"},{"id":"ref-for-access-authorization\u2460\u2464"},{"id":"ref-for-access-authorization\u2460\u2465"},{"id":"ref-for-access-authorization\u2460\u2466"},{"id":"ref-for-access-authorization\u2460\u2467"},{"id":"ref-for-access-authorization\u2460\u2468"},{"id":"ref-for-access-authorization\u2460\u2460\u24ea"},{"id":"ref-for-access-authorization\u2460\u2460\u2460"},{"id":"ref-for-access-authorization\u2460\u2460\u2461"},{"id":"ref-for-access-authorization\u2460\u2460\u2462"},{"id":"ref-for-access-authorization\u2460\u2460\u2463"},{"id":"ref-for-access-authorization\u2460\u2460\u2464"},{"id":"ref-for-access-authorization\u2460\u2460\u2465"},{"id":"ref-for-access-authorization\u2460\u2460\u2466"},{"id":"ref-for-access-authorization\u2460\u2460\u2467"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2460\u2468"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2461\u24ea"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2461\u2460"}],"title":"9.7. Access Receipt"},{"refs":[{"id":"ref-for-access-authorization\u2460\u2461\u2461"},{"id":"ref-for-access-authorization\u2460\u2461\u2462"},{"id":"ref-for-access-authorization\u2460\u2461\u2463"}],"title":"9.8. Authorization Registry"}],"url":"#access-authorization\u2460"},
+"access-description-set①": {"dfnID":"access-description-set\u2460","dfnText":"Access Description Set","external":false,"refSections":[{"refs":[{"id":"ref-for-access-description-set\u2460"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-description-set\u2460\u2460"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-access-description-set\u2460\u2461"}],"title":"8.3.2. Access Need Description"},{"refs":[{"id":"ref-for-access-description-set\u2460\u2462"}],"title":"8.3.3. Access Description Set"}],"url":"#access-description-set\u2460"},
+"access-grant①": {"dfnID":"access-grant\u2460","dfnText":"Access Grant","external":false,"refSections":[{"refs":[{"id":"ref-for-access-grant\u2460"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-access-grant\u2460\u2460"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-access-grant\u2460\u2461"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-access-grant\u2460\u2462"},{"id":"ref-for-access-grant\u2460\u2463"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-grant\u2460\u2464"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-access-grant\u2460\u2465"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-grant\u2460\u2466"},{"id":"ref-for-access-grant\u2460\u2467"},{"id":"ref-for-access-grant\u2460\u2468"},{"id":"ref-for-access-grant\u2460\u2460\u24ea"},{"id":"ref-for-access-grant\u2460\u2460\u2460"},{"id":"ref-for-access-grant\u2460\u2460\u2461"},{"id":"ref-for-access-grant\u2460\u2460\u2462"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-access-grant\u2460\u2460\u2463"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-access-grant\u2460\u2460\u2464"}],"title":"9.8.1. Resource Hierarchy"}],"url":"#access-grant\u2460"},
+"access-mode": {"dfnID":"access-mode","dfnText":"access mode","external":false,"refSections":[{"refs":[{"id":"ref-for-access-mode"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-access-mode\u2460"},{"id":"ref-for-access-mode\u2461"},{"id":"ref-for-access-mode\u2462"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-access-mode\u2463"},{"id":"ref-for-access-mode\u2464"},{"id":"ref-for-access-mode\u2465"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-access-mode\u2466"},{"id":"ref-for-access-mode\u2467"}],"title":"9.6.5. Inherited"}],"url":"#access-mode"},
+"access-need": {"dfnID":"access-need","dfnText":"Access Need","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need"},{"id":"ref-for-access-need\u2460"},{"id":"ref-for-access-need\u2461"},{"id":"ref-for-access-need\u2462"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-need\u2463"},{"id":"ref-for-access-need\u2464"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-access-need\u2465"},{"id":"ref-for-access-need\u2466"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need\u2467"},{"id":"ref-for-access-need\u2468"},{"id":"ref-for-access-need\u2460\u24ea"},{"id":"ref-for-access-need\u2460\u2460"},{"id":"ref-for-access-need\u2460\u2461"},{"id":"ref-for-access-need\u2460\u2462"},{"id":"ref-for-access-need\u2460\u2463"},{"id":"ref-for-access-need\u2460\u2464"},{"id":"ref-for-access-need\u2460\u2465"},{"id":"ref-for-access-need\u2460\u2466"},{"id":"ref-for-access-need\u2460\u2467"},{"id":"ref-for-access-need\u2460\u2468"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-access-need\u2461\u24ea"},{"id":"ref-for-access-need\u2461\u2460"}],"title":"8.3.2. Access Need Description"},{"refs":[{"id":"ref-for-access-need\u2461\u2461"}],"title":"8.3.3. Access Description Set"},{"refs":[{"id":"ref-for-access-need\u2461\u2462"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-need\u2461\u2463"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-access-need\u2461\u2464"},{"id":"ref-for-access-need\u2461\u2465"}],"title":"9.4. Data Grant"}],"url":"#access-need"},
+"access-need-description①": {"dfnID":"access-need-description\u2460","dfnText":"Access Need Description","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need-description\u2460"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need-description\u2460\u2460"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-access-need-description\u2460\u2461"}],"title":"8.3.2. Access Need Description"},{"refs":[{"id":"ref-for-access-need-description\u2460\u2462"}],"title":"8.3.3. Access Description Set"}],"url":"#access-need-description\u2460"},
+"access-need-group-description①": {"dfnID":"access-need-group-description\u2460","dfnText":"Access Need Group Description","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need-group-description\u2460"},{"id":"ref-for-access-need-group-description\u2460\u2460"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need-group-description\u2460\u2461"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-access-need-group-description\u2460\u2462"},{"id":"ref-for-access-need-group-description\u2460\u2463"}],"title":"8.3.3. Access Description Set"}],"url":"#access-need-group-description\u2460"},
+"access-need-group①": {"dfnID":"access-need-group\u2460","dfnText":"Access Need Group","external":false,"refSections":[{"refs":[{"id":"ref-for-access-need-group\u2460"},{"id":"ref-for-access-need-group\u2460\u2460"},{"id":"ref-for-access-need-group\u2460\u2461"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2462"},{"id":"ref-for-access-need-group\u2460\u2463"},{"id":"ref-for-access-need-group\u2460\u2464"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2465"},{"id":"ref-for-access-need-group\u2460\u2466"},{"id":"ref-for-access-need-group\u2460\u2467"},{"id":"ref-for-access-need-group\u2460\u2468"},{"id":"ref-for-access-need-group\u2460\u2460\u24ea"},{"id":"ref-for-access-need-group\u2460\u2460\u2460"},{"id":"ref-for-access-need-group\u2460\u2460\u2461"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2460\u2462"},{"id":"ref-for-access-need-group\u2460\u2460\u2463"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2460\u2464"},{"id":"ref-for-access-need-group\u2460\u2460\u2465"},{"id":"ref-for-access-need-group\u2460\u2460\u2466"},{"id":"ref-for-access-need-group\u2460\u2460\u2467"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2460\u2468"},{"id":"ref-for-access-need-group\u2460\u2461\u24ea"}],"title":"8.4. Access Request"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2461\u2460"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-access-need-group\u2460\u2461\u2461"}],"title":"9.3. Access Grant"}],"url":"#access-need-group\u2460"},
+"access-receipt①": {"dfnID":"access-receipt\u2460","dfnText":"Access Receipt","external":false,"refSections":[{"refs":[{"id":"ref-for-access-receipt\u2460"},{"id":"ref-for-access-receipt\u2460\u2460"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-receipt\u2460\u2461"},{"id":"ref-for-access-receipt\u2460\u2462"},{"id":"ref-for-access-receipt\u2460\u2463"}],"title":"9.7. Access Receipt"}],"url":"#access-receipt\u2460"},
+"access-request①": {"dfnID":"access-request\u2460","dfnText":"Access Request","external":false,"refSections":[{"refs":[{"id":"ref-for-access-request\u2460"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-access-request\u2460\u2460"},{"id":"ref-for-access-request\u2460\u2461"},{"id":"ref-for-access-request\u2460\u2462"}],"title":"8.4. Access Request"}],"url":"#access-request\u2460"},
+"access-scope": {"dfnID":"access-scope","dfnText":"Access Scope","external":false,"refSections":[{"refs":[{"id":"ref-for-access-scope"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-access-scope\u2460"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-access-scope\u2461"},{"id":"ref-for-access-scope\u2462"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-access-scope\u2463"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-access-scope\u2464"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-access-scope\u2465"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-access-scope\u2466"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-access-scope\u2467"}],"title":"9.6.5. Inherited"}],"url":"#access-scope"},
+"acl-resource": {"dfnID":"acl-resource","dfnText":"acl resource","external":false,"refSections":[{"refs":[{"id":"ref-for-acl-resource"}],"title":"11. Definitions"}],"url":"#acl-resource"},
+"agent-registrations": {"dfnID":"agent-registrations","dfnText":"Agent Registrations","external":false,"refSections":[{"refs":[{"id":"ref-for-agent-registrations"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-agent-registrations\u2460"},{"id":"ref-for-agent-registrations\u2461"},{"id":"ref-for-agent-registrations\u2462"}],"title":"5.4.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-agent-registrations\u2463"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-agent-registrations\u2464"},{"id":"ref-for-agent-registrations\u2465"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-agent-registrations\u2466"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-agent-registrations\u2467"},{"id":"ref-for-agent-registrations\u2468"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-agent-registrations\u2460\u24ea"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-agent-registrations\u2460\u2460"}],"title":"9.6.4. SelectedFromRegistry"}],"url":"#agent-registrations"},
+"agent-registry": {"dfnID":"agent-registry","dfnText":"Agent Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-agent-registry"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-agent-registry\u2460"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-agent-registry\u2461"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-agent-registry\u2462"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-agent-registry\u2463"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-agent-registry\u2464"},{"id":"ref-for-agent-registry\u2465"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-agent-registry\u2466"}],"title":"5.4.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-agent-registry\u2467"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-agent-registry\u2468"},{"id":"ref-for-agent-registry\u2460\u24ea"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-agent-registry\u2460\u2460"},{"id":"ref-for-agent-registry\u2460\u2461"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-agent-registry\u2460\u2462"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-agent-registry\u2460\u2463"}],"title":"9.6.4. SelectedFromRegistry"}],"url":"#agent-registry"},
+"agents①": {"dfnID":"agents\u2460","dfnText":"Agents","external":false,"refSections":[{"refs":[{"id":"ref-for-agents\u2460"},{"id":"ref-for-agents\u2460\u2460"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-agents\u2460\u2461"},{"id":"ref-for-agents\u2460\u2462"},{"id":"ref-for-agents\u2460\u2463"},{"id":"ref-for-agents\u2460\u2464"},{"id":"ref-for-agents\u2460\u2465"},{"id":"ref-for-agents\u2460\u2466"},{"id":"ref-for-agents\u2460\u2467"},{"id":"ref-for-agents\u2460\u2468"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u24ea"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2460"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2461"},{"id":"ref-for-agents\u2460\u2460\u2462"},{"id":"ref-for-agents\u2460\u2460\u2463"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2464"},{"id":"ref-for-agents\u2460\u2460\u2465"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2466"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-agents\u2460\u2460\u2467"},{"id":"ref-for-agents\u2460\u2460\u2468"},{"id":"ref-for-agents\u2460\u2461\u24ea"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2460"}],"title":"8.4. Access Request"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2461"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2462"},{"id":"ref-for-agents\u2460\u2461\u2463"},{"id":"ref-for-agents\u2460\u2461\u2464"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2465"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2466"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-agents\u2460\u2461\u2467"},{"id":"ref-for-agents\u2460\u2461\u2468"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u24ea"}],"title":"9.5. Delegated Data Grant"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u2460"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u2461"}],"title":"9.7. Access Receipt"},{"refs":[{"id":"ref-for-agents\u2460\u2462\u2462"},{"id":"ref-for-agents\u2460\u2462\u2463"},{"id":"ref-for-agents\u2460\u2462\u2464"},{"id":"ref-for-agents\u2460\u2462\u2465"},{"id":"ref-for-agents\u2460\u2462\u2466"},{"id":"ref-for-agents\u2460\u2462\u2467"},{"id":"ref-for-agents\u2460\u2462\u2468"}],"title":"11. Definitions"}],"url":"#agents\u2460"},
+"application": {"dfnID":"application","dfnText":"Application","external":false,"refSections":[{"refs":[{"id":"ref-for-application"},{"id":"ref-for-application\u2460"},{"id":"ref-for-application\u2461"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-application\u2462"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-application\u2463"},{"id":"ref-for-application\u2464"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-application\u2465"},{"id":"ref-for-application\u2466"},{"id":"ref-for-application\u2467"},{"id":"ref-for-application\u2468"},{"id":"ref-for-application\u2460\u24ea"},{"id":"ref-for-application\u2460\u2460"},{"id":"ref-for-application\u2460\u2461"},{"id":"ref-for-application\u2460\u2462"},{"id":"ref-for-application\u2460\u2463"},{"id":"ref-for-application\u2460\u2464"},{"id":"ref-for-application\u2460\u2465"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-application\u2460\u2466"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-application\u2460\u2467"},{"id":"ref-for-application\u2460\u2468"},{"id":"ref-for-application\u2461\u24ea"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-application\u2461\u2460"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-application\u2461\u2461"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-application\u2461\u2462"},{"id":"ref-for-application\u2461\u2463"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-application\u2461\u2464"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-application\u2461\u2465"},{"id":"ref-for-application\u2461\u2466"},{"id":"ref-for-application\u2461\u2467"},{"id":"ref-for-application\u2461\u2468"},{"id":"ref-for-application\u2462\u24ea"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-application\u2462\u2460"},{"id":"ref-for-application\u2462\u2461"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-application\u2462\u2462"},{"id":"ref-for-application\u2462\u2463"}],"title":"7.1.1. Authorization Redirect Endpoint"},{"refs":[{"id":"ref-for-application\u2462\u2464"},{"id":"ref-for-application\u2462\u2465"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-application\u2462\u2466"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-application\u2462\u2467"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-application\u2462\u2468"},{"id":"ref-for-application\u2463\u24ea"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-application\u2463\u2460"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-application\u2463\u2461"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-application\u2463\u2462"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-application\u2463\u2463"},{"id":"ref-for-application\u2463\u2464"},{"id":"ref-for-application\u2463\u2465"},{"id":"ref-for-application\u2463\u2466"},{"id":"ref-for-application\u2463\u2467"},{"id":"ref-for-application\u2463\u2468"},{"id":"ref-for-application\u2464\u24ea"},{"id":"ref-for-application\u2464\u2460"},{"id":"ref-for-application\u2464\u2461"},{"id":"ref-for-application\u2464\u2462"},{"id":"ref-for-application\u2464\u2463"},{"id":"ref-for-application\u2464\u2464"}],"title":"10.1. Application Authorization"},{"refs":[{"id":"ref-for-application\u2464\u2465"},{"id":"ref-for-application\u2464\u2466"}],"title":"11. Definitions"}],"url":"#application"},
+"application-identity": {"dfnID":"application-identity","dfnText":"application identity","external":false,"refSections":[{"refs":[{"id":"ref-for-application-identity"}],"title":"11. Definitions"}],"url":"#application-identity"},
+"application-profile-document": {"dfnID":"application-profile-document","dfnText":"application profile document","external":false,"refSections":[{"refs":[{"id":"ref-for-application-profile-document"}],"title":"11. Definitions"}],"url":"#application-profile-document"},
+"application-registration①": {"dfnID":"application-registration\u2460","dfnText":"Application Registration","external":false,"refSections":[{"refs":[{"id":"ref-for-application-registration\u2460"},{"id":"ref-for-application-registration\u2460\u2460"},{"id":"ref-for-application-registration\u2460\u2461"},{"id":"ref-for-application-registration\u2460\u2462"},{"id":"ref-for-application-registration\u2460\u2463"},{"id":"ref-for-application-registration\u2460\u2464"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-application-registration\u2460\u2465"},{"id":"ref-for-application-registration\u2460\u2466"}],"title":"5.4. Agent Registry"}],"url":"#application-registration\u2460"},
+"authenticated-agent": {"dfnID":"authenticated-agent","dfnText":"authenticated agent","external":false,"refSections":[{"refs":[{"id":"ref-for-authenticated-agent"},{"id":"ref-for-authenticated-agent\u2460"}],"title":"11. Definitions"}],"url":"#authenticated-agent"},
+"authorization-agent①": {"dfnID":"authorization-agent\u2460","dfnText":"Authorization Agent","external":false,"refSections":[{"refs":[{"id":"ref-for-authorization-agent\u2460"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2460"},{"id":"ref-for-authorization-agent\u2460\u2461"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2462"},{"id":"ref-for-authorization-agent\u2460\u2463"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2464"},{"id":"ref-for-authorization-agent\u2460\u2465"},{"id":"ref-for-authorization-agent\u2460\u2466"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2467"}],"title":"7.1.1. Authorization Redirect Endpoint"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2468"},{"id":"ref-for-authorization-agent\u2460\u2460\u24ea"},{"id":"ref-for-authorization-agent\u2460\u2460\u2460"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2460\u2461"},{"id":"ref-for-authorization-agent\u2460\u2460\u2462"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-authorization-agent\u2460\u2460\u2463"}],"title":"9.7. Access Receipt"}],"url":"#authorization-agent\u2460"},
+"authorization-registry": {"dfnID":"authorization-registry","dfnText":"Authorization Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-authorization-registry"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-authorization-registry\u2460"},{"id":"ref-for-authorization-registry\u2461"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-authorization-registry\u2462"},{"id":"ref-for-authorization-registry\u2463"},{"id":"ref-for-authorization-registry\u2464"}],"title":"9.8. Authorization Registry"},{"refs":[{"id":"ref-for-authorization-registry\u2465"}],"title":"9.8.1. Resource Hierarchy"}],"url":"#authorization-registry"},
+"authorization-statement": {"dfnID":"authorization-statement","dfnText":"authorization statement","external":false,"refSections":[],"url":"#authorization-statement"},
+"authorization-subject": {"dfnID":"authorization-subject","dfnText":"authorization subject","external":false,"refSections":[{"refs":[{"id":"ref-for-authorization-subject"},{"id":"ref-for-authorization-subject\u2460"}],"title":"11. Definitions"}],"url":"#authorization-subject"},
+"data-authorization①": {"dfnID":"data-authorization\u2460","dfnText":"Data Authorization","external":false,"refSections":[{"refs":[{"id":"ref-for-data-authorization\u2460"},{"id":"ref-for-data-authorization\u2460\u2460"},{"id":"ref-for-data-authorization\u2460\u2461"},{"id":"ref-for-data-authorization\u2460\u2462"},{"id":"ref-for-data-authorization\u2460\u2463"},{"id":"ref-for-data-authorization\u2460\u2464"},{"id":"ref-for-data-authorization\u2460\u2465"},{"id":"ref-for-data-authorization\u2460\u2466"},{"id":"ref-for-data-authorization\u2460\u2467"},{"id":"ref-for-data-authorization\u2460\u2468"},{"id":"ref-for-data-authorization\u2460\u2460\u24ea"},{"id":"ref-for-data-authorization\u2460\u2460\u2460"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2461"},{"id":"ref-for-data-authorization\u2460\u2460\u2462"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2463"},{"id":"ref-for-data-authorization\u2460\u2460\u2464"},{"id":"ref-for-data-authorization\u2460\u2460\u2465"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2466"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2460\u2467"},{"id":"ref-for-data-authorization\u2460\u2460\u2468"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2461\u24ea"},{"id":"ref-for-data-authorization\u2460\u2461\u2460"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-authorization\u2460\u2461\u2461"},{"id":"ref-for-data-authorization\u2460\u2461\u2462"},{"id":"ref-for-data-authorization\u2460\u2461\u2463"},{"id":"ref-for-data-authorization\u2460\u2461\u2464"},{"id":"ref-for-data-authorization\u2460\u2461\u2465"},{"id":"ref-for-data-authorization\u2460\u2461\u2466"},{"id":"ref-for-data-authorization\u2460\u2461\u2467"}],"title":"9.6.5. Inherited"}],"url":"#data-authorization\u2460"},
+"data-grant①": {"dfnID":"data-grant\u2460","dfnText":"Data Grant","external":false,"refSections":[{"refs":[{"id":"ref-for-data-grant\u2460"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-grant\u2460\u2460"},{"id":"ref-for-data-grant\u2460\u2461"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-data-grant\u2460\u2462"},{"id":"ref-for-data-grant\u2460\u2463"},{"id":"ref-for-data-grant\u2460\u2464"},{"id":"ref-for-data-grant\u2460\u2465"},{"id":"ref-for-data-grant\u2460\u2466"},{"id":"ref-for-data-grant\u2460\u2467"},{"id":"ref-for-data-grant\u2460\u2468"},{"id":"ref-for-data-grant\u2460\u2460\u24ea"},{"id":"ref-for-data-grant\u2460\u2460\u2460"},{"id":"ref-for-data-grant\u2460\u2460\u2461"},{"id":"ref-for-data-grant\u2460\u2460\u2462"},{"id":"ref-for-data-grant\u2460\u2460\u2463"},{"id":"ref-for-data-grant\u2460\u2460\u2464"},{"id":"ref-for-data-grant\u2460\u2460\u2465"},{"id":"ref-for-data-grant\u2460\u2460\u2466"},{"id":"ref-for-data-grant\u2460\u2460\u2467"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-data-grant\u2460\u2460\u2468"},{"id":"ref-for-data-grant\u2460\u2461\u24ea"}],"title":"9.5. Delegated Data Grant"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2460"},{"id":"ref-for-data-grant\u2460\u2461\u2461"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2462"},{"id":"ref-for-data-grant\u2460\u2461\u2463"},{"id":"ref-for-data-grant\u2460\u2461\u2464"},{"id":"ref-for-data-grant\u2460\u2461\u2465"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2466"},{"id":"ref-for-data-grant\u2460\u2461\u2467"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-data-grant\u2460\u2461\u2468"},{"id":"ref-for-data-grant\u2460\u2462\u24ea"},{"id":"ref-for-data-grant\u2460\u2462\u2460"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-grant\u2460\u2462\u2461"},{"id":"ref-for-data-grant\u2460\u2462\u2462"},{"id":"ref-for-data-grant\u2460\u2462\u2463"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-grant\u2460\u2462\u2464"},{"id":"ref-for-data-grant\u2460\u2462\u2465"},{"id":"ref-for-data-grant\u2460\u2462\u2466"},{"id":"ref-for-data-grant\u2460\u2462\u2467"},{"id":"ref-for-data-grant\u2460\u2462\u2468"}],"title":"9.6.5. Inherited"}],"url":"#data-grant\u2460"},
+"data-instance": {"dfnID":"data-instance","dfnText":"Data Instance","external":false,"refSections":[{"refs":[{"id":"ref-for-data-instance"},{"id":"ref-for-data-instance\u2460"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-data-instance\u2461"},{"id":"ref-for-data-instance\u2462"},{"id":"ref-for-data-instance\u2463"},{"id":"ref-for-data-instance\u2464"},{"id":"ref-for-data-instance\u2465"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-data-instance\u2466"}],"title":"7.1.1. Authorization Redirect Endpoint"},{"refs":[{"id":"ref-for-data-instance\u2467"},{"id":"ref-for-data-instance\u2468"},{"id":"ref-for-data-instance\u2460\u24ea"},{"id":"ref-for-data-instance\u2460\u2460"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-data-instance\u2460\u2461"},{"id":"ref-for-data-instance\u2460\u2462"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-instance\u2460\u2463"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-data-instance\u2460\u2464"},{"id":"ref-for-data-instance\u2460\u2465"},{"id":"ref-for-data-instance\u2460\u2466"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-instance\u2460\u2467"},{"id":"ref-for-data-instance\u2460\u2468"},{"id":"ref-for-data-instance\u2461\u24ea"},{"id":"ref-for-data-instance\u2461\u2460"},{"id":"ref-for-data-instance\u2461\u2461"},{"id":"ref-for-data-instance\u2461\u2462"},{"id":"ref-for-data-instance\u2461\u2463"},{"id":"ref-for-data-instance\u2461\u2464"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-instance\u2461\u2465"},{"id":"ref-for-data-instance\u2461\u2466"},{"id":"ref-for-data-instance\u2461\u2467"},{"id":"ref-for-data-instance\u2461\u2468"},{"id":"ref-for-data-instance\u2462\u24ea"},{"id":"ref-for-data-instance\u2462\u2460"},{"id":"ref-for-data-instance\u2462\u2461"},{"id":"ref-for-data-instance\u2462\u2462"},{"id":"ref-for-data-instance\u2462\u2463"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-instance\u2462\u2464"},{"id":"ref-for-data-instance\u2462\u2465"},{"id":"ref-for-data-instance\u2462\u2466"},{"id":"ref-for-data-instance\u2462\u2467"},{"id":"ref-for-data-instance\u2462\u2468"},{"id":"ref-for-data-instance\u2463\u24ea"},{"id":"ref-for-data-instance\u2463\u2460"},{"id":"ref-for-data-instance\u2463\u2461"},{"id":"ref-for-data-instance\u2463\u2462"},{"id":"ref-for-data-instance\u2463\u2463"},{"id":"ref-for-data-instance\u2463\u2464"},{"id":"ref-for-data-instance\u2463\u2465"}],"title":"9.6.5. Inherited"}],"url":"#data-instance"},
+"data-registration①": {"dfnID":"data-registration\u2460","dfnText":"Data Registration","external":false,"refSections":[{"refs":[{"id":"ref-for-data-registration\u2460"},{"id":"ref-for-data-registration\u2460\u2460"},{"id":"ref-for-data-registration\u2460\u2461"},{"id":"ref-for-data-registration\u2460\u2462"},{"id":"ref-for-data-registration\u2460\u2463"},{"id":"ref-for-data-registration\u2460\u2464"},{"id":"ref-for-data-registration\u2460\u2465"},{"id":"ref-for-data-registration\u2460\u2466"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-data-registration\u2460\u2467"},{"id":"ref-for-data-registration\u2460\u2468"},{"id":"ref-for-data-registration\u2460\u2460\u24ea"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-data-registration\u2460\u2460\u2460"},{"id":"ref-for-data-registration\u2460\u2460\u2461"},{"id":"ref-for-data-registration\u2460\u2460\u2462"},{"id":"ref-for-data-registration\u2460\u2460\u2463"},{"id":"ref-for-data-registration\u2460\u2460\u2464"},{"id":"ref-for-data-registration\u2460\u2460\u2465"},{"id":"ref-for-data-registration\u2460\u2460\u2466"},{"id":"ref-for-data-registration\u2460\u2460\u2467"},{"id":"ref-for-data-registration\u2460\u2460\u2468"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u24ea"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2460"},{"id":"ref-for-data-registration\u2460\u2461\u2461"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2462"},{"id":"ref-for-data-registration\u2460\u2461\u2463"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2464"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-registration\u2460\u2461\u2465"},{"id":"ref-for-data-registration\u2460\u2461\u2466"},{"id":"ref-for-data-registration\u2460\u2461\u2467"},{"id":"ref-for-data-registration\u2460\u2461\u2468"},{"id":"ref-for-data-registration\u2460\u2462\u24ea"},{"id":"ref-for-data-registration\u2460\u2462\u2460"},{"id":"ref-for-data-registration\u2460\u2462\u2461"},{"id":"ref-for-data-registration\u2460\u2462\u2462"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-registration\u2460\u2462\u2463"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-registration\u2460\u2462\u2464"},{"id":"ref-for-data-registration\u2460\u2462\u2465"},{"id":"ref-for-data-registration\u2460\u2462\u2466"},{"id":"ref-for-data-registration\u2460\u2462\u2467"}],"title":"9.6.5. Inherited"}],"url":"#data-registration\u2460"},
+"data-registry①": {"dfnID":"data-registry\u2460","dfnText":"Data Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-data-registry\u2460"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-data-registry\u2460\u2461"},{"id":"ref-for-data-registry\u2460\u2462"},{"id":"ref-for-data-registry\u2460\u2463"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-data-registry\u2460\u2464"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-data-registry\u2460\u2465"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-data-registry\u2460\u2466"},{"id":"ref-for-data-registry\u2460\u2467"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-data-registry\u2460\u2468"},{"id":"ref-for-data-registry\u2460\u2460\u24ea"},{"id":"ref-for-data-registry\u2460\u2460\u2460"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460\u2461"},{"id":"ref-for-data-registry\u2460\u2460\u2462"},{"id":"ref-for-data-registry\u2460\u2460\u2463"},{"id":"ref-for-data-registry\u2460\u2460\u2464"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460\u2465"},{"id":"ref-for-data-registry\u2460\u2460\u2466"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-data-registry\u2460\u2460\u2467"},{"id":"ref-for-data-registry\u2460\u2460\u2468"},{"id":"ref-for-data-registry\u2460\u2461\u24ea"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-data-registry\u2460\u2461\u2460"},{"id":"ref-for-data-registry\u2460\u2461\u2461"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-data-registry\u2460\u2461\u2462"}],"title":"9.6.5. Inherited"}],"url":"#data-registry\u2460"},
+"delegated-data-grant①": {"dfnID":"delegated-data-grant\u2460","dfnText":"Delegated Data Grant","external":false,"refSections":[{"refs":[{"id":"ref-for-delegated-data-grant\u2460"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-delegated-data-grant\u2460\u2460"},{"id":"ref-for-delegated-data-grant\u2460\u2461"},{"id":"ref-for-delegated-data-grant\u2460\u2462"},{"id":"ref-for-delegated-data-grant\u2460\u2463"}],"title":"9.5. Delegated Data Grant"},{"refs":[{"id":"ref-for-delegated-data-grant\u2460\u2464"}],"title":"9.6.1. All"},{"refs":[{"id":"ref-for-delegated-data-grant\u2460\u2465"},{"id":"ref-for-delegated-data-grant\u2460\u2466"}],"title":"9.6.2. AllFromAgent"}],"url":"#delegated-data-grant\u2460"},
+"did": {"dfnID":"did","dfnText":"DID","external":false,"refSections":[{"refs":[{"id":"ref-for-did"}],"title":"11. Definitions"}],"url":"#did"},
+"ecosystem": {"dfnID":"ecosystem","dfnText":"ecosystem","external":false,"refSections":[{"refs":[{"id":"ref-for-ecosystem"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-ecosystem\u2460"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-ecosystem\u2461"}],"title":"11. Definitions"}],"url":"#ecosystem"},
+"identity": {"dfnID":"identity","dfnText":"identity","external":false,"refSections":[{"refs":[{"id":"ref-for-identity"},{"id":"ref-for-identity\u2460"},{"id":"ref-for-identity\u2461"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-identity\u2462"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-identity\u2463"},{"id":"ref-for-identity\u2464"},{"id":"ref-for-identity\u2465"}],"title":"10.1. Application Authorization"},{"refs":[{"id":"ref-for-identity\u2466"},{"id":"ref-for-identity\u2467"}],"title":"11. Definitions"}],"url":"#identity"},
+"identity-profile-document": {"dfnID":"identity-profile-document","dfnText":"identity profile document","external":false,"refSections":[{"refs":[{"id":"ref-for-identity-profile-document"},{"id":"ref-for-identity-profile-document\u2460"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-identity-profile-document\u2461"},{"id":"ref-for-identity-profile-document\u2462"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-identity-profile-document\u2463"},{"id":"ref-for-identity-profile-document\u2464"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-identity-profile-document\u2465"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-identity-profile-document\u2466"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-identity-profile-document\u2467"},{"id":"ref-for-identity-profile-document\u2468"},{"id":"ref-for-identity-profile-document\u2460\u24ea"},{"id":"ref-for-identity-profile-document\u2460\u2460"}],"title":"11. Definitions"}],"url":"#identity-profile-document"},
+"pod": {"dfnID":"pod","dfnText":"pod","external":false,"refSections":[{"refs":[{"id":"ref-for-pod"},{"id":"ref-for-pod\u2460"}],"title":"11. Definitions"}],"url":"#pod"},
+"registry": {"dfnID":"registry","dfnText":"Registry","external":false,"refSections":[{"refs":[{"id":"ref-for-registry"},{"id":"ref-for-registry\u2460"},{"id":"ref-for-registry\u2461"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-registry\u2462"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-registry\u2463"}],"title":"5.2. Social Agent Registration"}],"url":"#registry"},
+"registry-set": {"dfnID":"registry-set","dfnText":"Registry Set","external":false,"refSections":[{"refs":[{"id":"ref-for-registry-set"},{"id":"ref-for-registry-set\u2460"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-registry-set\u2461"},{"id":"ref-for-registry-set\u2462"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-registry-set\u2463"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-registry-set\u2464"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-registry-set\u2465"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-registry-set\u2466"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-registry-set\u2467"}],"title":"9.8. Authorization Registry"}],"url":"#registry-set"},
+"server-side-application": {"dfnID":"server-side-application","dfnText":"server-side application","external":false,"refSections":[{"refs":[{"id":"ref-for-server-side-application"}],"title":"10.1. Application Authorization"},{"refs":[{"id":"ref-for-server-side-application\u2460"}],"title":"11. Definitions"}],"url":"#server-side-application"},
+"shape": {"dfnID":"shape","dfnText":"shape","external":false,"refSections":[{"refs":[{"id":"ref-for-shape"}],"title":"1. Introduction"}],"url":"#shape"},
+"shape-tree": {"dfnID":"shape-tree","dfnText":"Shape Tree","external":false,"refSections":[{"refs":[{"id":"ref-for-shape-tree"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-shape-tree\u2460"},{"id":"ref-for-shape-tree\u2461"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-shape-tree\u2462"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-shape-tree\u2463"},{"id":"ref-for-shape-tree\u2464"},{"id":"ref-for-shape-tree\u2465"},{"id":"ref-for-shape-tree\u2466"},{"id":"ref-for-shape-tree\u2467"}],"title":"6.2.1. Resource Hierarchy"},{"refs":[{"id":"ref-for-shape-tree\u2468"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-shape-tree\u2460\u24ea"},{"id":"ref-for-shape-tree\u2460\u2460"},{"id":"ref-for-shape-tree\u2460\u2461"},{"id":"ref-for-shape-tree\u2460\u2462"},{"id":"ref-for-shape-tree\u2460\u2463"}],"title":"8.2. Access Need"},{"refs":[{"id":"ref-for-shape-tree\u2460\u2464"},{"id":"ref-for-shape-tree\u2460\u2465"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-shape-tree\u2460\u2466"},{"id":"ref-for-shape-tree\u2460\u2467"},{"id":"ref-for-shape-tree\u2460\u2468"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-shape-tree\u2461\u24ea"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2460"},{"id":"ref-for-shape-tree\u2461\u2461"}],"title":"9.6.3. AllFromRegistry"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2462"}],"title":"9.6.4. SelectedFromRegistry"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2463"},{"id":"ref-for-shape-tree\u2461\u2464"}],"title":"9.6.5. Inherited"},{"refs":[{"id":"ref-for-shape-tree\u2461\u2465"}],"title":"11. Definitions"}],"url":"#shape-tree"},
+"shape-tree-decorator": {"dfnID":"shape-tree-decorator","dfnText":"Shape Tree Decorator","external":false,"refSections":[],"url":"#shape-tree-decorator"},
+"shape-tree-reference": {"dfnID":"shape-tree-reference","dfnText":"Shape Tree Reference","external":false,"refSections":[{"refs":[{"id":"ref-for-shape-tree-reference"}],"title":"9.4. Data Grant"}],"url":"#shape-tree-reference"},
+"social-agent": {"dfnID":"social-agent","dfnText":"Social Agent","external":false,"refSections":[{"refs":[{"id":"ref-for-social-agent"},{"id":"ref-for-social-agent\u2460"},{"id":"ref-for-social-agent\u2461"},{"id":"ref-for-social-agent\u2462"},{"id":"ref-for-social-agent\u2463"},{"id":"ref-for-social-agent\u2464"},{"id":"ref-for-social-agent\u2465"}],"title":"1. Introduction"},{"refs":[{"id":"ref-for-social-agent\u2466"}],"title":"2. Agents"},{"refs":[{"id":"ref-for-social-agent\u2467"},{"id":"ref-for-social-agent\u2468"},{"id":"ref-for-social-agent\u2460\u24ea"},{"id":"ref-for-social-agent\u2460\u2460"},{"id":"ref-for-social-agent\u2460\u2461"},{"id":"ref-for-social-agent\u2460\u2462"}],"title":"3. Social Agents"},{"refs":[{"id":"ref-for-social-agent\u2460\u2463"},{"id":"ref-for-social-agent\u2460\u2464"},{"id":"ref-for-social-agent\u2460\u2465"},{"id":"ref-for-social-agent\u2460\u2466"},{"id":"ref-for-social-agent\u2460\u2467"},{"id":"ref-for-social-agent\u2460\u2468"},{"id":"ref-for-social-agent\u2461\u24ea"}],"title":"3.1. Registry Set"},{"refs":[{"id":"ref-for-social-agent\u2461\u2460"},{"id":"ref-for-social-agent\u2461\u2461"},{"id":"ref-for-social-agent\u2461\u2462"},{"id":"ref-for-social-agent\u2461\u2463"}],"title":"4. Applications"},{"refs":[{"id":"ref-for-social-agent\u2461\u2464"},{"id":"ref-for-social-agent\u2461\u2465"}],"title":"5. Agent Registrations"},{"refs":[{"id":"ref-for-social-agent\u2461\u2466"},{"id":"ref-for-social-agent\u2461\u2467"}],"title":"5.1. Application Registration"},{"refs":[{"id":"ref-for-social-agent\u2461\u2468"},{"id":"ref-for-social-agent\u2462\u24ea"},{"id":"ref-for-social-agent\u2462\u2460"},{"id":"ref-for-social-agent\u2462\u2461"},{"id":"ref-for-social-agent\u2462\u2462"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-social-agent\u2462\u2463"},{"id":"ref-for-social-agent\u2462\u2464"},{"id":"ref-for-social-agent\u2462\u2465"},{"id":"ref-for-social-agent\u2462\u2466"},{"id":"ref-for-social-agent\u2462\u2467"},{"id":"ref-for-social-agent\u2462\u2468"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-social-agent\u2463\u24ea"},{"id":"ref-for-social-agent\u2463\u2460"},{"id":"ref-for-social-agent\u2463\u2461"},{"id":"ref-for-social-agent\u2463\u2462"},{"id":"ref-for-social-agent\u2463\u2463"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-social-agent\u2463\u2464"}],"title":"6. Data Registrations"},{"refs":[{"id":"ref-for-social-agent\u2463\u2465"},{"id":"ref-for-social-agent\u2463\u2466"}],"title":"6.1. Data Registration"},{"refs":[{"id":"ref-for-social-agent\u2463\u2467"}],"title":"6.2. Data Registry"},{"refs":[{"id":"ref-for-social-agent\u2463\u2468"},{"id":"ref-for-social-agent\u2464\u24ea"},{"id":"ref-for-social-agent\u2464\u2460"},{"id":"ref-for-social-agent\u2464\u2461"},{"id":"ref-for-social-agent\u2464\u2462"},{"id":"ref-for-social-agent\u2464\u2463"},{"id":"ref-for-social-agent\u2464\u2464"},{"id":"ref-for-social-agent\u2464\u2465"},{"id":"ref-for-social-agent\u2464\u2466"},{"id":"ref-for-social-agent\u2464\u2467"},{"id":"ref-for-social-agent\u2464\u2468"}],"title":"7. Authorization Flows"},{"refs":[{"id":"ref-for-social-agent\u2465\u24ea"},{"id":"ref-for-social-agent\u2465\u2460"},{"id":"ref-for-social-agent\u2465\u2461"}],"title":"7.1. Authorization Agent"},{"refs":[{"id":"ref-for-social-agent\u2465\u2462"},{"id":"ref-for-social-agent\u2465\u2463"},{"id":"ref-for-social-agent\u2465\u2464"},{"id":"ref-for-social-agent\u2465\u2465"},{"id":"ref-for-social-agent\u2465\u2466"},{"id":"ref-for-social-agent\u2465\u2467"}],"title":"7.1.3. Authorization Agent Discovery"},{"refs":[{"id":"ref-for-social-agent\u2465\u2468"},{"id":"ref-for-social-agent\u2466\u24ea"},{"id":"ref-for-social-agent\u2466\u2460"}],"title":"7.1.4. Agent Registration Discovery"},{"refs":[{"id":"ref-for-social-agent\u2466\u2461"},{"id":"ref-for-social-agent\u2466\u2462"},{"id":"ref-for-social-agent\u2466\u2463"},{"id":"ref-for-social-agent\u2466\u2464"},{"id":"ref-for-social-agent\u2466\u2465"}],"title":"8. Access Needs"},{"refs":[{"id":"ref-for-social-agent\u2466\u2466"},{"id":"ref-for-social-agent\u2466\u2467"},{"id":"ref-for-social-agent\u2466\u2468"}],"title":"8.1. Access Need Group"},{"refs":[{"id":"ref-for-social-agent\u2467\u24ea"}],"title":"8.3.1. Access Need Group Description"},{"refs":[{"id":"ref-for-social-agent\u2467\u2460"},{"id":"ref-for-social-agent\u2467\u2461"}],"title":"8.4. Access Request"},{"refs":[{"id":"ref-for-social-agent\u2467\u2462"},{"id":"ref-for-social-agent\u2467\u2463"}],"title":"9. Access Authorizations"},{"refs":[{"id":"ref-for-social-agent\u2467\u2464"},{"id":"ref-for-social-agent\u2467\u2465"},{"id":"ref-for-social-agent\u2467\u2466"},{"id":"ref-for-social-agent\u2467\u2467"}],"title":"9.1. Access Authorization"},{"refs":[{"id":"ref-for-social-agent\u2467\u2468"},{"id":"ref-for-social-agent\u2468\u24ea"},{"id":"ref-for-social-agent\u2468\u2460"},{"id":"ref-for-social-agent\u2468\u2461"}],"title":"9.2. Data Authorization"},{"refs":[{"id":"ref-for-social-agent\u2468\u2462"},{"id":"ref-for-social-agent\u2468\u2463"}],"title":"9.3. Access Grant"},{"refs":[{"id":"ref-for-social-agent\u2468\u2464"},{"id":"ref-for-social-agent\u2468\u2465"},{"id":"ref-for-social-agent\u2468\u2466"},{"id":"ref-for-social-agent\u2468\u2467"}],"title":"9.4. Data Grant"},{"refs":[{"id":"ref-for-social-agent\u2468\u2468"},{"id":"ref-for-social-agent\u2460\u24ea\u24ea"},{"id":"ref-for-social-agent\u2460\u24ea\u2460"}],"title":"9.6. Data Access Scopes"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2461"},{"id":"ref-for-social-agent\u2460\u24ea\u2462"},{"id":"ref-for-social-agent\u2460\u24ea\u2463"}],"title":"9.6.2. AllFromAgent"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2464"},{"id":"ref-for-social-agent\u2460\u24ea\u2465"},{"id":"ref-for-social-agent\u2460\u24ea\u2466"}],"title":"9.7. Access Receipt"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2467"}],"title":"9.8. Authorization Registry"},{"refs":[{"id":"ref-for-social-agent\u2460\u24ea\u2468"},{"id":"ref-for-social-agent\u2460\u2460\u24ea"},{"id":"ref-for-social-agent\u2460\u2460\u2460"},{"id":"ref-for-social-agent\u2460\u2460\u2461"},{"id":"ref-for-social-agent\u2460\u2460\u2462"}],"title":"10.1. Application Authorization"}],"url":"#social-agent"},
+"social-agent-invitation①": {"dfnID":"social-agent-invitation\u2460","dfnText":"Social Agent Invitation","external":false,"refSections":[{"refs":[{"id":"ref-for-social-agent-invitation\u2460"},{"id":"ref-for-social-agent-invitation\u2460\u2460"},{"id":"ref-for-social-agent-invitation\u2460\u2461"},{"id":"ref-for-social-agent-invitation\u2460\u2462"},{"id":"ref-for-social-agent-invitation\u2460\u2463"},{"id":"ref-for-social-agent-invitation\u2460\u2464"},{"id":"ref-for-social-agent-invitation\u2460\u2465"},{"id":"ref-for-social-agent-invitation\u2460\u2466"},{"id":"ref-for-social-agent-invitation\u2460\u2467"},{"id":"ref-for-social-agent-invitation\u2460\u2468"}],"title":"5.3. Social Agent Invitation"}],"url":"#social-agent-invitation\u2460"},
+"social-agent-registration①": {"dfnID":"social-agent-registration\u2460","dfnText":"Social Agent Registration","external":false,"refSections":[{"refs":[{"id":"ref-for-social-agent-registration\u2460"},{"id":"ref-for-social-agent-registration\u2460\u2460"},{"id":"ref-for-social-agent-registration\u2460\u2461"},{"id":"ref-for-social-agent-registration\u2460\u2462"},{"id":"ref-for-social-agent-registration\u2460\u2463"},{"id":"ref-for-social-agent-registration\u2460\u2464"},{"id":"ref-for-social-agent-registration\u2460\u2465"}],"title":"5.2. Social Agent Registration"},{"refs":[{"id":"ref-for-social-agent-registration\u2460\u2466"},{"id":"ref-for-social-agent-registration\u2460\u2467"},{"id":"ref-for-social-agent-registration\u2460\u2468"},{"id":"ref-for-social-agent-registration\u2460\u2460\u24ea"},{"id":"ref-for-social-agent-registration\u2460\u2460\u2460"}],"title":"5.3. Social Agent Invitation"},{"refs":[{"id":"ref-for-social-agent-registration\u2460\u2460\u2461"},{"id":"ref-for-social-agent-registration\u2460\u2460\u2462"}],"title":"5.4. Agent Registry"},{"refs":[{"id":"ref-for-social-agent-registration\u2460\u2460\u2463"}],"title":"9.7. Access Receipt"}],"url":"#social-agent-registration\u2460"},
+"solid": {"dfnID":"solid","dfnText":"Solid","external":false,"refSections":[{"refs":[{"id":"ref-for-solid"},{"id":"ref-for-solid\u2460"},{"id":"ref-for-solid\u2461"}],"title":"11. Definitions"}],"url":"#solid"},
+"strongly-identifiable-applications": {"dfnID":"strongly-identifiable-applications","dfnText":"Strongly identifiable applications","external":false,"refSections":[{"refs":[{"id":"ref-for-strongly-identifiable-applications"}],"title":"10.1. Application Authorization"}],"url":"#strongly-identifiable-applications"},
+"user-piloted-application": {"dfnID":"user-piloted-application","dfnText":"user-piloted application","external":false,"refSections":[{"refs":[{"id":"ref-for-user-piloted-application"},{"id":"ref-for-user-piloted-application\u2460"}],"title":"11. Definitions"}],"url":"#user-piloted-application"},
+"weakly-identifiable-applications": {"dfnID":"weakly-identifiable-applications","dfnText":"Weakly identifiable applications","external":false,"refSections":[{"refs":[{"id":"ref-for-weakly-identifiable-applications"}],"title":"10.1. Application Authorization"}],"url":"#weakly-identifiable-applications"},
+"webid": {"dfnID":"webid","dfnText":"WebID","external":false,"refSections":[{"refs":[{"id":"ref-for-webid"}],"title":"11. Definitions"}],"url":"#webid"},
+};
+
+document.addEventListener("DOMContentLoaded", ()=>{
+    genAllDfnPanels();
+
+    document.body.addEventListener("click", (e) => {
+        // If not handled already, just hide all dfn panels.
+        hideAllDfnPanels();
+    });
+});
+
+window.addEventListener("resize", () => {
+    // Pin any visible dfn panel
+    queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(el=>positionDfnPanel(el));
+});
+
+function genAllDfnPanels() {
+    for(const panelData of Object.values(dfnPanelData)) {
+        const dfnID = panelData.dfnID;
+        const dfn = document.getElementById(dfnID);
+        if(!dfn) {
+            console.log(`Can't find dfn#${dfnID}.`, panelData);
+            continue;
+        }
+        dfn.panelData = panelData;
+        insertDfnPopupAction(dfn);
+    }
+}
+
+function genDfnPanel(dfn, { dfnID, url, dfnText, refSections, external }) {
+    const dfnPanel = mk.aside({
+        class: "dfn-panel on",
+        id: `infopanel-for-${dfnID}`,
+        "data-for": dfnID,
+        "aria-labelled-by":`infopaneltitle-for-${dfnID}`,
+        },
+        mk.span({id:`infopaneltitle-for-${dfnID}`, style:"display:none"},
+            `Info about the '${dfnText}' ${external?"external":""} reference.`),
+        mk.a({href:url, class:"dfn-link"}, url),
+        refSections.length == 0 ? [] :
+            mk.b({}, "Referenced in:"),
+            mk.ul({},
+                ...refSections.map(section=>
+                    mk.li({},
+                        ...section.refs.map((ref, refI)=>
+                            [
+                                mk.a({ href: `#${ref.id}` },
+                                    (refI == 0) ? section.title : `(${refI + 1})`
+                                ),
+                                " ",
+                            ]
+                        ),
+                    ),
+                ),
+            ),
+        genLinkingSyntaxes(dfn),
+    );
+
+    dfnPanel.addEventListener('click', (event) => {
+        if (event.target.nodeName == 'A') {
+            scrollToTargetAndHighlight(event);
+            pinDfnPanel(dfnPanel);
+        }
+        event.stopPropagation();
+        refocusOnTarget(event);
+    });
+    dfnPanel.addEventListener('keydown', (event) => {
+        if(event.keyCode == 27) { // Escape key
+            hideDfnPanel({dfnPanel});
+            event.stopPropagation();
+            event.preventDefault();
+        }
+    });
+
+    dfnPanel.dfn = dfn;
+    dfn.dfnPanel = dfnPanel;
+    return dfnPanel;
+}
+
+
+
+function hideAllDfnPanels() {
+    // Delete the currently-active dfn panel.
+    queryAll(".dfn-panel").forEach(dfnPanel=>hideDfnPanel({dfnPanel}));
+}
+
+function showDfnPanel(dfn) {
+    hideAllDfnPanels(); // Only display one at a time.
+
+    dfn.setAttribute("aria-expanded", "true");
+
+    const dfnPanel = genDfnPanel(dfn, dfn.panelData);
+
+    // Give the dfn a unique tabindex, and then
+    // give all the tabbable panel bits successive indexes.
+    let tabIndex = 100;
+    dfn.tabIndex = tabIndex++;
+    const tabbable = dfnPanel.querySelectorAll(":is(a, button)");
+    for (const el of tabbable) {
+        el.tabIndex = tabIndex++;
+    }
+
+    append(document.body, dfnPanel);
+    positionDfnPanel(dfnPanel);
+}
+
+function positionDfnPanel(dfnPanel) {
+    const dfn = dfnPanel.dfn;
+    const dfnPos = getBounds(dfn);
+    dfnPanel.style.top = dfnPos.bottom + "px";
+    dfnPanel.style.left = dfnPos.left + "px";
+
+    const panelPos = dfnPanel.getBoundingClientRect();
+    const panelMargin = 8;
+    const maxRight = document.body.parentNode.clientWidth - panelMargin;
+    if (panelPos.right > maxRight) {
+        const overflowAmount = panelPos.right - maxRight;
+        const newLeft = Math.max(panelMargin, dfnPos.left - overflowAmount);
+        dfnPanel.style.left = newLeft + "px";
+    }
+}
+
+function pinDfnPanel(dfnPanel) {
+    // Switch it to "activated" state, which pins it.
+    dfnPanel.classList.add("activated");
+    dfnPanel.style.position = "fixed";
+    dfnPanel.style.left = null;
+    dfnPanel.style.top = null;
+}
+
+function hideDfnPanel({dfn, dfnPanel}) {
+    if(!dfnPanel) dfnPanel = dfn.dfnPanel;
+    if(!dfn) dfn = dfnPanel.dfn;
+    dfn.dfnPanel = undefined;
+    dfnPanel.dfn = undefined;
+    dfn.setAttribute("aria-expanded", "false");
+    dfn.tabIndex = undefined;
+    dfnPanel.remove()
+}
+
+function toggleDfnPanel(dfn) {
+    if(dfn.dfnPanel) {
+        hideDfnPanel(dfn);
+    } else {
+        showDfnPanel(dfn);
+    }
+}
+
+function insertDfnPopupAction(dfn) {
+    dfn.setAttribute('role', 'button');
+    dfn.setAttribute('aria-expanded', 'false')
+    dfn.tabIndex = 0;
+    dfn.classList.add('has-dfn-panel');
+    dfn.addEventListener('click', (event) => {
+        toggleDfnPanel(dfn);
+        event.stopPropagation();
+    });
+    dfn.addEventListener('keypress', (event) => {
+        const kc = event.keyCode;
+        // 32->Space, 13->Enter
+        if(kc == 32 || kc == 13) {
+            toggleDfnPanel(dfn);
+            event.stopPropagation();
+            event.preventDefault();
+        }
+    });
+}
+
+function refocusOnTarget(event) {
+    const target = event.target;
+    setTimeout(() => {
+        // Refocus on the event.target element.
+        // This is needed after browser scrolls to the destination.
+        target.focus();
+    });
+}
+
+// TODO: shared util
+// Returns the root-level absolute position {left and top} of element.
+function getBounds(el, relativeTo=document.body) {
+    const relativeRect = relativeTo.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const top = elRect.top - relativeRect.top;
+    const left = elRect.left - relativeRect.left;
+    return {
+        top,
+        left,
+        bottom: top + elRect.height,
+        right: left + elRect.width,
+    }
+}
+
+function scrollToTargetAndHighlight(event) {
+    let hash = event.target.hash;
+    if (hash) {
+        hash = decodeURIComponent(hash.substring(1));
+        const dest = document.getElementById(hash);
+        if (dest) {
+            dest.classList.add('highlighted');
+            setTimeout(() => dest.classList.remove('highlighted'), 1000);
+        }
+    }
+}
+
+// Functions, divided by link type, that wrap an autolink's
+// contents with the appropriate outer syntax.
+// Alternately, a string naming another type they format
+// the same as.
+function needsFor(type) {
+    switch(type) {
+        case "descriptor":
+        case "value":
+        case "element-attr":
+        case "attr-value":
+        case "element-state":
+        case "method":
+        case "constructor":
+        case "argument":
+        case "attribute":
+        case "const":
+        case "dict-member":
+        case "event":
+        case "enum-value":
+        case "stringifier":
+        case "serializer":
+        case "iterator":
+        case "maplike":
+        case "setlike":
+        case "state":
+        case "mode":
+        case "context":
+        case "facet": return true;
+
+        default: return false;
+    }
+}
+function refusesFor(type) {
+    switch(type) {
+        case "property":
+        case "element":
+        case "interface":
+        case "namespace":
+        case "callback":
+        case "dictionary":
+        case "enum":
+        case "exception":
+        case "typedef":
+        case "http-header":
+        case "permission": return true;
+
+        default: return false;
+    }
+}
+function linkFormatterFromType(type) {
+    switch(type) {
+        case 'scheme':
+        case 'permission':
+        case 'dfn': return (text) => `[=${text}=]`;
+
+        case 'abstract-op': return (text) => `[\$${text}\$]`;
+
+        case 'function':
+        case 'at-rule':
+        case 'selector':
+        case 'value': return (text) => `''${text}''`;
+
+        case 'http-header': return (text) => `[:${text}:]`;
+
+        case 'interface':
+        case 'constructor':
+        case 'method':
+        case 'argument':
+        case 'attribute':
+        case 'callback':
+        case 'dictionary':
+        case 'dict-member':
+        case 'enum':
+        case 'enum-value':
+        case 'exception':
+        case 'const':
+        case 'typedef':
+        case 'stringifier':
+        case 'serializer':
+        case 'iterator':
+        case 'maplike':
+        case 'setlike':
+        case 'extended-attribute':
+        case 'event':
+        case 'idl': return (text) => `{{${text}}}`;
+
+        case 'element-state':
+        case 'element-attr':
+        case 'attr-value':
+        case 'element': return (element) => `<{${element}}>`;
+
+        case 'grammar': return (text) => `${text} (within a <pre class=prod>)`;
+
+        case 'type': return (text)=> `<<${text}>>`;
+
+        case 'descriptor':
+        case 'property': return (text) => `'${text}'`;
+
+        default: return;
+    };
+};
+
+function genLinkingSyntaxes(dfn) {
+    if(dfn.tagName != "DFN") return;
+
+    const type = dfn.getAttribute('data-dfn-type');
+    if(!type) {
+        console.log(`<dfn> doesn't have a data-dfn-type:`, dfn);
+        return [];
+    }
+
+    // Return a function that wraps link text based on the type
+    const linkFormatter = linkFormatterFromType(type);
+    if(!linkFormatter) {
+        console.log(`<dfn> has an unknown data-dfn-type:`, dfn);
+        return [];
+    }
+
+    let ltAlts;
+    if(dfn.hasAttribute('data-lt')) {
+        ltAlts = dfn.getAttribute('data-lt')
+            .split("|")
+            .map(x=>x.trim());
+    } else {
+        ltAlts = [dfn.textContent.trim()];
+    }
+    if(type == "type") {
+        // lt of "<foo>", but "foo" is the interior;
+        // <<foo/bar>> is how you write it with a for,
+        // not <foo/<bar>> or whatever.
+        for(var i = 0; i < ltAlts.length; i++) {
+            const lt = ltAlts[i];
+            const match = /<(.*)>/.exec(lt);
+            if(match) { ltAlts[i] = match[1]; }
+        }
+    }
+
+    let forAlts;
+    if(dfn.hasAttribute('data-dfn-for')) {
+        forAlts = dfn.getAttribute('data-dfn-for')
+            .split(",")
+            .map(x=>x.trim());
+    } else {
+        forAlts = [''];
+    }
+
+    let linkingSyntaxes = [];
+    if(!needsFor(type)) {
+        for(const lt of ltAlts) {
+            linkingSyntaxes.push(linkFormatter(lt));
+        }
+    }
+    if(!refusesFor(type)) {
+        for(const f of forAlts) {
+            linkingSyntaxes.push(linkFormatter(`${f}/${ltAlts[0]}`))
+        }
+    }
+    return [
+        mk.b({}, 'Possible linking syntaxes:'),
+        mk.ul({},
+            ...linkingSyntaxes.map(link => {
+                const copyLink = async () =>
+                    await navigator.clipboard.writeText(link);
+                return mk.li({},
+                    mk.div({ class: 'link-item' },
+                        mk.button({
+                            class: 'copy-icon', title: 'Copy',
+                            type: 'button',
+                            _onclick: copyLink,
+                            tabindex: 0,
+                        }, mk.span({ class: 'icon' }) ),
+                        mk.span({}, link)
+                    )
+                );
+            })
+        )
+    ];
+}
+}
+</script>
+<script>/* Boilerplate: script-ref-hints */
+"use strict";
+{
+let refsData = {
+"#access-authorization①": {"displayText":"access authorization","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access authorization","type":"dfn","url":"#access-authorization\u2460"},
+"#access-description-set①": {"displayText":"access description set","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access description set","type":"dfn","url":"#access-description-set\u2460"},
+"#access-grant①": {"displayText":"access grant","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access grant","type":"dfn","url":"#access-grant\u2460"},
+"#access-mode": {"displayText":"access mode","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access mode","type":"dfn","url":"#access-mode"},
+"#access-need": {"displayText":"access need","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need","type":"dfn","url":"#access-need"},
+"#access-need-description①": {"displayText":"access need description","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need description","type":"dfn","url":"#access-need-description\u2460"},
+"#access-need-group-description①": {"displayText":"access need group description","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need group description","type":"dfn","url":"#access-need-group-description\u2460"},
+"#access-need-group①": {"displayText":"access need group","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access need group","type":"dfn","url":"#access-need-group\u2460"},
+"#access-receipt①": {"displayText":"access receipt","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access receipt","type":"dfn","url":"#access-receipt\u2460"},
+"#access-request①": {"displayText":"access request","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access request","type":"dfn","url":"#access-request\u2460"},
+"#access-scope": {"displayText":"access scope","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"access scope","type":"dfn","url":"#access-scope"},
+"#acl-resource": {"displayText":"acl resource","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"acl resource","type":"dfn","url":"#acl-resource"},
+"#agent-registrations": {"displayText":"agent registrations","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"agent registrations","type":"dfn","url":"#agent-registrations"},
+"#agent-registry": {"displayText":"agent registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"agent registry","type":"dfn","url":"#agent-registry"},
+"#agents①": {"displayText":"agents","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"agents","type":"dfn","url":"#agents\u2460"},
+"#application": {"displayText":"application","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application","type":"dfn","url":"#application"},
+"#application-identity": {"displayText":"application identity","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application identity","type":"dfn","url":"#application-identity"},
+"#application-profile-document": {"displayText":"application profile document","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application profile document","type":"dfn","url":"#application-profile-document"},
+"#application-registration①": {"displayText":"application registration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"application registration","type":"dfn","url":"#application-registration\u2460"},
+"#authenticated-agent": {"displayText":"authenticated agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authenticated agent","type":"dfn","url":"#authenticated-agent"},
+"#authorization-agent①": {"displayText":"authorization agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authorization agent","type":"dfn","url":"#authorization-agent\u2460"},
+"#authorization-registry": {"displayText":"authorization registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authorization registry","type":"dfn","url":"#authorization-registry"},
+"#authorization-subject": {"displayText":"authorization subject","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"authorization subject","type":"dfn","url":"#authorization-subject"},
+"#data-authorization①": {"displayText":"data authorization","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data authorization","type":"dfn","url":"#data-authorization\u2460"},
+"#data-grant①": {"displayText":"data grant","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data grant","type":"dfn","url":"#data-grant\u2460"},
+"#data-instance": {"displayText":"data instance","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data instance","type":"dfn","url":"#data-instance"},
+"#data-registration①": {"displayText":"data registration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data registration","type":"dfn","url":"#data-registration\u2460"},
+"#data-registry①": {"displayText":"data registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"data registry","type":"dfn","url":"#data-registry\u2460"},
+"#delegated-data-grant①": {"displayText":"delegated data grant","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"delegated data grant","type":"dfn","url":"#delegated-data-grant\u2460"},
+"#did": {"displayText":"did","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"did","type":"dfn","url":"#did"},
+"#ecosystem": {"displayText":"ecosystem","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"ecosystem","type":"dfn","url":"#ecosystem"},
+"#identity": {"displayText":"identity","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"identity","type":"dfn","url":"#identity"},
+"#identity-profile-document": {"displayText":"identity profile document","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"identity profile document","type":"dfn","url":"#identity-profile-document"},
+"#pod": {"displayText":"pod","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"pod","type":"dfn","url":"#pod"},
+"#registry": {"displayText":"registry","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"registry","type":"dfn","url":"#registry"},
+"#registry-set": {"displayText":"registry set","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"registry set","type":"dfn","url":"#registry-set"},
+"#server-side-application": {"displayText":"server-side application","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"server-side application","type":"dfn","url":"#server-side-application"},
+"#shape": {"displayText":"shape","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"shape","type":"dfn","url":"#shape"},
+"#shape-tree": {"displayText":"shape tree","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"shape tree","type":"dfn","url":"#shape-tree"},
+"#shape-tree-reference": {"displayText":"shape tree reference","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"shape tree reference","type":"dfn","url":"#shape-tree-reference"},
+"#social-agent": {"displayText":"social agent","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"social agent","type":"dfn","url":"#social-agent"},
+"#social-agent-invitation①": {"displayText":"social agent invitation","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"social agent invitation","type":"dfn","url":"#social-agent-invitation\u2460"},
+"#social-agent-registration①": {"displayText":"social agent registration","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"social agent registration","type":"dfn","url":"#social-agent-registration\u2460"},
+"#solid": {"displayText":"solid","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"solid","type":"dfn","url":"#solid"},
+"#strongly-identifiable-applications": {"displayText":"strongly identifiable applications","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"strongly identifiable applications","type":"dfn","url":"#strongly-identifiable-applications"},
+"#user-piloted-application": {"displayText":"user-piloted application","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"user-piloted application","type":"dfn","url":"#user-piloted-application"},
+"#weakly-identifiable-applications": {"displayText":"weakly identifiable applications","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"weakly identifiable applications","type":"dfn","url":"#weakly-identifiable-applications"},
+"#webid": {"displayText":"webid","export":true,"for_":[],"level":"1","normative":true,"shortname":"sai","spec":"sai-1","status":"local","text":"webid","type":"dfn","url":"#webid"},
+};
+
+function mkRefHint(link, ref) {
+    const linkText = link.textContent;
+    let dfnTextElements = '';
+    if (ref.displayText.toLowerCase() != linkText.toLowerCase()) {
+        // Give the original term if it's being displayed in a different way.
+        // But allow casing differences, they're insignificant.
+        dfnTextElements =
+            mk.li({},
+                mk.b({}, "Term: "),
+                mk.span({}, ref.displayText)
+            );
+    }
+    const forList = ref.for_;
+    let forListElements;
+    if(forList.length == 0) {
+        forListElements = [];
+    } else if(forList.length == 1) {
+        forListElements = mk.li({},
+            mk.b({}, "For: "),
+            mk.span({}, forList[0]),
+        );
+    } else {
+        forListElements = mk.li({},
+            mk.b({}, "For: "),
+            mk.ul({},
+                ...forList.map(forItem =>
+                    mk.li({},
+                        mk.span({}, forItem)
+                    ),
+                ),
+            ),
+        );
+    }
+    const url = ref.url;
+    const safeUrl = encodeURIComponent(url);
+    const hintPanel = mk.aside({
+        class: "ref-hint",
+        id: `ref-hint-for-${safeUrl}`,
+        "data-for": url,
+        "aria-labelled-by": `ref-hint-for-${safeUrl}`,
+    },
+        mk.ul({},
+            dfnTextElements,
+            mk.li({},
+                mk.b({}, "URL: "),
+                mk.a({ href: url, class: "ref" }, url),
+            ),
+            mk.li({},
+                mk.b({}, "Type: "),
+                mk.span({}, `${ref.type}`),
+            ),
+            mk.li({},
+                mk.b({}, "Spec: "),
+                mk.span({}, `${ref.spec ? ref.spec : ''}`),
+            ),
+            forListElements
+        ),
+    );
+    hintPanel.forLink = link;
+    setupRefHintEventListeners(link, hintPanel);
+    return hintPanel;
+}
+
+function hideAllRefHints() {
+    queryAll(".ref-hint").forEach(el=>hideRefHint(el));
+}
+
+function hideRefHint(refHint) {
+    const link = refHint.forLink;
+    link.setAttribute("aria-expanded", "false");
+    if(refHint.teardownEventListeners) {
+        refHint.teardownEventListeners();
+    }
+    refHint.remove();
+}
+
+function showRefHint(link) {
+    if(link.classList.contains("dfn-link")) return;
+    const url = link.getAttribute("href");
+    const refHintKey = link.getAttribute("data-refhint-key");
+    let key = url;
+    if(refHintKey) {
+        key = refHintKey + "_" + url;
+    }
+    const ref = refsData[key];
+    if(!ref) return;
+
+    hideAllRefHints(); // Only display one at this time.
+
+    const refHint = mkRefHint(link, ref);
+    append(document.body, refHint);
+    link.setAttribute("aria-expanded", "true");
+    positionRefHint(refHint);
+}
+
+function setupRefHintEventListeners(link, refHint) {
+    if (refHint.teardownEventListeners) return;
+    // Add event handlers to hide the refHint after the user moves away
+    // from both the link and refHint, if not hovering either within one second.
+    let timeout = null;
+    const startHidingRefHint = (event) => {
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+        timeout = setTimeout(() => {
+            hideRefHint(refHint);
+        }, 1000);
+    }
+    const resetHidingRefHint = (event) => {
+        if (timeout) clearTimeout(timeout);
+        timeout = null;
+    };
+    link.addEventListener("mouseleave", startHidingRefHint);
+    link.addEventListener("mouseenter", resetHidingRefHint);
+    link.addEventListener("blur", startHidingRefHint);
+    link.addEventListener("focus", resetHidingRefHint);
+    refHint.addEventListener("mouseleave", startHidingRefHint);
+    refHint.addEventListener("mouseenter", resetHidingRefHint);
+    refHint.addEventListener("blur", startHidingRefHint);
+    refHint.addEventListener("focus", resetHidingRefHint);
+
+    refHint.teardownEventListeners = () => {
+        // remove event listeners
+        resetHidingRefHint();
+        link.removeEventListener("mouseleave", startHidingRefHint);
+        link.removeEventListener("mouseenter", resetHidingRefHint);
+        link.removeEventListener("blur", startHidingRefHint);
+        link.removeEventListener("focus", resetHidingRefHint);
+        refHint.removeEventListener("mouseleave", startHidingRefHint);
+        refHint.removeEventListener("mouseenter", resetHidingRefHint);
+        refHint.removeEventListener("blur", startHidingRefHint);
+        refHint.removeEventListener("focus", resetHidingRefHint);
+    };
+}
+
+function positionRefHint(refHint) {
+    const link = refHint.forLink;
+    const linkPos = getBounds(link);
+    refHint.style.top = linkPos.bottom + "px";
+    refHint.style.left = linkPos.left + "px";
+
+    const panelPos = refHint.getBoundingClientRect();
+    const panelMargin = 8;
+    const maxRight = document.body.parentNode.clientWidth - panelMargin;
+    if (panelPos.right > maxRight) {
+        const overflowAmount = panelPos.right - maxRight;
+        const newLeft = Math.max(panelMargin, linkPos.left - overflowAmount);
+        refHint.style.left = newLeft + "px";
+    }
+}
+
+// TODO: shared util
+// Returns the root-level absolute position {left and top} of element.
+function getBounds(el, relativeTo=document.body) {
+    const relativeRect = relativeTo.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const top = elRect.top - relativeRect.top;
+    const left = elRect.left - relativeRect.left;
+    return {
+        top,
+        left,
+        bottom: top + elRect.height,
+        right: left + elRect.width,
+    }
+}
+
+function showRefHintListener(e) {
+    // If the target isn't in a link (or is a link),
+    // just ignore it.
+    let link = e.target.closest("a");
+    if(!link) return;
+
+    // If the target is in a ref-hint panel
+    // (aka a link in the already-open one),
+    // also just ignore it.
+    if(link.closest(".ref-hint")) return;
+
+    // Otherwise, show the panel for the link.
+    showRefHint(link);
+}
+
+function hideAllHintsListener(e) {
+    // If the click is inside a ref-hint panel, ignore it.
+    if(e.target.closest(".ref-hint")) return;
+    // Otherwise, close all the current panels.
+    hideAllRefHints();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.body.addEventListener("mousedown", showRefHintListener);
+    document.body.addEventListener("focus", showRefHintListener);
+
+    document.body.addEventListener("click", hideAllHintsListener);
+});
+
+window.addEventListener("resize", () => {
+    // Hide any open ref hint.
+    hideAllRefHints();
+});
+}
+</script>


### PR DESCRIPTION
The main goal is to create cannonical URSs and include RDF as JSON-LD in `<script>` tags.
I already have code for https://elf-pavlik.github.io/solid-efforts/#/ that gets those descriptions from either `<script>` tag or RDFa and aggregates it to be presented by the application.

Since it uses semver, I added shapshot permalinks like `/TR/tag/sai-v0.1`. I don't see any reason to create confusion by including artificial year and date versioning in the URL. 


### preview

* [sai](https://htmlpreview.github.io/?https://raw.githubusercontent.com/elf-pavlik/specification/refs/heads/publish-sai/sai.html)
* [sai-primer-application](https://htmlpreview.github.io/?https://raw.githubusercontent.com/elf-pavlik/specification/refs/heads/publish-sai/sai-primer-application.html)
* [sai-primer-authorization-agent](https://htmlpreview.github.io/?https://raw.githubusercontent.com/elf-pavlik/specification/refs/heads/publish-sai/sai-primer-authorization-agent.html)


### TODO

* [ ] get real WebID from @ericprud :wave: 
* [ ] update index with new links once we approve them