### PR TITLE
Add minutes for W3C Solid CG meeting on 2025-11-26

### DIFF
--- a/meetings/2025-11-26.md
+++ b/meetings/2025-11-26.md
@@ -72,67 +72,67 @@
   * a. Abide to the charter and carry out the remaining tasks
   * b. Step down from their role so that the CG can carry out the tasks with chairs that are willing. If no chairs, volunteers can carry out the election.
   * c. Another option where a consensus can be reached in the CG if there are strong reasons as to why options a. and b. are not acceptable.
-* SC: First, the current chairs can response to the above. The CG participants (not limited to those present in this meeting) can then follow up with next steps.
+* SC: First, the current chairs can respond to the above. The CG participants (not limited to those present in this meeting) can then follow up with next steps.
 * VB: I subscribe to all of the above expressed by SC.
 * SC: So, remaining question is whether or not the obligations imposed by the charter will be followed, or what the situation is regarding the election.
-Do the chairs intent to follow the charter as it stands, or do we need to figure out a different way forward.
-* MdJ: Why is the list of participants needed - if the WBS is used for authenticating a CG member.
+  Do the chairs intend to follow the charter as it stands, or do we need to figure out a different way forward?
+* MdJ: Why is the list of participants needed, if the WBS is used for authenticating a CG member?
 * VB: Are you familiar with the discussion around this? There were multiple instances of this discussion online.
 * MdJ: Not familiar with the discussion.
-* SC: One is who is a CG member, the other is the snapshot characteristics (the point in time is not that important). So mainly, it is to cross check with the W3C staff such that we can use the WBS, where indeed the CG participants can voke, but within there there is an additional filter to rule out anybody who is not eligible. It is more of a procedural thing, rather than an all-hell-breaks-loose scenario. So, there was the convenience of having W3C accounts in the WBS system.
+* SC: One is about who is a CG member; the other is the characteristics of the snapshot (the point in time is not that important). So mainly, it is to cross check with the W3C staff such that we can use the WBS, where indeed the CG participants can vote, but within that there is an additional filter to rule out anybody who is not eligible. It is more of a procedural thing, rather than an all-hell-breaks-loose scenario. So, there was the convenience of having W3C accounts in the WBS system.
 * MdJ: What could go wrong? 
 * VB: https://github.com/w3c-cg/solid/issues/35#issuecomment-3570472974 
-* MdJ: So, in practise there is a small difference but indee this is a matter of process.
-* VB: interjects: It is also a form of safeguard - just because we can't prevent everything under the sun does not mean we should not take care of some common sense things. *(did i get that right?), thanks.)
-* eP: there was discussion online, arguments were made. I am not convinced, I want to propose ammenemnds. But I am fine with doing this election by the charter - if we find people who want to run the election. 
-* MdJ: Just checking, you propose to pause the election, do we also require re-bidding for co-chair?
-* eP: No, just delaying until we are confrom to charter, i.e., two weeks after publication of the snapshot list.
-* MdJ: I don't want to stand in the way for this group to re-run the election by the charter. For my taste, there was too much discussion around process rather than building things. So, I will step down after this meeting.
-* SC: eP was not "elected" but only filled an interm seat when VB steppepd down. As charter:
-* >In the case of interim vacancy, the remaining chairs may appoint a co-chair for each open seat, hold an election for the same, or wait until the next election, at their discretion. If the chairs do not take any action, the seat will automatically be up for election in any cycle. Any such interim appointments or elections shall hold the seat until the end of its natural cycle.
-* VB: Also, the argument that "nothing happened last time" is fallacious. In 2023 we followed the process so maybe that's why "nothing happened"? And one experience is not enough data. Personal opinions are irrelevant.
-* SC: the point about what modifications to the charter is also relevant to this point, and we may/should discuss this as a different point today. 
-Because this feeds back to what the chairs are willing to do for this election.
+* MdJ: So, in practice there is a small difference but indeed, this is a matter of process.
+* VB: interjects: It is also a form of safeguard — just because we can't prevent everything under the sun does not mean we should not take care of some common sense things. *(SCRIBE: did i get that right? thanks.)
+* eP: There was discussion online, arguments were made. I am not convinced. I want to propose ammenemnds. But I am fine with doing this election by the charter — if we find people who want to run the election. 
+* MdJ: Just checking. You propose to pause the election. Do we also require re-bidding for co-chair?
+* eP: No, just delaying until we are conforming with charter, i.e., two weeks after publication of the snapshot list.
+* MdJ: I don't want to stand in the way of this group running the election by the charter. For my taste, there was too much discussion around process rather than building things. So, I will step down after this meeting.
+* SC: eP was not elected, but appointed to fill an interim seat when VB stepped down. As the charter says:
+  > In the case of interim vacancy, the remaining chairs may appoint a co-chair for each open seat, hold an election for the same, or wait until the next election, at their discretion. If the chairs do not take any action, the seat will automatically be up for election in any cycle. Any such interim appointments or elections shall hold the seat until the end of its natural cycle.
+* VB: Also, the argument that "nothing happened last time" is fallacious. In 2023, we followed the process, so maybe that's why "nothing happened"? And one experience is not enough data. Personal opinions are irrelevant.
+* SC: The point about what modifications to the charter are needed is also relevant to this point, and we may/should discuss this at a different point today, because this feeds back to what the chairs are willing to do for this election.
 * SC: There was another individual who was willing to run back then, so there was no election necessary because there was just one bidder.
