### PR TITLE
Add meeting notes for W3C Solid CG on 2025-10-15

### DIFF
--- a/meetings/2025-10-15.md
+++ b/meetings/2025-10-15.md
@@ -17,7 +17,7 @@
 * Theo - @thhck 
 * Hadrian Zbarcea
 * Marc Haddle
-* Ted Thibodeau
+* [Ted Thibodeau Jr](https://www.linkedin.com/in/macted/) (he/him) (OpenLinkSw.com) // GitHub:[@TallTed](https://github.com/TallTed) // Mastodon:[@TallTed](https://mastodon.social/@TallTed)
 * Luke Dary
 
 ## Regrets
@@ -70,12 +70,12 @@ MdJ: we'll move these items to github, so we can remove them here
 * eP: Followup on https://github.com/solid/specification/blob/main/meetings/2025-10-01.md#copyright-violation-claim-in-solid-cg
 * eP: From email thread, I understand that Ruben just wants to be left alone and CG should be able to restore content. We could write very short action plan to restore content I could double check with Ruben if he commits to accept that content being restored not to raise any copyright claims.
 * eP: Where exactly the offcial claim (not renaming issue) was raised and who is responsible for resolving it? There were mentions of ODI and W3C but to my understanding not directly Solid CG.
-* SC: Don't need permission from RV to restore content / change issue title. Anything pertaining to copyright can be addressed by W3C, if it has any merit. The rest is about protecting CG material, and the CG (e.g. chairs) can do that.
+* SC: Don't need permission from RV to restore content or change issue titles. Anything pertaining to copyright can be addressed by W3C, if it has any merit. The rest is about protecting CG material, and the CG (e.g., chairs) can do that.
 * SC: With respect to being "left alone", that certainly didn't seem to be the case when RV decided to participate in https://github.com/solid/specification/pull/711 (see also Internet Archive) on his own (years after leaving the CG). No one is chasing RV to my knowledge.
 
 ### Spin-off CGs?
 
-* MdJ: Thinking outside the box here - some of our work items (like personal data interop and personal data auth) are useful outside of Solid too. So we could move them into spin-off CGs?
+* MdJ: Thinking outside the box here — some of our work items (like personal data interop and personal data auth) are useful outside of Solid, too. So we could move them into spin-off CGs?
 * eP: yes, I tried something like this with RDF-CRDT, but there was too much overhead animating the momentum, so in the end we would maybe end up with 5 inactive CGs instead of one active one
 * SC: I think along the same lines. There needs to be significant activity to be worthwhile whether panel or another CG/WG/IG or whatever. SAI could become a WG because there is incubation history. You would also need to get buy-in from outside Solid. Groups have a risk of being exciting at first but then quieting down later. Have some commitment from people and have a charter etc.
 * eP: I'll join the CG program meeting again, we can improve interaction with other CGs. It's a bit like monorepo vs multiple repos, it doesn't really matter what you call it, the same people would be doing the same work.


### PR DESCRIPTION
Documented the agenda and participants for the W3C Solid Community Group meeting on October 15, 2025, including action items and topics for discussion.