### PR TITLE
Add meeting notes for W3C Solid CG on 2025-11-05

### DIFF
--- a/meetings/2025-11-05.md
+++ b/meetings/2025-11-05.md
@@ -1,0 +1,102 @@
+# W3C Solid Community Group: Weekly
+
+* Date: 2025-11-05T14:00:00Z
+* Call: https://meet.jit.si/solid-cg
+* Repository: https://github.com/solid/specification
+
+## Chair
+
+* Michiel
+
+## Present
+
+* Michiel 
+* Erich Bremer
+* [elf Pavlik](https://elf-pavlik.hackers4peace.net)
+* Michael Greig
+* Hadrian Zbarcea
+* [Ted Thibodeau Jr](https://www.linkedin.com/in/macted/) (he/him) (OpenLinkSw.com) // GitHub:[@TallTed](https://github.com/TallTed) // Mastodon:[@TallTed](https://mastodon.social/@TallTed)
+* Meem Arafat Manab
+
+
+## Regrets
+
+## Scribes
+
+
+---
+
+## Announcements
+
+* MdJ: 26 november will be the last time I chair, going travelling after that. There will be CG co-chair elections coming up soon, please consider volunteering! :)
+
+### Meeting Guidelines
+* [W3C Solid Community Group Calendar](https://www.w3.org/groups/cg/solid/calendar).
+* [W3C Solid Community Group Meeting Guidelines](https://github.com/w3c-cg/solid/blob/main/meetings/README.md).
+* No audio or video recording, or automated transcripts without consent. Meetings are transcribed and made public. If consent is withheld by anyone, recording/retention must not occur.
+* Join queue to talk.
+* Topics can be proposed at the bottom of the agenda to be discussed as time allows. Make it known if a topic is urgent or cannot be postponed.
+
+### Participation and Code of Conduct
+* [Join the W3C Solid Community Group](https://www.w3.org/community/solid/join), [W3C Account Request](http://www.w3.org/accounts/request), [W3C Community Contributor License Agreement](https://www.w3.org/community/about/agreements/cla/)
+* [Solid Code of Conduct](https://github.com/solid/process/blob/main/code-of-conduct.md), [Positive Work Environment at W3C: Code of Conduct](https://www.w3.org/policies/code-of-conduct/)
+* Operating principle for effective participation is to allow access across disabilities, across country borders, and across time. Feedback on tooling and meeting timing is welcome.
+* If this is your first time, welcome! please introduce yourself.
+
+---
+
+
+## Introductions
+
+* Meem: Doing PhD at ... Madrit. I'm integrating with data spaces. I will intorduce it to my superviser. 
+* Michael: Product designer for about 8 years. Was working for consultatncy in US, now working in UK. After reading TimBLs memoir I found Solid. I resontate with the concerns Solid tries to solve about data owenership. 
+
+
+## Review Action items
+
+* HZ: to organize session about DIDs in Solid
+
+## Topics
+
+### Towards an end-to-end demo of Solid
+MdJ: We have partial demos of how Solid works but as far as I'm aware we can't show a full demo where:
+* the user authenticates to an app with their WebID
+* the storage is separate from the application
+* the app gets partial access (not root access) to the user's storage
+* BONUS: a second app can read and "understand" the data that the first app stored
+
+Some of us have had this goal since the start of the Solid project. What is holding us back from building it?
+
+We can use [SAI](https://solidproject.org/TR/sai) but there are no implementations of that available yet.
+
+We can tell people to hand-edit their ACLs but that's not really an acceptable demo in terms of UX, other than for power users.
+
+We can use [the app launcher based on ACP and type indexes](https://hackmd.io/@solid/cg-weekly) but this is not compatible with solidcommunity.net, with SolidOS, or with SAI.
+
+All in all there is nowhere where we can point interested people to try out a demo of Solid.
+
+MdJ: I think we sort of saw the limitations and stopped working on app authorization with ACLs after https://www.youtube.com/watch?v=5Q1nUmGdaXE&t=19s.
+
+We also discussed "Christoph's demo" (see Matrix chat):
+> From my experience of introducing people to Solid , the minimal demo that a user expects is (after signup - which is step 0) have a storage to put some data (even if it is a .pdf) and share that with another user. The fact that the same data can be used in different apps or by different users always came as a step 2. The critique always was along the lines of "well, then we just use drive/sharepoint/nextcloud" because this works the way the users are used to - when it comes to "control" who has access to your data.
+
+> As a side note: There is stuff out there that could be used by the community to build the desired simple data sharing.
+After addressing standing issues including https://github.com/solid/web-access-control-spec/issues/81, 
+Look at demos from research/industry projects including https://purl.archive.org/mandatb2b/JWE2024 which showcases an Authorization App whose codebase is available github.com/DATEV-Research/Solid-authorization-app (granted not well-documented, but the stuff is there).
+>
+> I am in the progress of slowly extracting stuff from these things into repos that are better usable by the community.
+> 
+>For example, the code of https://github.com/uvdsl/solid-oidc-client-browser was extracted from https://github.com/DATEV-Research/Solid-B2B-showcase-libs.
+Re-writing the AuthApp codebase to work with the Pods we have today rather than extended Pods with data registries etc. could bring us closer to the simple data sharing demo you are talking about...
+
+
+And we discussed how SAI could be implemented in the policy engine of CSS. https://github.com/CommunitySolidServer/policy-engine
+ 
+
+### Pull Requests
+
+### Tracking obstacles
+
+
+## Actions
+* eP: send out the call for nominations for the chair elections


### PR DESCRIPTION
Documented the details of the W3C Solid Community Group meeting held on November 5, 2025, including attendees, announcements, and discussion topics.