-* eP: In my opinion, the charter is too convoluted too make sense of it. 
+* eP: In my opinion, the charter is too convoluted to make sense of.
 * VB: I can make sense of it.
-* eP: After sending the call for nominations, there was no election on-going yet.
-* eP: From a procedural standpoint, do we actually need to go back and do a snapshot. What is the timeline here
-* VB: I dont understand the problem with running the script. I dont't understand what can be so time consuming that it leads to this whole discussion for weeks, which is a waste of time. Just take the snapshot, you use it if you need it, if you don't, you don't. 
-* MdJ: To respond to the question, we all read the charter multiple the times throughout the years - I think I said pavlik to send out the email for nominations. Because we thought we knew it well enough. I still maintain that this was good enough - as per how I believe a CG should be run. The main point of dicussion was around the voting rights of affiliated members. The lesser points were about fake accounts etc. So, I was not aware of these points.
-* SC: If we can get through, why we are currently not following the charter, where we did in 2023, we can discuss that. So, question being what is the status on the snapshop? At the very least, this is an opportunity for the affiliated members to call out for change the member who is eligible to vote on the affiliations behalf. The tooling etc is also available at the link I provided. There is also the opportunity to raise questions to the ones who know. But instead there was an effort to change things that were not understood or liked. If there is a different way of how you want to run things, that would be for the next time but not this election.
-* eP: Clarifying, I did not willfully violated the charter, I just missed it. I would like to point out, after the call for nominations, nobody complained. 
-So I believe this part is not necessary.
-I am not the only one who missed it.
-* VB: I never thought that it was willfull. I dont think that because nobody notices it, it can be removed. I would not be concerned so much of fake accounts, I can bring real life friends. The 2023 election followed the charter, so there is no comparison here. Opinions are not to be mistaken with facts.
-* MdJ: Quick interject, do we want to restart completely or just delay.
-* CB: I'd be willing to accept the delay and have the set of chair candidates as is. So follow the protocol from here on. The charter just says the election is two weeks after the eligible list is published. On the fact that no body spoke on process or error, good that this was raised. And this was your (eP) responsibility. The fact that nobody else looked at it because it wasn't their duty at that poitn. The argument no one else looking at the ceharter, so charter is useless, doesn't really fit in my opinion here.
-* Michal: the snapshot did not happen on the date of announcement of the election, but we have the option to agree on a date of snapshot and move on.
-My position is that we can use it, but if we do not agree, we should re-start completely.
-* eP: I found that confusing - but if we can do the snapshot now, keep the list of candidates, then it is perfectly fine.
+* eP: After sending the call for nominations, there was no election begun yet.
+* eP: From a procedural standpoint, do we actually need to go back and do a snapshot? What is the timeline here?
+* VB: I don/t understand the problem with running the script. I don't understand what can be so time consuming that it leads to this whole discussion for weeks, which is a waste of time. Just take the snapshot, use it if you need it. If you don't need it, don't use it. 
+* MdJ: To respond to the question, we all read the charter multiple times through the years — I think I said pavlik to send out the email for nominations. Because we thought we knew it well enough. I still maintain that this was good enough — as how I believe a CG should be run. The main point of discussion was around the voting rights of affiliated members. The lesser points were about fake accounts, etc. So, I was not aware of these points.
+* SC: If we can get through, why we are currently not following the charter, where we did in 2023, we can discuss that. So, question being what is the status on the snapshot? At the very least, this is an opportunity for the affiliated members to call out to change the member who is eligible to vote on the affiliation's behalf. The tooling, etc., is also available at the link I provided. There is also the opportunity to raise questions to the ones who know. But instead there was an effort to change things that were not understood or liked. If there is a different way you want to run things, that would be for the next time but not this election.
+* eP: Clarifying: I did not willfully violate the charter, I just missed it. I would also like to point out, after the call for nominations, nobody complained. 
+  So I believe this part is not a *common sense* approach.
+  I am not the only one who missed it.
+* VB: I never thought that it was willful. I don't think that because nobody notices it, it should be removed. I would not be concerned so much about fake accounts; I can bring real life friends. The 2023 election followed the charter, so there is no comparison here. Opinions are not to be mistaken with facts.
+* MdJ: Quick interjection: do we want to restart completely or just delay?
+* CB: I'd be willing to accept the delay and have the set of chair candidates as is. Then follow the protocol from here on. The charter just says the election is held two weeks after the eligible list is published. On the fact that nobody spoke on process or error, good that this was raised. And this was your (eP's) responsibility. The fact that nobody else looked at it is just because it wasn't their duty at that point. The argument that "no one else was looking at the charter" makes the charter useless, doesn't really fit in my opinion here.
+* Michal: The snapshot did not happen on the date of announcement of the election, but we have the option to agree on a date of snapshot and move on.
+  My position is that we can use it, but if we do not agree, we should re-start completely.
+* eP: I found that confusing — but if we can do the snapshot now, and keep the list of candidates, then it is perfectly fine.
 * MdJ: Does anyone want to comment before we vote on it?
 * SC: I dont quite understand the thing about the dates? I thought the agreement was already that we do the snapshot
 * MdJ: PROPOSAL: 
