### PR TITLE
Require `pim:storage` in WebID profile

### DIFF
--- a/ED/protocol.html
+++ b/ED/protocol.html
@@ -1023,6 +1023,8 @@ content:counter(appendix, upper-alpha) "." counter(sub-appendix) "\00a0";
                 <h3 property="schema:name">WebID</h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>A <em>WebID</em> is an HTTP URI denoting an agent, for example a person, organisation, or software [<cite><a class="bibref" href="#bib-webid">WEBID</a></cite>]. When a WebID is dereferenced, server provides a representation of the WebID Profile in an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] which uniquely describes an agent denoted by a WebID. WebIDs are an underpinning component in the Solid ecosystem and are used as the primary identifier for users and applications.</p>
+
+                  <p>The RDF document provided by the server when a WebID is dereferenced must contain at least one statement whose subject is the WebID, whose predicate is <code>pim:storage</code> and whose object is a <a href="#storage">storage</a> <a href="#root-container">root container</a>.</p>
                 </div>
               </section>
             </div>

--- a/protocol.html
+++ b/protocol.html
@@ -1285,8 +1285,6 @@ margin-bottom:0.5rem;
                 <h3 property="schema:name">WebID</h3>
                 <div datatype="rdf:HTML" property="schema:description">
                   <p>A <em>WebID</em> is an HTTP URI denoting an agent, for example a person, organisation, or software [<cite><a class="bibref" href="#bib-webid">WEBID</a></cite>]. When a WebID is dereferenced, server provides a representation of the WebID Profile in an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] which uniquely describes an agent denoted by a WebID. WebIDs are an underpinning component in the Solid ecosystem and are used as the primary identifier for users and applications.</p>
-
-                  <p>The RDF document provided by the server when a WebID is dereferenced must contain at least one statement whose subject is the WebID, whose predicate is <code>pim:storage</code> and whose object is a <a href="#storage">storage</a> <a href="#root-container">root container</a>.</p>
                 </div>
               </section>
             </div>


### PR DESCRIPTION
Current section 9.1 [mentions](https://solidproject.org/TR/protocol#webid) WebID as "underpinning component" and "used as the primary identifier" in Solid.

This change adds a **requirement for [WebID Profiles](https://www.w3.org/2005/Incubator/webid/spec/identity/#:~:text=WebID%20Profile%20or-,Profile%20Document,-A%20WebID%20Profile) to be dereferencable 'publicly'**.

---

The Protocol currently [enables](https://solidproject.org/TR/protocol#client-rdf-storage) discovery of the root container from a Solid resource

However there is no defined mechanism for discovering a Solid storage from a WebID.

This change aims to improve interoperability by adding a normative requirement which corresponds to overwhelming practice in implementations of WebID in the ecosystem.