-    * Snapshot now, publish it, 
-        (also send out email to CG for affiliation voting member to update)
-    * wait 2 weeks and allow affiliations to update voting eligible member, 
-    * questionaire (voting, presumably WBS), 
-    * wait 2 weeks, 
-    * close.
-    * Dates are calculated relative to the actual publication of the snapshot list.
-* SC: https://github.com/solid/specification/discussions/582 this has a rough timeline about when things were happening. 
-We already have eligbile voters per affiliation. 
-We are able to compute the list of elibile list of members, theo already did that. What we did in the past is give heads-up to the affiliated members for them to be able to update the one member of the affiliation who should be the one who is the one to vote.
+  1. Snapshot now, publish it, 
+     (also send out email to CG for affiliation voting member to update)
+  2. wait 2 weeks and allow affiliations to update voting eligible member, 
+  3. questionnaire (voting, presumably WBS), 
+  4. wait 2 weeks, 
+  5. close.
+* MdJ: Dates are calculated relative to the actual publication of the snapshot list.
+* SC: [Discussion#582](https://github.com/solid/specification/discussions/582) has a rough timeline about when things were happening.
+  We already have eligible voters per affiliation. 
+  We are able to compute the list of eligible members; Theo already did that. What we did in the past is give a heads-up to the affiliated members for them to be able to update the one member of the affiliation who should be the one to vote.
 * Michal: For the newest version of the script, I modified the import/export folders. Just FYI.
-* MdJ: Any objections against the proposal?
-* SILENCE
-* eP: I can send out the email, does anyone want to do the snapshot.
+* MdJ: Any objections to the proposal?
+* [ SILENCE ]
+* eP: I can send out the email. Does anyone want to do the snapshot?
 * CB: A W3C staff member already volunteered to look at the snapshot.
-* Michal: If this is an issue, let's discuss this and figure it out.
-* eP: I already opened a PR to document the process, after running the scripts, we should commit them.
-* PROPOSAL ACCEPTED.
-* eP: ACTION to send out the email.
-* Michal, eP: ACTION to figure out the script and snapshot.
+* Michal: If this is an issue, let's discuss and figure it out.
+* eP: I already opened a PR to document the process. After running the scripts, we should commit them.
+* [ PROPOSAL ACCEPTED ]
+
+* ACTION: eP to send out the email.
+* ACTION: Michal and eP to figure out the script and snapshot.
 
 
 ### CG chair election process discussions
@@ -140,13 +140,13 @@ We are able to compute the list of elibile list of members, theo already did tha
 * eP: Given Virginia's comment https://github.com/w3c-cg/solid/issues/26#issuecomment-3567699333
 * ...: I think we should consider a new run, this time organized by volunteer committee composed of people who have strong preference to do it this specific way.
 * ...: Christoph responded on matrix:
-> I'd second following the charter. If this means to re-start the process due to non-conformance, that's fine with me. 
+  > I'd second following the charter. If this means restarting the process due to non-conformance, that's fine with me. 
 * eP: Virginia's comment with her list of reasons to do the snapshot: https://github.com/w3c-cg/solid/issues/35#issuecomment-3570472974
 * ...: Rahul and Christoph made points about potential to audit list from the snapshot: https://github.com/w3c-cg/solid/issues/35#issuecomment-3570902572
-* eP: is anyone actually going to do that audit? during 2 weeks of call for candidates, no one even noticed that I missed this whole snapshotting step. Exact auditing and potential participant verification process most likelly would need to be clearly documented first. Even with that I find it very hard to believe that someone would be actually doing it.
+* eP: Is anyone actually going to do that audit? During 2 weeks of call for candidates, no-one even noticed that I missed this whole snapshot step. Exact auditing and potential participant verification process most likely would need to be clearly documented first. Even with that, I find it very hard to believe that someone would be actually doing it.
 * ...: I also don't see any snapshot in 2024 special election when I took a vacated chair seat https://lists.w3.org/Archives/Public/public-solid/2024Nov/
-* ...: I'm going to focus on proposals to ammend charter **after** this election, let's better focus **now** on getting the reboot done prudently following the current charter.
-* RG: I shall still not be participating in the Call as the material circumstances around my speech being disrupted, enabled by CG Chairs, remain unchanged. See https://github.com/solid/specification/blob/main/meetings/2025-04-30.md#code-of-conduct-followup. The chairs continue to ignore the establish rules, norms and code of conduct as they did then. However, the failure to follow established democratic due process, such as drawing up the electoral roles, indicates that the chairs are unfit or unwilling to assume the responsibility of chairing itself. I would like to put on record that the actions of last two weeks sets a dangerous precedent which I categorically oppose.
+* ...: I'm going to focus on proposals to amend the charter **after** this election. Better we focus **now** on getting the reboot done following the current charter.
+* RG: I shall still not be participating in the Call as the material circumstances around my speech being disrupted, enabled by CG Chairs, remain unchanged. See https://github.com/solid/specification/blob/main/meetings/2025-04-30.md#code-of-conduct-followup. The chairs continue to ignore the established rules, norms, and code of conduct, as they did then. However, the failure to follow established democratic due process, such as drawing up the electoral roles, indicates that the chairs are unfit or unwilling to assume the responsibility of chairing itself. I would like to put on record that the actions of the last two weeks set a dangerous precedent which I categorically oppose.
 * CB: I would be willing to accept the delay and keep the set of candidates. I see nothing that requires one before the other. Only the 2 weeks after the snapshot is published. 
 * ...: It is good that you raised the point that we missed it. It was your responsibility. Nobody else looked at it since it wasn't their duty. I don't agree with conclusion of it being *useless*.
 * 
@@ -168,15 +168,15 @@ afterthought
 * Rui
 
 * SC: I have self-review questions at https://github.com/solid/specification/discussions/568#discussion-5605593
-* SC: As a self-reflection exercise, why do you want to be chair? What contributions to do you want to make? And what efforts to you want to put towards the group's benefit? And, can you prioritise the groups opinion/consensus over you personal opinion?
+* SC: As a self-reflection exercise, why do you want to be chair? What contributions to do you want to make? What efforts to you want to put towards the group's benefit? Can you prioritize the groups opinion/consensus over your personal opinion?
 * SC: So have a look at the questions above, keep them in mind, you do not need to share or answer, but you are welcome to. I think it would go a long way. I wish everyone good luck :)
 
 
 ### Open up questionnaire for voting
 
-* MdJ: unless blocked by discussions and objections, let's open up  https://www.w3.org/wbs/110151/SolidCgChairElection2025/
-* VB: I want to state for the record I object to this proposal and continuing the process as is, and rather follow the process outlined in the previous topic for the current election. 
-* SC: Objection. There is no point in wasting CG's time on alternative ideas or processes in the middle of an ongoing election especially when there are tasks that are not fulfilled by the current chairs. The charter already defines the expectations, and there is both procedure and tooling available that can be used. The topic "Chair Election Duties Under the Solid CG Charter" takes precedence.
+* MdJ: Unless blocked by discussions and objections, let's open up  https://www.w3.org/wbs/110151/SolidCgChairElection2025/
+* VB: I want to state for the record I object to this proposal and continuing the process as is, and would rather follow the process outlined in the previous topic for the current election. 
+* SC: Objection. There is no point in wasting the CG's time on alternative ideas or processes in the middle of an ongoing election, especially when there are tasks that are not fulfilled by the current chairs. The charter already defines the expectations, and there is both procedure and tooling available that can be used. The topic "Chair Election Duties Under the Solid CG Charter" takes precedence.
 * postponed due to 'PROPOSAL' above
 
 ## Actions


### PR DESCRIPTION
Document the W3C Solid Community Group meeting held on 2025-11-26, including attendance, announcements, and discussions regarding chair election duties and processes.