### PR TITLE
Add TR snapshot for WAC 1.1 (2026-04-20)

### DIFF
--- a/2026/wac-20260420.html
+++ b/2026/wac-20260420.html
@@ -1,0 +1,1429 @@
+<!DOCTYPE html>
+<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <title>Web Access Control</title>
+    <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
+    <style>
+main,
+main>article,
+main>article>div {
+background:inherit;
+}
+body {
+counter-reset:section sub-section appendix sub-appendix;
+}
+code, samp { color: #e00; }
+pre code, pre samp { color: var(--text); }
+dfn { font-weight:inherit; }
+.do.fragment a { border-bottom:0; }
+.do.fragment a:hover { background:none; border-bottom:0; }
+section figure pre { margin:1em 0; display:block; }
+cite .bibref { font-style: normal; }
+.tabs nav ul li { margin:0; }
+div.issue, div.note, div.warning {
+clear: both;
+margin: 1em 0;
+position: relative;
+}
+div.issue h3, div.note h3,
+div.issue h4, div.note h4,
+div.issue h5, div.note h5 {
+margin:0;
+font-weight:normal;
+font-style:normal;
+font-size:1em;
+}
+div.issue h3 > span, div.note h3 > span,
+div.issue h4 > span, div.note h4 > span,
+div.issue h5 > span, div.note h5 > span,
+figure.example > figcaption > span {
+text-transform: uppercase;
+}
+div.issue h3, div.issue h4, div.issue h5 {
+color:var(--issueheading-text);
+}
+div.note h3, div.note h4, div.note h5 {
+color:var(--noteheading-text);
+}
+figure.example figcaption {
+color:var(--exampleheading-text);
+}
+main figure {
+text-align:left;
+}
+figure[id] {
+position:relative;
+padding:0.5em;
+}
+figure[id] figcaption {
+font-style:normal;
+font-size:1em;
+}
+figure.example figcaption span + span {
+text-transform:initial;
+}
+.copyright + hr {
+border-style: solid;
+}
+header address a[href] {
+float: right;
+margin: 1rem 0 0.2rem 0.4rem;
+background: transparent none repeat scroll 0 0;
+border: medium none;
+text-decoration: none;
+}
+header address img[src*="logos/W3C"] {
+background: #1a5e9a none repeat scroll 0 0;
+border-color: #1a5e9a;
+border-image: none;
+border-radius: 0.4rem;
+border-style: solid;
+border-width: 0.65rem 0.7rem 0.6rem;
+color: white;
+display: block;
+font-weight: bold;
+}
+main article > h1 {
+font-size: 220%;
+font-weight:bold;
+}
+#acknowledgements ul { padding: 0; margin:0; }
+#acknowledgements li { display:inline; }
+#acknowledgements li:after { content: ", "; }
+#acknowledgements li:last-child:after { content: ""; }
+dd .contributed {
+user-select: none;
+}
+aside.do { overflow:inherit; }
+aside.do blockquote {
+padding: 0; border: 0; margin: 0;
+}
+dl[id^="document-"] ul {
+padding-left:0;
+list-style-type:none;
+}
+dl [rel~="odrl:action"],
+dl [rel~="odrl:action"] li {
+display: inline;
+}
+dl [rel~="odrl:action"] li:after {
+content: ", ";
+}
+dl [rel~="odrl:action"] li:last-child:after {
+content: "";
+}
+aside section > .toc,
+aside section > .toc ol {
+margin-left: revert;
+}
+aside section > .toc li li {
+margin-left: 1em;
+font-size: revert;
+}
+table {
+border-collapse:collapse;
+}
+table + table {
+margin-top:2em;
+}
+caption {
+text-align:left;
+padding:0 0.25em 0.25em;
+margin-bottom: 1em;
+font-size: 1em;
+font-style: revert;
+font-weight: bold;
+border-bottom: 1px solid;
+}
+caption, tbody, tfoot {
+border-bottom:2pt solid #ccc;
+}
+thead,
+thead th[colspan] {
+border-bottom:1pt solid #ccc;
+}
+[rowspan] { vertical-align: bottom; }
+tbody [rowspan] { vertical-align: middle; }
+tbody th[scope="rowgroup"] {
+border-bottom:3pt double #ccc;
+}
+tr {
+border-bottom:1pt solid #ccc;
+}
+th, td {
+padding:0.25em;
+font-size:0.923em;
+word-wrap:normal;
+}
+table ul,
+table ol,
+table li,
+table p,
+table dd {
+margin:0;
+text-align:left;
+}
+table ul,
+table ol {
+padding-left:1em;
+}
+tfoot td > * + * {
+margin-top:1em;
+}
+tfoot dd:after { content: "\A"; white-space:pre; }
+tfoot dt, tfoot dd { display:inline; }
+tfoot dd { margin-left: 0.5em; }
+tfoot dd + dt { margin-top:0; }
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]):not([id=exit-criteria]) {
+counter-increment:section;
+counter-reset:sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]) section:not([id$=references]):not([id=exit-criteria]) {
+counter-increment:sub-section;
+counter-reset:sub-sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]) section:not([id$=references]):not([id=exit-criteria]) section {
+counter-increment:sub-sub-section;
+counter-reset:sub-sub-sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]) section:not([id$=references]):not([id=exit-criteria]) section section {
+counter-increment:sub-sub-sub-section;
+counter-reset:sub-sub-sub-sub-section;
+}
+article section:not([id=abstract]):not([id=sotd]):not([id=references]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]):not([id=exit-criteria]):not([id^=table-of-]):not([id^=list-of-]) > h2:before {
+content:counter(section) ".\00a0";
+}
+section:not([id$=references]):not([id^=changelog]):not([id=exit-criteria]):not([id^=table-of-]):not([id^=list-of-]) > h3:before {
+content:counter(section) "." counter(sub-section) "\00a0";
+}
+section > h4:before {
+content:counter(section)"." counter(sub-section) "." counter(sub-sub-section) "\00a0";
+}
+article section.appendix {
+counter-increment:appendix;
+counter-reset:sub-appendix;
+}
+article section[class~=appendix]:not([id=abstract]):not([id=sotd]):not([id=appendix]):not([id=acknowledgements]):not([id=changelog]):not([id=exit-criteria]) section {
+counter-increment:sub-appendix;
+counter-reset:sub-sub-appendix;
+}
+section.appendix > h2:before {
+content:counter(appendix, upper-alpha) ".\00a0";
+}
+section.appendix section > h3:before {
+content:counter(appendix, upper-alpha) "." counter(sub-appendix) "\00a0";
+}
+</style>
+    <link href="https://www.w3.org/StyleSheets/TR/2021/base.css" media="all" rel="stylesheet" title="W3C-Base" />
+    <link href="https://www.w3.org/StyleSheets/TR/2021/dark.css" media="(prefers-color-scheme: dark)" rel="stylesheet" />
+    <link href="https://dokie.li/media/css/dokieli.css" media="all" rel="stylesheet" />
+    <script async="" src="https://dokie.li/scripts/dokieli.js"></script>
+  </head>
+  <body about="" prefix="rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# rdfs: http://www.w3.org/2000/01/rdf-schema# owl: http://www.w3.org/2002/07/owl# xsd: http://www.w3.org/2001/XMLSchema# dcterms: http://purl.org/dc/terms/ skos: http://www.w3.org/2004/02/skos/core# prov: http://www.w3.org/ns/prov# mem: http://mementoweb.org/ns# qb: http://purl.org/linked-data/cube# schema: http://schema.org/ doap: http://usefulinc.com/ns/doap# deo: http://purl.org/spar/deo/ cito: http://purl.org/spar/cito/ as: https://www.w3.org/ns/activitystreams# ldp: http://www.w3.org/ns/ldp# earl: http://www.w3.org/ns/earl# spec: http://www.w3.org/ns/spec# rel: https://www.w3.org/ns/iana/link-relations/relation# odrl: http://www.w3.org/ns/odrl/2/">
+    <main>
+      <article about="" typeof="schema:Article">
+        <div class="head">
+          <h1 property="schema:name">Web Access Control</h1>
+          <p id="w3c-state"><a href="https://www.w3.org/standards/types/#reports" rel="rdf:type">Draft Community Group Report</a>, <time datetime="2026-04-20T00:00:00Z">20 April 2026</time></p>
+          <details open="">
+            <summary>More details about this document</summary>
+            <dl id="document-identifier">
+              <dt>This version</dt>
+              <dd><a href="https://solidproject.org/TR/2026/wac-20260420" rel="owl:sameAs">https://solidproject.org/TR/2026/wac-20260420</a></dd>
+            </dl>
+            <dl id="document-latest-published-version">
+              <dt>Latest published version</dt>
+              <dd><a href="https://solidproject.org/TR/wac" rel="rel:latest-version mem:original">https://solidproject.org/TR/wac</a></dd>
+            </dl>
+            <dl id="document-previous-version">
+              <dt>Previous version</dt>
+              <dd><a href="https://solidproject.org/TR/2024/wac-20240512" rel="rel:predecessor-version">https://solidproject.org/TR/2024/wac-20240512</a></dd>
+            </dl>
+            <dl id="document-editors-draft">
+              <dt>Editor’s draft</dt>
+              <dd><a href="https://solid.github.io/web-access-control-spec/" rel="rdfs:seeAlso">https://solid.github.io/web-access-control-spec/</a></dd>
+            </dl>
+
+            <dl id="document-timemap">
+              <dt>TimeMap</dt>
+              <dd><a href="https://solidproject.org/TR/wac.timemap" rel="mem:timemap">https://solidproject.org/TR/wac.timemap</a></dd>
+            </dl>
+            <dl id="document-history">
+              <dt>History</dt>
+              <dd><a href="https://github.com/solid/web-access-control-spec/commits/main/index.html">Commit history</a></dd>
+            </dl>
+            <dl id="document-editors">
+              <dt>Editors</dt>
+              <dd data-editor-id="46140" id="Sarven-Capadisli"><span about="" rel="schema:creator schema:editor"><span about="https://csarven.ca/#i" typeof="schema:Person"><a href="https://csarven.ca/" rel="schema:url"><span about="https://csarven.ca/#i" property="schema:name"><span property="schema:givenName">Sarven</span> <span property="schema:familyName">Capadisli</span></span></a></span></span></dd>
+            </dl>
+            <dl id="document-authors">
+              <dt>Authors</dt>
+              <dd data-editor-id="2017" id="Tim-Berners-Lee"><span about="" rel="schema:author"><span about="https://www.w3.org/People/Berners-Lee/card#i" typeof="schema:Person"><a href="https://www.w3.org/People/Berners-Lee/" rel="schema:url"><span about="https://www.w3.org/People/Berners-Lee/card#i" property="schema:name"><span property="schema:givenName">Tim</span> <span property="schema:familyName">Berners-Lee</span></span></a></span></span></dd>
+              <dd id="Henry-Story"><span about="" rel="schema:author"><span about="https://bblfish.net/profile/card#me" typeof="schema:Person"><a href="https://bblfish.net/" rel="schema:url"><span about="https://bblfish.net/profile/card#me" property="schema:name"><span property="schema:givenName">Henry</span> <span property="schema:familyName">Story</span></span></a></span></span></dd>
+              <dd><a about="" href="https://csarven.ca/" rel="schema:author" resource="https://csarven.ca/#i">Sarven Capadisli</a></dd>
+              <dd data-editor-id="128292" id="Christoph-Braun"><span about="" rel="schema:author"><span about="https://uvdsl.solid.aifb.kit.edu/profile/card#me" typeof="schema:Person"><a href="https://aifb.kit.edu/web/Christoph_Braun/en" rel="schema:url"><span about="https://uvdsl.solid.aifb.kit.edu/profile/card#me" property="schema:name"><span property="schema:givenName">Christoph</span> <span property="schema:familyName">Braun</span></span></a></span></span></dd>
+            </dl>
+            <dl id="document-created">
+              <dt>Created</dt>
+              <dd><time content="2026-04-20T00:00:00Z" datatype="xsd:dateTime" datetime="2026-04-20T00:00:00Z" property="schema:dateCreated">2026-04-20</time></dd>
+            </dl>
+            <dl id="document-published">
+              <dt>Published</dt>
+              <dd><time content="2026-04-20T00:00:00Z" datatype="xsd:dateTime" datetime="2026-04-20T00:00:00Z" property="schema:datePublished">2026-04-20</time></dd>
+            </dl>
+            <dl id="document-modified">
+              <dt>Modified</dt>
+              <dd><time content="2026-04-20T00:00:00Z" datatype="xsd:dateTime" datetime="2026-04-20T00:00:00Z" property="schema:dateModified">2026-04-20</time></dd>
+            </dl>
+            <dl id="document-feedback">
+              <dt>Feedback</dt>
+              <dd><a href="https://github.com/solid/web-access-control-spec" rel="doap:repository">GitHub solid/web-access-control-spec</a> (<a href="https://github.com/solid/web-access-control-spec/pulls">pull requests</a>, <a href="https://github.com/solid/web-access-control-spec/issues/new">new issue</a>, <a href="https://github.com/solid/web-access-control-spec/issues" rel="doap:bug-database">open issues</a>)</dd>
+            </dl>
+            <dl id="document-derived-from">
+              <dt>Derived From</dt>
+              <dd>
+                <ul>
+                  <li><cite><a data-versiondate="2021-06-16T12:49:59Z" data-versionurl="https://web.archive.org/web/20210616124959/https://www.w3.org/wiki/WebAccessControl" href="https://www.w3.org/wiki/WebAccessControl" rel="prov:wasDerivedFrom">WebAccessControl</a></cite></li>
+                  <li><cite><a data-versiondate="2021-06-16T12:53:07Z" data-versionurl="https://web.archive.org/web/20210616125307/https://github.com/solid/web-access-control-spec/blob/65034fd0fa1f270aff32af56cb59fd8949f64591/README.md" href="https://github.com/solid/web-access-control-spec/blob/65034fd0fa1f270aff32af56cb59fd8949f64591/README.md" rel="prov:wasDerivedFrom">solid/web-access-control-spec</a></cite></li>
+                  <li><cite><a data-versiondate="2021-06-16T13:01:41Z" data-versionurl="https://web.archive.org/web/20210616130141/https://solidproject.org/TR/protocol" href="https://solidproject.org/TR/protocol" rel="prov:wasDerivedFrom">Solid Protocol</a></cite></li>
+                </ul>
+              </dd>
+            </dl>
+            <dl id="document-language">
+              <dt>Language</dt>
+              <dd><span content="en" lang="" property="dcterms:language" xml:lang="">English</span></dd>
+            </dl>
+            <dl id="document-type">
+              <dt>Document Type</dt>
+              <dd><a href="http://usefulinc.com/ns/doap#Specification" rel="rdf:type">Specification</a></dd>
+            </dl>
+            <dl id="document-version">
+              <dt>Version</dt>
+              <dd><span lang="" property="schema:version" xml:lang="">1.1.0</span></dd>
+            </dl>
+            <dl id="document-inbox">
+              <dt>Notifications Inbox</dt>
+              <dd><a href="https://specs.solidcommunity.net/inbox/wac/" rel="ldp:inbox">https://specs.solidcommunity.net/inbox/wac/</a></dd>
+            </dl>
+            <dl id="document-in-reply-to">
+              <dt>In Reply To</dt>
+              <dd><a href="https://solidproject.org/about" rel="as:inReplyTo">About Solid</a></dd>
+            </dl>
+            <dl id="document-policy">
+              <dt>Policy</dt>
+              <dd>
+                <dl id="document-policy-offer" rel="odrl:hasPolicy" resource="#document-policy-offer" typeof="odrl:Policy">
+                  <dt>Rule</dt>
+                  <dd><a about="#document-policy-offer" href="https://www.w3.org/TR/odrl-vocab/#term-Offer" typeof="odrl:Offer">Offer</a></dd>
+                  <dt>Unique Identifier</dt>
+                  <dd><a href="https://solid.github.io/web-access-control-spec/#document-policy-offer" rel="odrl:uid">https://solid.github.io/web-access-control-spec/#document-policy-offer</a></dd>
+                  <dt>Target</dt>
+                  <dd><a href="https://solid.github.io/web-access-control-spec/" rel="odrl:target">https://solid.github.io/web-access-control-spec/</a></dd>
+                  <dt>Permission</dt>
+                  <dd>
+                    <dl id="document-permission" rel="odrl:permission" resource="#document-permission" typeof="odrl:Permission">
+                      <dt>Assigner</dt>
+                      <dd><a href="https://www.w3.org/groups/cg/solid/" rel="odrl:assigner">W3C Solid Community Group</a></dd>
+                      <dt>Action</dt>
+                      <dd>
+                        <ul rel="odrl:action">
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-aggregate" resource="odrl:aggregate">Aggregate</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-archive" resource="odrl:archive">Archive</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-concurrentUse" resource="odrl:concurrentUse">Concurrent Use</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-DerivativeWorks" resource="http://creativecommons.org/ns#DerivativeWorks">Derivative Works</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-derive" resource="odrl:derive">Derive</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-digitize" resource="odrl:digitize">Digitize</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-display" resource="odrl:display">Display</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-Distribution" resource="http://creativecommons.org/ns#Distribution">Distribution</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-index" resource="odrl:index">Index</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-inform" resource="odrl:inform">Inform</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-install" resource="odrl:install">Install</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-Notice" resource="http://creativecommons.org/ns#Notice">Notice</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-present" resource="odrl:present">Present</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-print" resource="odrl:print">Print</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-read" resource="odrl:read">Read</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-reproduce" resource="odrl:reproduce">Reproduce</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-Reproduction" resource="http://creativecommons.org/ns#Reproduction">Reproduction</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-stream" resource="odrl:stream">Stream</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-synchronize" resource="odrl:synchronize">Synchronize</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-textToSpeech" resource="odrl:textToSpeech">Text-to-speech</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-transform" resource="odrl:transform">Transform</a></li>
+                          <li><a href="https://www.w3.org/TR/odrl-vocab/#term-translate" resource="odrl:translate">Translate</a></li>
+                        </ul>
+                      </dd>
+                    </dl>
+                  </dd>
+                </dl>
+              </dd>
+            </dl>
+          </details>
+          <p class="copyright" rel="dcterms:rights" resource="#document-rights"><span property="dcterms:description"><a href="https://www.w3.org/policies/#copyright">Copyright</a> © 2021–2026 the Contributors to Web Access Control, Editor’s Draft, under the <a about="" href="https://www.w3.org/community/about/agreements/cla/" rel="schema:license">W3C Community Contributor License Agreement (CLA)</a>. A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. All code snippets are in the public domain, <a about="" href="https://creativecommons.org/public-domain/cc0/" rel="schema:license">CC0</a>.</span></p>
+          <hr title="Separator for header" />
+        </div>
+        <div datatype="rdf:HTML" id="content" property="schema:description">
+          <section id="abstract">
+            <h2>Abstract</h2>
+            <div datatype="rdf:HTML" property="schema:abstract">
+              <p>Web Access Control (<abbr title="Web Access Control">WAC</abbr>) is a decentralized cross-domain access control system providing a way for Linked Data systems to set authorization conditions on HTTP resources using the Access Control List (<abbr title="Access Control List">ACL</abbr>) model.</p>
+            </div>
+          </section>
+          <section id="sotd" inlist="" rel="schema:hasPart" resource="#sotd">
+            <h2 property="schema:name">Status of This Document</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This report was not published by the <a href="https://www.w3.org/groups/cg/solid/">Solid Community Group</a>. It is not a W3C Standard nor is it on the W3C Standards Track.</p>
+              <p>Publication as an Editor’s Draft does not imply endorsement by anyone. This document and may be updated, replaced or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress. You are invited to contribute any feedback, comments, or questions you might have.</p>
+            </div>
+          </section>
+          <nav id="toc">
+            <h2>Table of Contents</h2>
+            <div>
+              <ol class="toc">
+                <li class="tocline"><a class="tocxref" href="#abstract"><bdi class="secno"></bdi> <span>Abstract</span></a></li>
+                <li class="tocline"><a class="tocxref" href="#sotd"><bdi class="secno"></bdi> <span>Status of This Document</span></a></li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#introduction"><bdi class="secno">1.</bdi> <span>Introduction</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#terminology"><bdi class="secno">1.1</bdi> <span>Terminology</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#namespaces"><bdi class="secno">1.2</bdi> <span>Namespaces</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.3</bdi> <span>Conformance</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline"><a class="tocxref" href="#http-interactions"><bdi class="secno">2.</bdi> <span>HTTP Interactions</span></a></li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#acl-resources"><bdi class="secno">3.</bdi> <span>ACL Resources</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#acl-resource-discovery"><bdi class="secno">3.1</bdi> <span>ACL Resource Discovery</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#acl-resource-condition-discovery"><bdi class="secno">3.2</bdi> <span>ACL Resource Condition Discovery</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#acl-resource-representation"><bdi class="secno">3.3</bdi> <span>ACL Resource Representation</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#authorization-rule"><bdi class="secno">4.</bdi> <span>Authorization Rule</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#access-objects"><bdi class="secno">4.1</bdi> <span>Access Objects</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#access-modes"><bdi class="secno">4.2</bdi> <span>Access Modes</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#access-subjects"><bdi class="secno">4.3</bdi> <span>Access Subjects</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#access-conditions"><bdi class="secno">4.4</bdi> <span>Access Conditions</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#authorization-process"><bdi class="secno">5.</bdi> <span>Authorization Process</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#effective-acl-resource"><bdi class="secno">5.1</bdi> <span>Effective ACL Resource</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#authorization-conformance"><bdi class="secno">5.2</bdi> <span>Authorization Conformance</span></a></li>
+                    <li class="tocline">
+                      <p><a class="tocxref" href="#authorization-evaluation"><bdi class="secno">5.3</bdi> <span>Authorization Evaluation</span></a></p>
+                      <ol>
+                        <li class="tocline"><a class="tocxref" href="#reading-writing-resources"><bdi class="secno">5.3.1</bdi> <span>Reading and Writing Resources</span></a></li>
+                        <li class="tocline"><a class="tocxref" href="#condition-evaluation"><bdi class="secno">5.3.2</bdi> <span>Condition Evaluation</span></a></li>
+                        <li class="tocline"><a class="tocxref" href="#web-origin-authorization"><bdi class="secno">5.3.3</bdi> <span>Web Origin Authorization</span></a></li>
+                        <li class="tocline"><a class="tocxref" href="#authorization-matching"><bdi class="secno">5.3.4</bdi> <span>Authorization Matching</span></a></li>
+                        <li class="tocline"><a class="tocxref" href="#access-privileges"><bdi class="secno">5.3.5</bdi> <span>Access Privileges</span></a></li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#http-definitions"><bdi class="secno">6.</bdi> <span>HTTP Definitions</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#wac-allow"><bdi class="secno">6.1</bdi> <span>wac-allow HTTP Header</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#acl-link-relation"><bdi class="secno">6.2</bdi> <span>acl Link Relation</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#extensions"><bdi class="secno">7.</bdi> <span>Extensions</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#authorization-extensions"><bdi class="secno">7.1</bdi> <span>Authorization Extensions</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#access-mode-extensions"><bdi class="secno">7.2</bdi> <span>Access Mode Extensions</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#access-condition-extensions"><bdi class="secno">7.3</bdi> <span>Access Condition Extensions</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#permission-inheritance-extensions"><bdi class="secno">7.4</bdi> <span>Permission Inheritance Extensions</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#distinct-effective-acl-resource-extensions"><bdi class="secno">7.5</bdi> <span>Distinct Effective ACL Resource Extensions</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#considerations"><bdi class="secno">8.</bdi> <span>Considerations</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#security-considerations"><bdi class="secno">8.1</bdi> <span>Security Considerations</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#privacy-considerations"><bdi class="secno">8.2</bdi> <span>Privacy Considerations</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#accessibility-considerations"><bdi class="secno">8.3</bdi> <span>Accessibility Considerations</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#internationalization-considerations"><bdi class="secno">8.4</bdi> <span>Internationalization Considerations</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#security-privacy-review"><bdi class="secno">8.5</bdi> <span>Security and Privacy Review</span></a></li>
+                  </ol>
+                </li>
+                <li class="tocline"><a class="tocxref" href="#changelog"><bdi class="secno">A.</bdi> <span>Change Log</span></a></li>
+                <li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B.</bdi> <span>Acknowledgements</span></a></li>
+                <li class="tocline">
+                  <p><a class="tocxref" href="#references"><bdi class="secno">C.</bdi> <span>References</span></a></p>
+                  <ol>
+                    <li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1</bdi> <span>Normative References</span></a></li>
+                    <li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.2</bdi> <span>Informative References</span></a></li>
+                  </ol>
+                </li>
+              </ol>
+            </div>
+          </nav>
+          <section id="introduction" inlist="" rel="schema:hasPart" resource="#introduction">
+            <h2 about="#introduction" property="schema:name" typeof="deo:Introduction">Introduction</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p><em>This section is non-normative.</em></p>
+              <p id="motivation" rel="schema:hasPart" resource="#motivation" typeof="deo:Motivation"><span datatype="rdf:HTML" property="schema:description">Unauthorized access or modification of Web resources could lead to unintended loss, damage or disclosure of data. To support read-write operations within the framework of HTTP and meet the social requirements of decentralised applications, mechanisms for expressing and applying authorization rules.</span></p>
+              <p><dfn id="wac">Web Access Control</dfn> (<abbr title="Web Access Control">WAC</abbr>) is a decentralized cross-domain access control system providing a way for Linked Data systems to set authorization rules on HTTP resources using the <dfn id="acl">Access Control List</dfn> (<abbr title="Access Control List">ACL</abbr>) model.</p>
+              <p id="wac-overview" rel="schema:hasPart" resource="#wac-overview"><span datatype="rdf:HTML" property="schema:description">The WAC specification describes how to enable applications to discover <a href="#authorization">Authorizations</a> associated with a given <a href="#resource">resource</a>, and to control such rules, as directed by an agent. Server manages the association between a resource and an <a href="#acl-resource">ACL resource</a>, and applies the authorization rules on requested operations. Authorizations are described using the <cite><a href="http://www.w3.org/ns/auth/acl" rel="cito:citesAsAuthority">ACL ontology</a></cite> to express and determine access privileges of a requested resource. Any kind of access can be given to a resource as per the ACL ontology. This specification uses the <a href="#access-mode">access modes</a> currently defined by the ACL ontology, such as the class of operations to read, write, append and control resources. An Authorization can allow public access to resources or place the requirement for authenticated <a href="#agent">agents</a>. Resources and agents can be on different origins.</span></p>
+              <div class="note" id="specification-orthogonality" inlist="" rel="schema:hasPart" resource="#specification-orthogonality">
+                <h4 property="schema:name"><span>Note</span>: Specification Orthogonality</h4>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>This specification does not specify mechanisms for authentication or methods to verify assertions. It is assumed that systems using WAC have the ability to apply authentication and verification techniques when desired.</p>
+                </div>
+              </div>
+              <p>The access control system can be enhanced by adding more inference or expressivity to express social constraints. See the <cite><a href="#extensions" rel="rdfs:seeAlso">Extensions</a></cite> section.</p>
+              <p>This specification is for:</p>
+              <ul about="" rel="schema:audience">
+                <li><a href="http://data.europa.eu/esco/occupation/a7c1d23d-aeca-4bee-9a08-5993ed98b135">Resource server developers</a> and <a href="http://data.europa.eu/esco/occupation/a44a1dc5-be08-4840-8bd5-770c4ac1ca6d">security technicians</a> who want to enable agents to obtain and control access to resources;</li>
+                <li><a href="http://data.europa.eu/esco/occupation/c40a2919-48a9-40ea-b506-1f34f693496d">Application developers</a> who want to implement a client to obtain and control access to resources.</li>
+              </ul>
+              <section id="terminology" inlist="" rel="schema:hasPart" resource="#terminology" typeof="skos:ConceptScheme">
+                <h3 property="schema:name skos:prefLabel">Terminology</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                  <p property="skos:definition">The WAC specification defines the following terms. These terms are referenced throughout this specification.</p>
+                  <dl rel="skos:hasTopConcept">
+                    <dt about="#uri" property="skos:prefLabel" typeof="skos:Concept"><dfn id="uri">URI</dfn></dt>
+                    <dd about="#uri" property="skos:definition">A <dfn>Uniform Resource Identifier</dfn> (<abbr title="Uniform Resource Identifier">URI</abbr>) provides the means for identifying resources [<cite><a class="bibref" href="#bib-rfc3986">RFC3986</a></cite>].</dd>
+                    <dt about="#resource" property="skos:prefLabel" typeof="skos:Concept"><dfn id="resource">resource</dfn></dt>
+                    <dd about="#resource" property="skos:definition">A resource is the target of an HTTP request identified by a URI [<cite><a class="bibref" href="#bib-rfc9110">RFC9110</a></cite>].</dd>
+                    <dt about="#container-resource" property="skos:prefLabel" typeof="skos:Concept"><dfn id="container-resource">container resource</dfn></dt>
+                    <dd about="#container-resource" property="skos:definition">A container resource is a hierarchical collection of resources that contains other resources, including containers.</dd>
+                    <dt about="#root-container" property="skos:prefLabel" typeof="skos:Concept"><dfn id="root-container">root container</dfn></dt>
+                    <dd about="#root-container" property="skos:definition">A root container is a container resource that is at the highest level of the collection hierarchy.</dd>
+                    <dt about="#acl-resource" property="skos:prefLabel" typeof="skos:Concept"><dfn id="acl-resource">ACL resource</dfn></dt>
+                    <dd about="#acl-resource" property="skos:definition">An ACL resource is represented by an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that includes <a href="#authorization">Authorizations</a> determining access to resources.</dd>
+                    <dt about="#authorization" property="skos:prefLabel" typeof="skos:Concept"><dfn id="authorization">Authorization</dfn></dt>
+                    <dd about="#authorization" property="skos:definition">An Authorization is an abstract thing which is identified by a URI and whose properties are defined in an <a href="#acl-resource">ACL resource</a>, e.g., <a href="#access-mode">access modes</a> granted to <a href="#agent">agents</a> the ability to perform operations on <a href="#resource">resources</a>.</dd>
+                    <dt about="#access-mode" property="skos:prefLabel" typeof="skos:Concept"><dfn id="access-mode">access mode</dfn></dt>
+                    <dd about="#access-mode" property="skos:definition">An access mode is a class of operations that can be performed on one or more resources.</dd>
+                    <dt about="#agent" property="skos:prefLabel" typeof="skos:Concept"><dfn id="agent">agent</dfn></dt>
+                    <dd about="#agent" property="skos:definition">An agent is a person, social entity or software identified by a URI, e.g., a WebID denotes an agent [<cite><a class="bibref" href="#bib-webid">WEBID</a></cite>].</dd>
+                    <dt about="#agent-group" property="skos:prefLabel" typeof="skos:Concept"><dfn id="agent-group">agent group</dfn></dt>
+                    <dd about="#agent-group" property="skos:definition">An agent group is a group of persons or entities identified by a URI.</dd>
+                    <dt about="#agent-class" property="skos:prefLabel" typeof="skos:Concept"><dfn id="agent-class">agent class</dfn></dt>
+                    <dd about="#agent-class" property="skos:definition">An agent class is a class of persons or entities identified by a URI.</dd>
+                    <dt about="#issuer" property="skos:prefLabel" typeof="skos:Concept"><dfn id="issuer">issuer</dfn></dt>
+                    <dd about="#issuer" property="skos:definition">An issuer is an <a href="#agent">agent</a> that asserts characteristics of an <a href="#agent">agent</a>, such as identity, role, attribute, capability, or similar.</dd>
+                    <dt about="#client" property="skos:prefLabel" typeof="skos:Concept"><dfn id="client">client</dfn></dt>
+                    <dd about="#client" property="skos:definition">A client is a software <a href="#agent">agent</a> (application) which requests <a href="#resource">resources</a> on behalf of an <a href="#agent">agent</a> (possibly itself).</dd>
+                    <dt about="#origin" property="skos:prefLabel" typeof="skos:Concept"><dfn id="origin">origin</dfn></dt>
+                    <dd about="#origin" property="skos:definition">An origin indicates where an HTTP request originates from [<cite><a class="bibref" href="#bib-rfc6454">RFC6454</a></cite>].</dd>
+                    <dt about="#condition" property="skos:prefLabel" typeof="skos:Concept"><dfn id="condition">condition</dfn></dt>
+                    <dd about="#condition" property="skos:definition">A condition is an additional requirement on an <a href="#authorization">Authorization</a> that is evaluated as part of <a href="#authorization-evaluation">Authorization Evaluation</a>.</dd>
+                  </dl>
+                  <p>In addition to the terminology above, this specification also uses terminology from the [<cite><a class="bibref" href="#bib-infra">INFRA</a></cite>] specification. When INFRA terminology is used, such as <a href="https://infra.spec.whatwg.org/#strings">string</a> and <a href="https://infra.spec.whatwg.org/#booleans">boolean</a>, it is linked directly to that specification.</p>
+                </div>
+              </section>
+              <section id="namespaces" inlist="" rel="schema:hasPart" resource="#namespaces">
+                <h3 property="schema:name">Namespaces</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <table>
+                    <caption>Prefixes and Namespaces</caption>
+                    <thead>
+                      <tr>
+                        <th>Prefix</th>
+                        <th>Namespace</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td><code>rdf</code></td>
+                        <td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td>
+                        <td>[<cite><a class="bibref" href="#bib-rdf-schema">RDF-SCHEMA</a></cite>]</td>
+                      </tr>
+                      <tr>
+                        <td><code>acl</code></td>
+                        <td>http://www.w3.org/ns/auth/acl#</td>
+                        <td>ACL ontology</td>
+                      </tr>
+                      <tr>
+                        <td><code>foaf</code></td>
+                        <td>http://xmlns.com/foaf/0.1/</td>
+                        <td>[<cite><a class="bibref" href="#bib-foaf">FOAF</a></cite>]</td>
+                      </tr>
+                      <tr>
+                        <td><code>vcard</code></td>
+                        <td>http://www.w3.org/2006/vcard/ns#</td>
+                        <td>[<cite><a class="bibref" href="#bib-vcard-rdf">VCARD-RDF</a></cite>]</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+              <section id="conformance" inlist="" rel="schema:hasPart" resource="#conformance">
+                <h3 property="schema:name">Conformance</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>All assertions, diagrams, examples, and notes are non-normative, as are all sections explicitly marked non-normative. Everything else is normative.</p>
+                  <p>The key words “MUST” and “MUST NOT” are to be interpreted as described in <cite><a href="https://tools.ietf.org/html/bcp14" rel="rdfs:seeAlso">BCP 14</a></cite> [<cite><a class="bibref" href="#bib-rfc2119">RFC2119</a></cite>] [<cite><a class="bibref" href="#bib-rfc8174">RFC8174</a></cite>] when, and only when, they appear in all capitals, as shown here.</p>
+                </div>
+              </section>
+            </div>
+          </section>
+          <section id="http-interactions" inlist="" rel="schema:hasPart" resource="#http-interactions">
+            <h2 property="schema:name">HTTP Interactions</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p><em>This section is non-normative.</em></p>
+              <p>Clients who want to perform read-write operations on <a href="#acl-resource">ACL resources</a> with respect to <a href="#authorization">Authorizations</a> which are stored on a server can do so within the framework of HTTP. This specification does not describe the HTTP interaction to read-write resources. It is assumed that servers have a mapping to handle HTTP requests and the required Authorizations to grant operations on resources. Implementations are strongly encouraged to use existing approaches that provide an extension of the rules of <cite><a class="bibref" href="https://www.w3.org/DesignIssues/LinkedData" rel="cito:citesAsAuthority">Linked Data</a></cite>, e.g., [<cite><a class="bibref" href="#bib-solid-protocol">SOLID-PROTOCOL</a></cite>], [<cite><a class="bibref" href="#bib-ldp">LDP</a></cite>], [<cite><a class="bibref" href="#bib-activitypub">ACTIVITYPUB</a></cite>].</p>
+            </div>
+          </section>
+          <section id="acl-resources" inlist="" rel="schema:hasPart" resource="#acl-resources">
+            <h2 property="schema:name">ACL Resources</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This section describes ACL resource <a href="#acl-resource-discovery" rel="cito:discusses">discovery</a>, <a href="#acl-resource-condition-discovery" rel="cito:discusses">condition discovery</a>, and <a href="#acl-resource-representation" rel="cito:discusses">representation</a>.</p>
+              <section id="acl-resource-discovery" inlist="" rel="schema:hasPart" resource="#acl-resource-discovery">
+                <h3 property="schema:name">ACL Resource Discovery</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p about="" id="server-link-acl" rel="spec:requirement" resource="#server-link-acl"><span property="spec:statement">When a server wants to enable applications to discover <a href="#authorization">Authorizations</a> associated with a given <a href="#resource">resource</a>, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> advertise the <a href="#acl-resource">ACL resource</a> that is associated with a resource by responding to an HTTP request including a <code>Link</code> header with the <code>rel</code> value of <code>acl</code> (<cite><a href="#acl-link-relation" rel="rdfs:seeAlso">acl Link Relation</a></cite>) and the ACL resource as link target [<cite><a class="bibref" href="#bib-rfc8288">RFC8288</a></cite>].</span></p>
+                  <p>ACL Resource Discovery is used towards determining the <cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite> of a resource.</p>
+                  <p about="" id="server-resource-acl-max" rel="spec:requirement" resource="#server-resource-acl-max"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUSTNOT">MUST NOT</span> directly associate more than one ACL resource to a resource.</span></p>
+                  <p about="" id="client-link-acl" rel="spec:requirement" resource="#client-link-acl"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Client">Clients</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> discover the ACL resource associated with a resource by making an HTTP request on the target URL, and checking the HTTP <code>Link</code> header with the <code>rel</code> parameter.</span></p>
+                  <div class="note" id="acl-resource-uri-security" inlist="" rel="schema:hasPart" resource="#uri-security">
+                    <h4 property="schema:name"><span>Note</span>: ACL Resource URI Security</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>The URI of an ACL resource does not in itself pose a security threat ([<cite><a class="bibref" href="#bib-rfc3986">RFC3986</a></cite>] security considerations). This specification does not constrain the discoverability of ACL resources.</p>
+                    </div>
+                  </div>
+                  <div class="note" id="uri-origin" inlist="" rel="schema:hasPart" resource="#uri-origin">
+                    <h4 property="schema:name"><span>Note</span>: URI Origin</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>The resource and the associated ACL resource can be on different origins [<cite><a class="bibref" href="#bib-rfc6454">RFC6454</a></cite>].</p>
+                    </div>
+                  </div>
+                  <p about="" id="client-acl-uri" rel="spec:requirement" resource="#client-acl-uri"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Client">Clients</span> <span rel="spec:requirementLevel" resource="spec:MUSTNOT">MUST NOT</span> derive the URI of the ACL resource through string operations on the URI of the resource.</span></p>
+                  <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/8" rel="cito:citesAsSourceDocument">issues/8</a>, <a href="https://github.com/solid/web-access-control-spec/issues/62" rel="cito:citesAsSourceDocument">issues/62</a>, <a href="https://github.com/solid/specification/issues/131" rel="cito:citesAsSourceDocument">issues/131</a>, <a href="https://github.com/solid/specification/issues/176" rel="cito:citesAsSourceDocument">issues/176</a></p>
+                </div>
+              </section>
+              <section id="acl-resource-condition-discovery" inlist="" rel="schema:hasPart" resource="#acl-resource-condition-discovery">
+                <h3 property="schema:name">ACL Resource Condition Discovery</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p about="" id="server-link-condition" rel="spec:requirement" resource="#server-link-condition"><span property="spec:statement">When a server wants to enable applications to discover supported condition types (<cite><a href="#access-conditions" rel="rdfs:seeAlso">Access Conditions</a></cite>) for a given <a href="#effective-acl-resource">effective ACL resource</a>, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> advertise each supported condition type by responding to an HTTP request on the effective ACL resource including a <code>Link</code> header with the <code>rel</code> value of <code>http://www.w3.org/ns/auth/acl#condition</code> and the condition type as link target [<cite><a class="bibref" href="#bib-rfc8288">RFC8288</a></cite>].</span></p>
+                  <p about="" id="client-link-condition" rel="spec:requirement" resource="#client-link-condition"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Client">Clients</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> make an HTTP request on the <a href="#effective-acl-resource">effective ACL resource</a> and check the HTTP <code>Link</code> header with the <code>rel</code> parameter value of <code>http://www.w3.org/ns/auth/acl#condition</code> to discover supported condition types (<cite><a href="#access-conditions" rel="rdfs:seeAlso">Access Conditions</a></cite>).</span></p>
+                  <div class="note" id="condition-discovery-via-effective-acl-resource" inlist="" rel="schema:hasPart" resource="#condition-discovery-via-effective-acl-resource">
+                    <h3 property="schema:name"><span>Note</span>: Discovering Condition Types via Effective ACL Resource</h3>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>Clients do not need an additional HTTP request to <a href="#client-link-condition">discover supported condition types</a>, since they can be obtained as part of determining the <a href="#effective-acl-resource">effective ACL resource</a>.</p>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section id="acl-resource-representation" inlist="" rel="schema:hasPart" resource="#acl-resource-representation">
+                <h3 property="schema:name">ACL Resource Representation</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>An ACL resource is an <em>RDF document</em> [<cite><a class="bibref" href="#bib-rdf11-concepts">RDF11-CONCEPTS</a></cite>] that can hold any information, typically comprises an unordered set of <a href="#authorization">Authorizations</a>, any of which could permit an attempted access.</p>
+                  <p about="" id="server-get-acl-turtle" rel="spec:requirement" resource="#server-get-acl-turtle"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> accept an HTTP <code>GET</code> and <code>HEAD</code> request targeting an ACL resource when the value of the <code>Accept</code> header requests a representation in <code>text/turtle</code> [<cite><a class="bibref" href="#bib-turtle">TURTLE</a></cite>].</span></p>
+                  <p about="" id="server-acl-without-representation" rel="spec:requirement" resource="#server-acl-without-representation"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> who want a resource to inherit Authorizations (<cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite>) from a container resource  <span rel="spec:requirementLevel" resource="spec:MUSTNOT">MUST NOT</span> have a representation for the ACL resource that is associated with the resource.</span></p>
+                  <p about="" id="server-get-acl-without-representation" rel="spec:requirement" resource="#server-get-acl-without-representation"><span property="spec:statement">When an authorized HTTP <code>GET</code> or <code>HEAD</code> request targets an ACL resource without an existing representation, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> respond with the <code>404</code> status code as per [<cite><a class="bibref" href="#bib-rfc9110">RFC9110</a></cite>].</span></p>
+                  <p about="" id="server-root-container-acl" rel="spec:requirement" resource="#server-root-container-acl"><span property="spec:statement">When an authorized HTTP <code>GET</code> or <code>HEAD</code> request targets <a href="#root-container">root container</a>’s ACL resource, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> respond with a representation.</span></p>
+                  <p about="" id="server-root-container-acl-authorization-control" rel="spec:requirement" resource="#server-root-container-acl-authorization-control"><span property="spec:statement">The ACL resource of the root container <span rel="spec:requirementSubject" resource="spec:Server"></span><span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> include an Authorization allowing the <code>acl:Control</code> access privilege (<cite><a href="#acl-mode-control" rel="rdfs:seeAlso"><code>acl:Control</code></a></cite> access mode).</span></p>
+                  <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/45" rel="cito:citesAsSourceDocument">issues/45</a></p>
+                </div>
+              </section>
+            </div>
+          </section>
+          <section id="authorization-rule" inlist="" rel="schema:hasPart" resource="#authorization-rule">
+            <h2 property="schema:name">Authorization Rule</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p><a href="#authorization">Authorization</a> (instance of <code>acl:Authorization</code>) is the most fundamental unit of access control describing access permissions granting to agents the ability to perform operations on resources. Authorizations are described with RDF statements and can express any information. This section describes the following characteristics of an Authorization: <a href="#access-objects" rel="cito:discusses">access objects</a> to specify what can be accessed, <a href="#access-modes" rel="cito:discusses">access modes</a> to specify permissions, <a href="#access-subjects" rel="cito:discusses">access subjects</a> to specify who can access the objects, and <a href="#access-conditions">access conditions</a> to specify additional requirements. See the <cite><a href="#authorization-conformance" rel="rdfs:seeAlso">Authorization Conformance</a></cite> section for applicable Authorizations towards <cite><a href="#authorization-evaluation" rel="rdfs:seeAlso">Authorization Evaluation</a></cite>.</p>
+              <section id="access-objects" inlist="" rel="schema:hasPart" resource="#access-objects">
+                <h3 property="schema:name">Access Objects</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p id="acl-accessto">The <code>acl:accessTo</code> predicate denotes the resource to which access is being granted.</p>
+                  <p id="acl-default">The <code>acl:default</code> predicate denotes the container resource whose Authorization can be applied to a resource lower in the collection hierarchy.</p>
+                  <p>Inheriting Authorizations from the most significant container’s ACL resource is useful to avoid individually managing an ACL resource for each resource, as well as to define access control for resources that do not exist yet.</p>
+                  <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/59" rel="cito:citesAsSourceDocument">issues/59</a></p>
+                </div>
+              </section>
+              <section id="access-modes" inlist="" rel="schema:hasPart" resource="#access-modes">
+                <h3 property="schema:name">Access Modes</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The <a href="#access-mode">access modes</a> described in this section are defined in the <cite><a href="http://www.w3.org/ns/auth/acl" rel="cito:citesAsAuthority">ACL ontology</a></cite>, such as the class of operations to read, write, append and control resources. The requirements for new access modes is explained in the <cite><a href="#access-mode-extensions" rel="rdfs:seeAlso">Access Mode Extensions</a></cite> section.</p>
+                  <p id="acl-mode">The <code>acl:mode</code> predicate denotes a class of operations that the agents can perform on a resource.</p>
+                  <dl id="acl-access-modes">
+                    <dt id="acl-mode-read"><code>acl:Read</code></dt>
+                    <dd>Allows access to a class of read operations on a resource, e.g., to view the contents of a resource on HTTP <code>GET</code> requests.</dd>
+                    <dt id="acl-mode-write"><code>acl:Write</code></dt>
+                    <dd>Allows access to a class of write operations on a resource, e.g., to create, delete or modify resources on HTTP <code>PUT</code>, <code>POST</code>, <code>PATCH</code>, <code>DELETE</code> requests.</dd>
+                    <dt id="acl-mode-append"><code>acl:Append</code></dt>
+                    <dd>Allows access to a class of append operations on a resource, e.g., to add information, but not remove, information on HTTP <code>POST</code>, <code>PATCH</code> requests.</dd>
+                    <dt id="acl-mode-control"><code>acl:Control</code></dt>
+                    <dd>Allows access to a class of read and write operations on an ACL resource associated with a resource.</dd>
+                  </dl>
+                  <div class="note" id="access-mode-classes" inlist="" rel="schema:hasPart" resource="#access-mode-classes">
+                    <h3 property="schema:name"><span>Note</span>: Access Mode Classes</h3>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p><code>acl:Access</code> is a superclass where specific access modes (entailing a class of operations) can be subclassed. It is not intended to be used for setting or matching access privileges.</p>
+                      <p><code>acl:Append</code> is a subclass of <code>acl:Write</code>.</p>
+                    </div>
+                  </div>
+                  <div class="note" id="uri-ownership" inlist="" rel="schema:hasPart" resource="#uri-ownership">
+                    <h3 property="schema:name"><span>Note</span>: URI Ownership</h3>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p><q>URI ownership</q>, as per <cite><a href="https://www.w3.org/TR/webarch/#uri-ownership" rel="cito:citesAsAuthority">Architecture of the World Wide Web</a></cite> [<cite><a class="bibref" href="#bib-webarch">WEBARCH</a></cite>], is outside the scope of this specification, and thus cannot be changed by modifying Authorizations.</p>
+                    </div>
+                  </div>
+                  <div class="note" id="loss-of-control-mitigation" inlist="" rel="schema:hasPart" resource="#loss-of-control-mitigation">
+                    <h3 property="schema:name"><span>Note</span>: Loss of Control Mitigation</h3>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>It is assumed that systems using WAC have mechanisms to mitigate loss of control of the resources, such as by ensuring valid ACL resources and Authorizations, by providing administrative functions on the storage, or by implicitly granting control over all resources in a storage to owners.</p>
+                      <p class="advisement">Source: <a href="https://github.com/solid/specification/issues/67" rel="cito:citesAsSourceDocument">issues/67</a>, <a href="https://github.com/solid/specification/issues/153" rel="cito:citesAsSourceDocument">issues/153</a>, <a href="https://github.com/solid/specification/pull/264" rel="cito:citesAsSourceDocument">pull/264</a></p>
+                    </div>
+                  </div>
+                  <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/33" rel="cito:citesAsSourceDocument">issues/33</a></p>
+                </div>
+              </section>
+              <section id="access-subjects" inlist="" rel="schema:hasPart" resource="#access-subjects">
+                <h3 property="schema:name">Access Subjects</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The ability of a <em>subject</em> to access a resource can be granted to identifiable agents, a class of agents, a group of agents, or an origin.</p>
+                  <p id="acl-agent">The <code>acl:agent</code> predicate denotes an <a href="#agent">agent</a> being given the access permission.</p>
+                  <p id="acl-agentgroup">The <code>acl:agentGroup</code> predicate denotes a <a href="#agent-group">group of agents</a> being given the access permission. The object of an <code>acl:agentGroup</code> statement is an instance of <code>vcard:Group</code>, where the members of the group are specified with the <code>vcard:hasMember</code> predicate.</p>
+                  <p id="acl-agentclass">The <code>acl:agentClass</code> predicate denotes a <a href="#agent-class">class of agents</a> being given the access permission.</p>
+                  <p>Two agent classes are defined here:</p>
+                  <dl>
+                    <dt id="acl-agentclass-foaf-agent"><code>foaf:Agent</code></dt>
+                    <dd>Allows access to any agent, i.e., the public.</dd>
+                    <dt id="acl-agentclass-authenticated-agent"><code>acl:AuthenticatedAgent</code></dt>
+                    <dd>Allows access to any authenticated agent.</dd>
+                  </dl>
+                  <p id="acl-origin">The <code>acl:origin</code> predicate denotes the <a href="#origin">origin</a> of an HTTP request that is being given the access permission.</p>
+                  <div class="note" id="subject-verification" inlist="" rel="schema:hasPart" resource="#subject-verification">
+                    <h3 property="schema:name"><span>Note</span>: Subject Verification</h3>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>Servers might accept different authentication protocols as well as credential verification methods.</p>
+                    </div>
+                  </div>
+                  <div class="note" id="origin-considerations" inlist="" rel="schema:hasPart" resource="#origin-considerations">
+                    <h3 property="schema:name"><span>Note</span>: Origin Considerations</h3>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>Typical web browsers use origin-based security to isolate content and prevent malicious interactions. While not designed to identify clients, it can complement security mechanisms such as mTLS-based authentication.</p>
+                    </div>
+                  </div>
+                  <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/34" rel="cito:citesAsSourceDocument">issues/34</a>, <a href="https://github.com/solid/specification/issues/32" rel="cito:citesAsSourceDocument">issues/32</a>, <a href="https://github.com/solid/specification/issues/59">issues/59</a></p>
+                </div>
+              </section>
+              <section id="access-conditions" inlist="" rel="schema:hasPart" resource="#access-conditions">
+                <h3 property="schema:name">Access Conditions</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p id="acl-condition">The <code>acl:condition</code> predicate specifies a condition on an <a href="#authorization">Authorization</a> beyond <a href="#access-objects">access objects</a>, <a href="#access-modes">access modes</a>, and <a href="#access-subjects">access subjects</a>. The value of <code>acl:condition</code> entails <code>acl:Condition</code>. Supported condition types are discovered via <a href="#acl-resource-condition-discovery" rel="rdfs:seeAlso">ACL Resource Condition Discovery</a>. The requirements for new access conditions is explained in the <cite><a href="#access-condition-extensions" rel="rdfs:seeAlso">Access Condition Extensions</a></cite> section.</p>
+                  <section id="access-client-condition" inlist="" rel="schema:hasPart" resource="#access-client-condition">
+                    <h4 property="schema:name">Client Condition</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>A <em>subject</em> <a href="#agent">agent</a> may interact with <a href="#resource">resources</a> using a <a href="#client">client</a>. An <code>acl:ClientCondition</code> defines which clients are permitted to act on behalf of the subject agent. The following properties are defined:</p>
+                      <p id="acl-client">The <code>acl:client</code> predicate denotes a <a href="#client">client</a> being allowed access when acting on behalf of the subject <a href="#agent">agent</a>.</p>
+                      <p id="acl-clientgroup">The <code>acl:clientGroup</code> predicate denotes a <a href="#agent-group">group of agents</a> being allowed access when acting on behalf of the subject <a href="#agent">agent</a>. The object of an <code>acl:clientGroup</code> statement is an instance of <code>vcard:Group</code>, where the members of the group are specified with the <code>vcard:hasMember</code> predicate.</p>
+                      <p id="acl-clientclass">The <code>acl:clientClass</code> predicate denotes a <a href="#agent-class">class of agents</a> being allowed access when acting on behalf of the subject <a href="#agent">agent</a>.</p>
+                      <p>One client class is defined here:</p>
+                      <dl>
+                        <dt id="acl-clientclass-foaf-agent"><code>foaf:Agent</code></dt>
+                        <dd>Allows any client, i.e., the public, on behalf of the subject agent.</dd>
+                      </dl>
+                    </div>
+                  </section>
+                  <section id="access-issuer-condition" inlist="" rel="schema:hasPart" resource="#access-issuer-condition">
+                    <h4 property="schema:name">Issuer Condition</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>The ability to authenticate a <em>subject</em> might rely on the ability to identify the <a href="#issuer">issuer</a> of a corresponding assertion of identity, role, attribute or similar. An <code>acl:IssuerCondition</code> defines which issuers are trusted to make assertions about the subject <a href="#agent">agent</a>. The following properties are defined:</p>
+                      <p id="acl-issuer">The <code>acl:issuer</code> predicate denotes an <a href="#issuer">issuer</a> being trusted to make correct assertions about a subject <a href="#agent">agent</a>.</p>
+                      <p id="acl-issuergroup">The <code>acl:issuerGroup</code> predicate denotes a <a href="#agent-group">group of agents</a> being trusted to make correct assertions about a subject <a href="#agent">agent</a>. The object of an <code>acl:issuerGroup</code> statement is an instance of <code>vcard:Group</code>, where the members of the group are specified with the <code>vcard:hasMember</code> predicate.</p>
+                      <p id="acl-issuerclass">The <code>acl:issuerClass</code> predicate denotes a <a href="#agent-class">class of agents</a> being trusted to make correct assertions about a subject <a href="#agent">agent</a>.</p>
+                      <p>One issuer class is defined here:</p>
+                      <dl>
+                        <dt id="acl-issuerclass-foaf-agent"><code>foaf:Agent</code></dt>
+                        <dd>Accepts assertions made by any agent, i.e., the public.</dd>
+                      </dl>
+                    </div>
+                  </section>
+                </div>
+                <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/81" rel="cito:citesAsSourceDocument">issues/81</a>, <a href="https://github.com/solid/web-access-control-spec/pull/133" rel="cito:citesAsSourceDocument">pull/133</a></p>
+              </section>
+            </div>
+          </section>
+          <section id="authorization-process" inlist="" rel="schema:hasPart" resource="#authorization-process">
+            <h2 property="schema:name">Authorization Process</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This section describes how implementations can determine the <a href="#effective-acl-resource" rel="cito:discusses">effective ACL resource</a> of a resource and hence which set of <a href="#authorization-conformance" rel="cito:discusses">conforming authorizations</a> to use.</p>
+              <p>Servers process access requests by <a href="#authorization-evaluation" rel="cito:discusses">evaluating the Authorizations</a> associated with referenced resources in order to determine whether the necessary access permissions are granted for a particular request.</p>
+              <section id="effective-acl-resource" inlist="" rel="schema:hasPart" resource="#effective-acl-resource">
+                <h3 property="schema:name">Effective ACL Resource</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>Servers enforce the effective ACL resource of a resource, whereas clients determine the effective ACL resource of a resource to perform control operations.</p>
+                  <p id="effective-acl-resource-with-representation">When an ACL resource associated with a resource has a representation (<cite><a href="#acl-resource-representation" rel="rdfs:seeAlso">ACL Resource Representation</a></cite>), it is the <em>effective ACL resource</em> of the requested resource.</p>
+                  <p id="effective-acl-resource-without-representation">When an ACL resource associated with a resource does not have a representation (<cite><a href="#acl-resource-representation" rel="rdfs:seeAlso">ACL Resource Representation</a></cite>), no Authorizations can be immediately checked against the requested resource. In this case, a container resource’s ACL resource might apply on every access to a member resource, in specifying Authorizations for the requested resource.</p>
+                  <p id="effective-acl-resource-container-hierarchy">WAC has the property of being recursive with respect to container hierarchy, meaning that a member resource inherits Authorizations from the closest container resource (heading towards the root container).</p>
+                  <dl id="effective-acl-resource-algorithm" rel="schema:hasPart" resource="#effective-acl-resource-algorithm">
+                    <dt property="schema:name">Effective ACL Resource Algorithm</dt>
+                    <dd datatype="rdf:HTML" property="schema:description">
+                      <p>To determine the <em>effective ACL resource</em> of a resource, perform the following steps. Returns <a href="https://infra.spec.whatwg.org/#strings">string</a> (the URI of an ACL Resource).</p>
+                      <ol class="algorithm">
+                        <li>Let <var>resource</var> be the <a href="#resource">resource</a>.</li>
+                        <li>Let <var>aclResource</var> be the <a href="#acl-resource">ACL resource</a> of <var>resource</var>.</li>
+                        <li>If <var>resource</var> has an associated <var>aclResource</var> with a representation, return <var>aclResource</var>.</li>
+                        <li>Otherwise, repeat the steps using the <a href="#container-resource">container resource</a> of <var>resource</var>.</li>
+                      </ol>
+                    </dd>
+                  </dl>
+                  <div class="note" id="effective-acl-resource-alternatives" inlist="" rel="schema:hasPart" resource="#effective-acl-resource-alternatives">
+                    <h4 property="schema:name"><span>Note</span>: Effective ACL Resource Alternatives</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>This specification does not constrain alternative methods to determine the effective ACL resource of a resource.</p>
+                    </div>
+                  </div>
+                  <p class="advisement">Source: <a href="https://github.com/solid/specification/issues/55" rel="cito:citesAsSourceDocument">issues/55</a>, <a href="https://github.com/solid/specification/issues/106" rel="cito:citesAsSourceDocument">issues/106</a>, <a href="https://github.com/solid/specification/issues/130" rel="cito:citesAsSourceDocument">issues/130</a>, <a href="https://github.com/solid/specification/issues/257" rel="cito:citesAsSourceDocument">issues/257</a>, <a href="https://github.com/solid/specification/issues/251" rel="cito:citesAsSourceDocument">issues/251</a></p>
+                </div>
+              </section>
+              <section id="authorization-conformance" inlist="" rel="schema:hasPart" resource="#authorization-conformance">
+                <h3 property="schema:name">Authorization Conformance</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>An applicable Authorization has the following properties:</p>
+                  <ul>
+                    <li>At least one <code>rdf:type</code> property whose object is <code>acl:Authorization</code>.</li>
+                    <li>At least one <code>acl:accessTo</code> or <code>acl:default</code> property value (<cite><a href="#access-objects" rel="rdfs:seeAlso">Access Objects</a></cite>).</li>
+                    <li>At least one <code>acl:mode</code> property value (<cite><a href="#access-modes" rel="rdfs:seeAlso">Access Modes</a></cite>).</li>
+                    <li>At least one <code>acl:agent</code>, <code>acl:agentGroup</code>, <code>acl:agentClass</code> or <code>acl:origin</code> property value (<cite><a href="#access-subjects" rel="rdfs:seeAlso">Access Subjects</a></cite>).</li>
+                    <li>Any <code>acl:condition</code> property value (<cite><a href="#access-conditions" rel="rdfs:seeAlso">Access Conditions</a></cite>).</li>
+                  </ul>
+                  <p class="advisement">Source: <a href="https://github.com/solid/specification/issues/56" rel="cito:citesAsSourceDocument">issues/56</a>, <a href="https://github.com/solid/specification/issues/57" rel="cito:citesAsSourceDocument">issues/57</a>, <a href="https://github.com/solid/specification/issues/169" rel="cito:citesAsSourceDocument">issues/169</a>, <a href="https://github.com/solid/specification/issues/186" rel="cito:citesAsSourceDocument">issues/186</a>, <a href="https://github.com/solid/specification/issues/193" rel="cito:citesAsSourceDocument">issues/193</a>, <a href="https://github.com/solid/web-access-control-spec/issues/17" rel="cito:citesAsSourceDocument">issues/17</a>, <a href="https://github.com/solid/web-access-control-spec/issues/18" rel="cito:citesAsSourceDocument">issues/18</a>, <a href="https://github.com/solid/web-access-control-spec/issues/63" rel="cito:citesAsSourceDocument">issues/38</a>, <a href="https://github.com/solid/web-access-control-spec/issues/68" rel="cito:citesAsSourceDocument">issues/68</a>, <a href="https://github.com/solid/web-access-control-spec/issues/78" rel="cito:citesAsSourceDocument">issues/78</a>, <a href="https://github.com/fcrepo/fcrepo-specification/issues/145" rel="cito:citesAsSourceDocument">issues/145</a></p>
+                </div>
+              </section>
+              <section id="authorization-evaluation" inlist="" rel="schema:hasPart" resource="#authorization-evaluation">
+                <h3 property="schema:name">Authorization Evaluation</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p id="authorization-evaluation-applicable">The evaluation of an authorization is concerned with finding Authorizations that match the required parameters of an operation (<cite><a href="#authorization-conformance" rel="rdfs:seeAlso">Authorization Conformance</a></cite>). Evaluation stops when all access permission requests have been granted by one or more Authorizations. Authorizations that do not match a required access permission have no effect on the outcome of the evaluation. Access is granted when conforming Authorizations are matched, otherwise access is denied.</p>
+                  <p id="authorization-evaluation-context">As per determining the <cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite> of a resource, an Authorization can be evaluated explicitly (via <code>acl:accessTo</code>) or inherited (via <code>acl:default</code>) against a particular request.</p>
+                  <p id="authorization-evaluation-acl-mode-entailment">When a request requires an access mode (<code>acl:mode</code>) which is a limitation of another access mode, then access is granted if either mode is allowed by an Authorization. For example, when a request requires <code>acl:Append</code>, then access will be granted to agents having <code>acl:Write</code>.</p>
+                  <p id="authorization-evaluation-origin">The presence of the <code>acl:origin</code> property and its value is taken into account in the evaluation only when the HTTP request includes the <code>Origin</code> header (<cite><a href="#web-origin-authorization" rel="rdfs:seeAlso">Web Origin Authorization</a></cite>). </p>
+                  <section id="reading-writing-resources" inlist="" rel="schema:hasPart" resource="#reading-writing-resources">
+                    <h4 property="schema:name">Reading and Writing Resources</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>Working alongside <cite><a href="#http-interactions" rel="rdfs:seeAlso">HTTP Interactions</a></cite>, WAC enables a standard set of operations which can be applied to different resource types for a given request based on the set of access modes which control those operations:</p>
+                      <p id="http-crud">Generally: read operations attempt to confirm the existence of a resource or to view the contents of a resource; write operations attempt to create, delete, or modify resources; append operations attempt to create resources or add information to existing resources; and control operations attempt to view, create, delete, or modify ACL resources.</p>
+                      <p>As container resources and member resources are hierarchically organised, requests to perform operations on resources are in the context of the applicable container (<cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite>).</p>
+                      <p about="" id="server-read-operation" rel="spec:requirement" resource="#server-read-operation"><span property="spec:statement">When an operation requests to read a resource, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> match an Authorization allowing the <code>acl:Read</code> access privilege on the resource.</span></p>
+                      <p about="" id="server-create-operation" rel="spec:requirement" resource="#server-create-operation"><span property="spec:statement">When an operation requests to create a resource as a member of a container resource, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege (as needed by the operation) on the resource to be created.</span></p>
+                      <p about="" id="server-update-operation" rel="spec:requirement" resource="#server-update-operation"><span property="spec:statement">When an operation requests to update a resource, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> match an Authorization allowing the <code>acl:Append</code> or <code>acl:Write</code> access privilege on the resource.</span></p>
+                      <p about="" id="server-delete-operation" rel="spec:requirement" resource="#server-delete-operation"><span property="spec:statement">When an operation requests to delete a resource, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> match Authorizations allowing the <code>acl:Write</code> access privilege on the resource and the containing container.</span></p>
+                      <div class="note" id="container-permissions" inlist="" rel="schema:hasPart" resource="#container-permissions">
+                        <h5 property="schema:name"><span>Note</span>: Container Permissions</h5>
+                        <div datatype="rdf:HTML" property="schema:description">
+                          <p>When a server supports the creation of intermediate containers in the process of creating a resource, the server applies the same requirements for the create operation for each container.</p>
+                          <p>When a server supports the recursive deletion of a container, the server applies the same requirements for the delete operation for each member resource.</p>
+                        </div>
+                      </div>
+                      <div class="note" id="reinstated-resource-permissions" inlist="" rel="schema:hasPart" resource="#reinstated-resource-permissions">
+                        <h5 property="schema:name"><span>Note</span>: Reinstated Resource Permissions</h5>
+                        <div datatype="rdf:HTML" property="schema:description">
+                          <p>Implementations might perform cleanup tasks such as deleting the ACL resource that is associated with a resource when the resource is deleted. As deleted resources can be replaced by new resources with the same URI, access permissions on the new resource can differ when the <cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite> is determined.</p>
+                        </div>
+                      </div>
+                      <p about="" id="server-control-operation" rel="spec:requirement" resource="#server-control-operation"><span property="spec:statement">When an operation requests to read and write an ACL resource, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> match an Authorization allowing the <code>acl:Control</code> access privilege on the resource.</span></p>
+                      <div class="note" id="http-method-access-mode-mapping" inlist="" rel="schema:hasPart" resource="#http-method-access-mode-mapping">
+                        <h5 property="schema:name"><span>Note</span>: HTTP Method and Access Mode Mapping</h5>
+                        <div datatype="rdf:HTML" property="schema:description">
+                          <p id="http-acl-resource">When the target of the HTTP request is the ACL resource, the operation can only be allowed with the <code>acl:Control</code> access mode. Having <code>acl:Control</code> does not imply that the agent has <code>acl:Read</code> or <code>acl:Write</code> access to the resource itself, just to its corresponding ACL resource. For example, an agent with control access can disable their own write access (to prevent accidental over-writing of a resource by an application), but be able to change their access levels at a later point (since they retain <code>acl:Control</code> access).</p>
+                          <dl id="http-methods-access-modes">
+                            <dt id="http-get"><code>GET</code></dt>
+                            <dd>The HTTP <code>GET</code> method request targeting a resource can only be allowed with the <code>acl:Read</code> access mode.</dd>
+                            <dt id="http-post"><code>POST</code></dt>
+                            <dd>The HTTP <code>POST</code> can be used to create a new resource in a container or add information to existing resources (but not remove resources or its contents) with either <code>acl:Append</code> or <code>acl:Write</code>.</dd>
+                            <dt id="http-put"><code>PUT</code></dt>
+                            <dd>The HTTP <code>PUT</code> method requests to create or replace the resource state. <em>Creating</em> a new resource requires <code>acl:Append</code> and/or <code>acl:Write</code> access to the container as well as <code>acl:Write</code> access to the (new) resource. <em>Replacing</em> an existing resource requires only <code>acl:Write</code> access to the resource itself.</dd>
+                            <dt id="http-patch"><code>PATCH</code></dt>
+                            <dd>As the processing of HTTP <code>PATCH</code> method request depends on the request semantics and content, <code>acl:Append</code> can allow requests to <em>insert</em> but not <em>delete</em> operations, whereas <code>acl:Write</code> would allow both operations. To create a new resource, <code>acl:Append</code> or <code>acl:Write</code> access mode to the container is additionally required.</dd>
+                            <dt id="http-delete"><code>DELETE</code></dt>
+                            <dd>As the HTTP <code>DELETE</code> method requests to remove a resource, the <code>acl:Write</code> access mode would be required.</dd>
+                          </dl>
+                        </div>
+                      </div>
+                      <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/47" rel="cito:citesAsSourceDocument">issues/47</a>, <a href="https://github.com/solid/specification/issues/132" rel="cito:citesAsSourceDocument">issues/132</a>, <a href="https://github.com/solid/specification/issues/197" rel="cito:citesAsSourceDocument">issues/197</a>, <a href="https://github.com/solid/specification/issues/246" rel="cito:citesAsSourceDocument">issues/246</a>, <a href="https://github.com/solid/web-access-control-spec/issues/122" rel="cito:citesAsSourceDocument">issues/122</a></p>
+                    </div>
+                  </section>
+                  <section id="condition-evaluation" inlist="" rel="schema:hasPart" resource="#condition-evaluation">
+                    <h4 property="schema:name">Condition Evaluation</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p about="" id="server-condition-evaluation" rel="spec:requirement" resource="#server-condition-evaluation"><span property="spec:statement">When an Authorization includes one or more <code>acl:condition</code> properties, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> only consider conditions whose types are signalled via <a href="#acl-resource-condition-discovery">ACL Resource Condition Discovery</a>. Conditions whose types are not signalled are not used in Authorization Evaluation.</span></p>
+                      <p about="" id="server-condition-evaluation-conjunctive" rel="spec:requirement" resource="#server-condition-evaluation-conjunctive"><span property="spec:statement">When an Authorization includes one or more <code>acl:condition</code> properties whose types are signalled, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> match an Authorization only when all such conditions are satisfied.</span></p>
+                      <p>This specification defines condition types in <cite><a href="#access-conditions" rel="rdfs:seeAlso">Access Conditions</a></cite>. Additional condition types can be defined as per <cite><a href="#authorization-extensions" rel="rdfs:seeAlso">Authorization Extensions</a></cite>.</p>
+                    </div>
+                  </section>
+                  <section id="web-origin-authorization" inlist="" rel="schema:hasPart" resource="#web-origin-authorization">
+                    <h4 property="schema:name">Web Origin Authorization</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>User agents include the HTTP <code>Origin</code> header field to isolate different origins and permit controlled communication between origins. The <code>Origin</code> header warns the server that a possibly untrusted Web application is being used.</p>
+                      <p id="server-origin-authorization">When an HTTP request includes the <code>Origin</code> header, the requested operation is granted on the target resource when there is a match for:</p>
+                      <ul>
+                        <li>an Authorization allowing access to the requesting agent (<code>acl:agent</code>, <code>acl:agentGroup</code>, <code>acl:agentClass</code>);</li>
+                        <li>an Authorization with an <code>acl:origin</code> property value that of <code>Origin</code>’s field-value, when the required access mode is not available to all agents (<code>acl:agentClass foaf:Agent</code>); and</li>
+                        <li>the required access mode is allowed for the requesting agent and the origin.</li>
+                      </ul>
+                      <p about="" id="server-cors-acao-acah" rel="spec:requirement" resource="#server-cors-acao-acah"><span property="spec:statement">When a server participates in the <abbr title="Cross-Origin Resource Sharing">CORS</abbr> protocol [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>] and authorization is granted to an HTTP request including the <code>Origin</code> header, the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> include the HTTP <code>Access-Control-Allow-Origin</code> and <code>Access-Control-Allow-Headers</code> headers in the response of the HTTP request.</span></p>
+                      <div class="note" id="access-subject-origin-rejection-reason" inlist="" rel="schema:hasPart" resource="#access-subject-origin-rejection-reason">
+                        <h5 property="schema:name"><span>Note</span>: Access Subject and Origin Rejection Reason</h5>
+                        <div datatype="rdf:HTML" property="schema:description">
+                          <p>Implementations are encouraged to describe reasons to reject the request in the HTTP response the difference between the access subject not being allowed and the origin associated with the HTTP request not being granted access.</p>
+                        </div>
+                      </div>
+                      <div class="note" id="trusted-origins" inlist="" rel="schema:hasPart" resource="#trusted-origins">
+                        <h5 property="schema:name"><span>Note</span>: Trusted Origins</h5>
+                        <div datatype="rdf:HTML" property="schema:description">
+                          <p>Implementations might implicitly allow a list of origins, such as the same-origin [<cite><a class="bibref" href="#bib-rfc6454">RFC6454</a></cite>].</p>
+                        </div>
+                      </div>
+                    </div>
+                  </section>
+                  <section id="authorization-matching" inlist="" rel="schema:hasPart" resource="#authorization-matching">
+                    <h4 property="schema:name">Authorization Matching</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p><em>This section is non-normative.</em></p>
+                      <p>This specification does not impose a storage system that can be used to store Authorizations. Similarly, mechanisms that can be used to find required RDF statements of Authorizations is deliberately unspecified to allow for a wide variety of use. This section <em>exemplifies</em> access check via SPARQL 1.1 Query Language’s [<cite><a class="bibref" href="#bib-sparql11-query">SPARQL11-QUERY</a></cite>] <code>ASK</code> form to test whether or not an Authorization pattern matches; returns <a href="https://infra.spec.whatwg.org/#booleans">boolean</a>.</p>
+                      <p>The <code>ASK</code> queries below exemplify atomic graph patterns that can be executed against the default graph of an RDF dataset using named graphs for resources. The examples use query variables marked with "<var>?</var>" to indicate any value, and "<var>$</var>" to indicate inputs passed to the query, e.g., <samp>&lt;http://example.org/.acl&gt;</samp> as the IRI reference of the effective ACL resource of a request replaces <code>$aclResource</code> in the query, and likewise, <samp>acl:Write</samp> as input is intended to replace <code>$mode</code> in the examples.</p>
+                      <figure class="example listing" id="match-accessto-agent-mode" rel="schema:hasPart" resource="#match-accessto-agent-mode" typeof="schema:SoftwareSourceCode">
+                        <figcaption property="schema:name"><span>Example</span>: <span>Match an Authorization with a specific resource, agent and access mode.</span></figcaption>
+                        <pre property="schema:description"><code>PREFIX acl: &lt;http://www.w3.org/ns/auth/acl#&gt;</code>
+<code>PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;</code>
+<code>PREFIX vcard: &lt;http://www.w3.org/2006/vcard/ns#&gt;</code>
+<code></code>
+<code>ASK {</code>
+<code>  GRAPH $aclResource {</code>
+<code>    ?authorization</code>
+<code>      a acl:Authorization ;</code>
+<code>      acl:accessTo $resource ;</code>
+<code>      acl:agent $agent ;</code>
+<code>      acl:mode $mode .</code>
+<code>  }</code>
+<code>}</code></pre>
+                        <p><code>ASK</code> query matching an Authorization given inputs <var>resource</var>, <var>agent</var> and <var>mode</var>.</p>
+                      </figure>
+                      <p>From here on, <code>PREFIX</code>s in the query are assumed to be present.</p>
+                      <p>The following query is typically used in context of inheriting Authorizations (<code>acl:default</code>) from a container’s ACL resource. The query also demonstrates matching Authorizations that use a superclass of the required access mode (<cite><a href="#access-mode-classes" rel="rdfs:seeAlso">Access Mode Classes</a></cite>):</p>
+                      <figure class="example listing" id="match-default-agentclass-mode" rel="schema:hasPart" resource="#match-default-agentclass-mode" typeof="schema:SoftwareSourceCode">
+                        <figcaption property="schema:name"><span>Example</span>: <span>Match an Authorization with a specific container resource, agent class membership and access mode.</span></figcaption>
+                        <pre property="schema:description"><code>ASK {</code>
+<code>  GRAPH $aclResource {</code>
+<code>    {</code>
+<code>      ?authorization</code>
+<code>        a acl:Authorization ;</code>
+<code>        acl:default $containerResource ;</code>
+<code>        acl:agentClass $agentClass ;</code>
+<code>        acl:mode $requiredMode .</code>
+<code>    }</code>
+<code>    UNION</code>
+<code>    {</code>
+<code>      ?authorization</code>
+<code>        a acl:Authorization ;</code>
+<code>        acl:default $containerResource ;</code>
+<code>        acl:agentClass $agentClass ;</code>
+<code>        acl:mode ?mode .</code>
+<code>      GRAPH $aclOntologyResource {</code>
+<code>        $requiredMode rdfs:subClassOf+ ?mode .</code>
+<code>      }</code>
+<code>    }</code>
+<code>  }</code>
+<code>}</code></pre>
+                        <p><code>ASK</code> query matching an Authorization given inputs <var>containerResource</var>, <var>agentClass</var> and <var>requiredMode</var> (which could be a subclass of another access mode).</p>
+                      </figure>
+                      <p>The following query can be used to check if an agent is a member of any group that can access a resource:</p>
+                      <figure class="example listing" id="match-accessto-agentgroup-mode" rel="schema:hasPart" resource="#match-accessto-agentgroup-mode" typeof="schema:SoftwareSourceCode">
+                        <figcaption property="schema:name"><span>Example</span>: <span>Match an Authorization with a specific resource, agent with any group membership, and specific access mode.</span></figcaption>
+                        <pre property="schema:description"><code>ASK {</code>
+<code>  GRAPH $aclResource {</code>
+<code>    ?authorization</code>
+<code>      a acl:Authorization ;</code>
+<code>      acl:accessTo $resource ;</code>
+<code>      acl:agentGroup ?agentGroup ;</code>
+<code>      acl:mode $mode .</code>
+<code>  }</code>
+<code>  GRAPH ?groupResource {</code>
+<code>    ?agentGroup vcard:hasMember $agent .</code>
+<code>  }</code>
+<code>}</code></pre>
+                        <p><code>ASK</code> query matching an Authorization given inputs <var>resource</var>, <var>agent</var> and <var>mode</var>.</p>
+                      </figure>
+                      <p>The following query demonstrates matching an Authorization that includes multiple <code>acl:condition</code> values:</p>
+                      <figure class="example listing" id="match-accessto-agent-mode-conditions" rel="schema:hasPart" resource="#match-accessto-agent-mode-conditions" typeof="schema:SoftwareSourceCode">
+                        <figcaption property="schema:name"><span>Example</span>: <span>Match an Authorization with a specific resource, agent, access mode, client and issuer conditions.</span></figcaption>
+                        <pre property="schema:description"><code>ASK {</code>
+<code>  GRAPH $aclResource {</code>
+<code>    ?authorization</code>
+<code>      a acl:Authorization ;</code>
+<code>      acl:accessTo $resource ;</code>
+<code>      acl:agent $agent ;</code>
+<code>      acl:mode $mode ;</code>
+<code>      acl:condition</code>
+<code>        [ a acl:ClientCondition ; acl:client $client ] ,</code>
+<code>        [ a acl:IssuerCondition ; acl:issuer $issuer ] .</code>
+<code>  }</code>
+<code>}</code></pre>
+                        <p><code>ASK</code> query matching an Authorization given inputs <var>resource</var>, <var>agent</var>, <var>mode</var>, <var>client</var> and <var>issuer</var>.</p>
+                      </figure>
+                    </div>
+                  </section>
+                  <section id="access-privileges" inlist="" rel="schema:hasPart" resource="#access-privileges">
+                    <h4 property="schema:name">Access Privileges</h4>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p about="" id="server-wac-allow" rel="spec:requirement" resource="#server-wac-allow"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Server">Servers</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> advertise client’s access privileges on a resource by including the <code>WAC-Allow</code> HTTP header (<cite><a href="#wac-allow" rel="rdfs:seeAlso">WAC-Allow</a></cite>) in the response of HTTP <code>GET</code> and <code>HEAD</code> requests.</span></p>
+                      <p about="" id="client-wac-allow" rel="spec:requirement" resource="#client-wac-allow"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Client">Clients</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> discover access privileges on a resource by making an HTTP <code>GET</code> or <code>HEAD</code> request on the target resource, and checking the <code>WAC-Allow</code> header value for access parameters listing the allowed access modes per permission group (<cite><a href="#wac-allow" rel="rdfs:seeAlso">WAC-Allow</a></cite>).</span></p>
+                      <p about="" id="server-cors-aceh-wac-allow" rel="spec:requirement" resource="#server-cors-aceh-wac-allow"><span property="spec:statement">When a server participates in the <abbr title="Cross-Origin Resource Sharing">CORS</abbr> protocol [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>], the <span rel="spec:requirementSubject" resource="spec:Server">server</span> <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> include <code>WAC-Allow</code> in the <code>Access-Control-Expose-Headers</code> field-value in the HTTP response.</span></p>
+                    </div>
+                  </section>
+                </div>
+              </section>
+            </div>
+          </section>
+          <section id="http-definitions" inlist="" rel="schema:hasPart" resource="#http-definitions">
+            <h2 property="schema:name">HTTP Definitions</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <section id="wac-allow" inlist="" rel="schema:hasPart" resource="#wac-allow">
+                <h3 property="schema:name">wac-allow HTTP Header</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The syntax for the <code>WAC-Allow</code> header, using the ABNF syntax defined in Section 2.1 of [<cite><a class="bibref" href="#bib-rfc9110">RFC9110</a></cite>], is:</p>
+                  <pre class="def">wac-allow        = "WAC-Allow" ":" OWS #access-param OWS
+access-param     = permission-group OWS "=" OWS access-modes
+permission-group = 1*ALPHA
+access-modes     = DQUOTE OWS *1(access-mode *(RWS access-mode)) OWS DQUOTE
+access-mode      = "read" / "write" / "append" / "control"</pre>
+                  <p>The <code>WAC-Allow</code> HTTP header’s field-value is a comma-separated list of <code>access-param</code>s. <code>access-param</code> is a whitespace-separated list of <code>access-modes</code> granted to a <code>permission-group</code>.</p>
+                  <div class="issue" id="wac-allow-access-mode" rel="schema:hasPart" resource="#wac-allow-access-modes">
+                    <h3 property="schema:name"><span>Issue</span>: WAC-Allow Access Modes</h3>
+                    <div datatype="rdf:HTML" property="schema:description">
+                      <p>Allow any access mode <a href="https://github.com/solid/web-access-control-spec/issues/82" rel="cito:citesAsRelated">issues/82</a>.</p>
+                    </div>
+                  </div>
+                  <p>This specification defines the following <code>permission-group</code>s:</p>
+                  <dl>
+                    <dt><code>user</code></dt>
+                    <dd>Permissions granted to the agent requesting the resource.</dd>
+                    <dt><code>public</code></dt>
+                    <dd>Permissions granted to the public.</dd>
+                  </dl>
+                  <p><code>access-mode</code> corresponds to the <cite><a href="#access-modes" rel="rdfs:seeAlso">Access Modes</a></cite> as defined in the ACL ontology (<code>acl:Read</code>, <code>acl:Write</code>, <code>acl:Append</code>, <code>acl:Control</code>).</p>
+                  <p about="" id="client-wac-allow-parsing" rel="spec:requirement" resource="#client-wac-allow-parsing"><span property="spec:statement"><span rel="spec:requirementSubject" resource="spec:Client">Client</span> parsing algorithms for <code>WAC-Allow</code> header field-values <span rel="spec:requirementLevel" resource="spec:MUST">MUST</span> incorporate error handling. When the received message fails to match an allowed pattern, clients MUST ignore the received <code>WAC-Allow</code> header-field. When unrecognised access parameters (such as permission groups or access modes) are found, clients MUST continue processing the access parameters as if those properties were not present.</span></p>
+                  <p class="advisement">Source: <a href="https://github.com/solid/specification/issues/171" rel="cito:citesAsSourceDocument">issues/171</a>, <a href="https://github.com/solid/specification/issues/170" rel="cito:citesAsSourceDocument">issues/170</a>, <a href="https://github.com/solid/specification/issues/181" rel="cito:citesAsSourceDocument">issues/181</a>, <a href="https://gitter.im/solid/specification?at=60101295d8bdab47395e6775" rel="cito:citesAsSourceDocument">60101295d8bdab47395e6775</a>, <a href="https://github.com/solid/specification/pull/210">pull/210</a></p>
+                </div>
+              </section>
+              <section id="acl-link-relation" inlist="" rel="schema:hasPart" resource="#acl-link-relation">
+                <h3 property="schema:name">acl Link Relation</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p>The following Link Relationship is submitted to IANA for review, approval, and inclusion in the IANA Link Relations registry [<cite><a class="bibref" href="#bib-rfc8288">RFC8288</a></cite>].</p>
+                  <dl>
+                    <dt>Relation Name</dt>
+                    <dd><code>acl</code></dd>
+                    <dt>Description</dt>
+                    <dd>Asserts that the link target provides an access control resource for the link context.</dd>
+                    <dt>Reference</dt>
+                    <dd>https://solidproject.org/TR/wac#acl-link-relation</dd>
+                  </dl>
+                  <p class="advisement">Source: <a href="https://github.com/solid/specification/issues/54" rel="cito:citesAsSourceDocument">issues/54</a>, <a href="https://github.com/solid/web-access-control-spec/issues/21" rel="cito:citesAsSourceDocument">issues/21</a>, <a href="https://github.com/protocol-registries/link-relations/issues/32" rel="cito:citesAsSourceDocument">issues/32</a></p>
+                </div>
+              </section>
+            </div>
+          </section>
+          <section id="extensions" inlist="" rel="schema:hasPart" resource="#extensions">
+            <h2 property="schema:name">Extensions</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>Extensions incorporate additional features beyond what is defined in this specification. Extensions MUST NOT contradict nor cause the non-conformance of functionality defined in the WAC specification.</p>
+              <section id="authorization-extensions" inlist="" rel="schema:hasPart" resource="#authorization-extensions">
+                <h3 property="schema:name">Authorization Extensions</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                  <p id="extension-acl-authorization">As ACL resources are RDF sources; <a href="#authorization">Authorization</a> descriptions can be extended or limited by constraints, e.g., temporal or spatial constraints; and duties, e.g., payments, can be imposed on permissions; but no behaviour is defined by this specification. For example, the <cite><a href="https://www.w3.org/TR/odrl-model/" rel="cito:citesAsPotentialSolution">ODRL Information Model</a></cite> can be used to set obligations required to be met by agents prior to accessing a resource.</p>
+                  <p id="extension-acl-accesstoclass">To allow access to a class of resources, implementations can use the <code>acl:accessToClass</code> predicate as defined in the <cite><a href="http://www.w3.org/ns/auth/acl" rel="cito:citesAsAuthority">ACL ontology</a></cite>.</p>
+                  <p class="advisement">Source: <a href="https://github.com/solid/web-access-control-spec/issues/10" rel="cito:citesAsSourceDocument">issues/10</a>, <a href="https://github.com/solid/web-access-control-spec/issues/22" rel="cito:citesAsSourceDocument">issues/22</a>, <a href="https://github.com/solid/web-access-control-spec/pull/37" rel="cito:citesAsSourceDocument">pull/37</a>, <a href="https://github.com/solid/specification/issues/20" rel="cito:citesAsSourceDocument">issues/20</a></p>
+                </div>
+              </section>
+              <section id="access-mode-extensions" inlist="" rel="schema:hasPart" resource="#access-mode-extensions">
+                <h3 property="schema:name">Access Mode Extensions</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p id="extension-acl-mode">An extension to access modes is any mode that is defined in the <cite><a href="http://www.w3.org/ns/auth/acl" rel="cito:citesAsAuthority">ACL ontology</a></cite>, i.e., as a subclass of <code>acl:Access</code>, but not described in this specification (<cite><a href="#access-modes" rel="rdfs:seeAlso">Access Modes</a></cite>). Consumers of Authorizations that encounter unrecognised access modes MUST NOT stop processing or signal an error and MUST continue processing the access modes as if those properties were not present.</p>
+                  <p>Foreign-namespaced access modes are allowed in ACL resources, but they MUST NOT cause increased access.</p>
+                </div>
+              </section>
+              <section id="access-condition-extensions" inlist="" rel="schema:hasPart" resource="#access-condition-extensions">
+                <h3 property="schema:name">Access Condition Extensions</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p id="extension-acl-condition">An extension to access conditions is any condition type not described in this specification (<cite><a href="#access-conditions" rel="rdfs:seeAlso">Access Conditions</a></cite>), including foreign-namespaced types, which need not explicitly declare <code>a acl:Condition</code>. Consumers of Authorizations that encounter condition types they do not support MUST NOT stop processing or signal an error and MUST continue processing the access conditions as if those properties were not present.</p>
+                </div>
+              </section>
+              <section id="permission-inheritance-extensions" inlist="" rel="schema:hasPart" resource="#permission-inheritance-extensions">
+                <h3 property="schema:name">Permission Inheritance Extensions</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                  <p id="extension-authorization-inheritance">This specification describes permission inheritance based on determining the <cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite> of a resource. Alternative strategies such as cumulative permissions (union of all the permissions from each ACL resource inherited from the ancestors of a resource) are allowed, but no behaviour is defined by this specification.</p>
+                </div>
+              </section>
+              <section id="distinct-effective-acl-resource-extensions" inlist="" rel="schema:hasPart" resource="#distinct-effective-acl-resource-extensions">
+                <h3 property="schema:name">Distinct Effective ACL Resource Extensions</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                  <p id="extension-effective-acl-resource">This specification describes the use of <cite><a href="#acl-link-relation" rel="rdfs:seeAlso">acl Link Relation</a></cite> for <cite><a href="#acl-resource-discovery" rel="rdfs:seeAlso">ACL Resource Discovery</a></cite> and the algorithm to determine the <cite><a href="#effective-acl-resource" rel="rdfs:seeAlso">Effective ACL Resource</a></cite> of a resource. To enable clients to perform discovery faster, separate link relation type targeting the <em>effective ACL resource</em> is allowed, but no behaviour is defined by this specification.</p>
+                </div>
+              </section>
+            </div>
+          </section>
+          <section id="considerations" inlist="" rel="schema:hasPart" resource="#considerations" typeof="spec:Considerations">
+            <h2 property="schema:name">Considerations</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>This section details <span about="" rel="spec:consideration"><a href="#security-considerations">security</a>, <a href="#privacy-considerations">privacy</a>, <a href="#accessibility-considerations">accessibility</a> and <a href="#internationalization-considerations">internationalization</a> considerations</span>.</p>
+              <p>Some of the normative references with this specification point to documents with a <em>Living Standard</em> or <em>Draft</em> status, meaning their contents can still change over time. It is advised to monitor these documents, as such changes might have implications.</p>
+              <section id="security-considerations" inlist="" rel="schema:hasPart" resource="#security-considerations" typeof="spec:SecurityConsiderations">
+                <h3 property="schema:name">Security Considerations</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                  <p about="" id="robust-protection-reliability-advice" rel="spec:advisement" resource="#robust-protection-reliability-advice"><span property="spec:statement">While this section attempts to highlight a set of security considerations, it is not a complete list. Implementers are <span rel="spec:advisementLevel" resource="spec:StronglyEncouraged">strongly encouraged</span> to seek the advice of security professionals when developing systems that require robust protection and reliability using the technology outlined in this specification.</span></p>
+                  <p id="consider-uri-http">Implementations are encouraged to follow the security considerations that are found in URI <cite><a href="https://datatracker.ietf.org/doc/html/rfc3986#section-7" rel="cito:citesForInformation">Generic Syntax</a></cite>, <cite><a href="https://www.rfc-editor.org/rfc/rfc9112#name-security-considerations" rel="cito:citesForInformation">HTTP/1.1</a></cite> and <cite><a href="https://www.rfc-editor.org/rfc/rfc9110#name-security-considerations" rel="cito:citesForInformation">HTTP Semantics</a></cite>.</p>
+                  <p id="consider-additional-information-lookups">Servers are strongly discouraged from trusting the information returned by looking up an agent’s WebID for access control purposes. The server operator can also provide the server with other trusted information to include in the search for a reason to give the requester the access.</p>
+                  <p id="consider-authorization-integrity-authenticity">Transfer of <a href="#authorization">Authorizations</a> between a client and server over an open network creates the potential for those rules to be modified or disclosed without proper authorization. The requirements for the WAC protocol discussed in this specification do not include cryptographic protection of Authorization information, because it is assumed that this protection can be provided through HTTP over TLS. The path between client and application might be composed of multiple independent TLS connections, thus for end-to-end integrity and authenticity of content within an HTTP message, implementers can use mechanisms such as <cite><a href="https://www.rfc-editor.org/rfc/rfc9421" rel="cito:citesAsPotentialSolution">HTTP Message Signatures</a></cite>. For cryptographic proof of Authorizations asserted by agents and protection from undetected modifications, implementers can use mechanisms such as <cite><a href="https://w3c-ccg.github.io/ld-proofs/" rel="cito:citesAsPotentialSolution">Linked Data Security</a></cite>.</p>
+                  <p id="consider-acl-resource-activities">Implementations are encouraged to use mechanisms to record activities about ACL resources for the purpose of accountability and integrity, e.g., by having audit trails, notification of changes, reasons for change, preserving provenance information.</p>
+                  <p id="consider-provenance-accountability">Implementations that want to allow a class of write or control operations on resources are encouraged to require agents to be authenticated, e.g., for purposes of provenance or accountability.</p>
+                  <p about="" id="consider-client-agnostic-control" rel="spec:advisement" resource="#consider-client-agnostic-control"><span property="spec:statement">Implementations are <span rel="spec:advisementLevel" resource="spec:Encouraged">encouraged</span> to consider scenarios in which Authorizations granting <code>acl:Control</code> are client-agnostic and issuer-agnostic, avoiding inadvertent <a href="#loss-of-control-mitigation" rel="rdfs:seeAlso">loss of control</a> if a client or issuer becomes unavailable or untrustworthy, as well as scenarios in which restricting control access to specific clients or issuers could expose the controller to manipulation through a malicious client or issuer.</span></p>
+                  <p about="" id="consider-condition-legacy" rel="spec:advisement" resource="#consider-condition-legacy"><span property="spec:statement">Implementations are <span rel="spec:advisementLevel" resource="spec:StronglyEncouraged">strongly encouraged</span> to be aware that Authorizations including <code>acl:condition</code> evaluated by a server without condition support could result in access rights broader than those intended by the original Authorization. Similarly, clients that do not support a condition type will process the Authorization without evaluating that condition. System operators are strongly encouraged to verify Authorizations with conditions against the condition capabilities of the server prior to deployment.</span></p>
+                  <p about="" id="consider-condition-control" rel="spec:advisement" resource="#consider-condition-control"><span property="spec:statement">Implementations are <span rel="spec:advisementLevel" resource="spec:Encouraged">encouraged</span> to consider granting <code>acl:Control</code> access using an <code>acl:Condition</code> to clients known to support conditions, to preserve Authorization integrity, and to reduce the risk of inadvertent condition removal by condition-unaware clients.</span></p>
+                </div>
+              </section>
+              <section id="privacy-considerations" inlist="" rel="schema:hasPart" resource="#privacy-considerations" typeof="spec:PrivacyConsiderations">
+                <h3 property="schema:name">Privacy Considerations</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                  <p>The class of read and write operations require discrete access permissions:</p>
+                  <p id="consider-append-read-diff">Access permission to append a new resource to a container resource is independent of access permission to read a container resource. Thus, servers are encouraged to prevent information leakage when a successful HTTP request appends a new resource to a container resource. For instance, while the knowledge of the URI-Reference in <code>Location</code> and <code>Content-Location</code> HTTP headers in the response of a <code>POST</code> does not in itself pose a security threat ([<cite><a class="bibref" href="#bib-rfc3986">RFC3986</a></cite>]), servers can consider the risks when read access to the container is not granted to agents.</p>
+                  <p id="consider-delete-read-diff">Access permission to update a resource is independent of access permission to read a resource. Thus, servers are encouraged to prevent information leakage when an attempt to delete information in a resource might reveal the existence of the information. For instance, when an HTTP <code>PATCH</code> request uses SPARQL Update’s <code>DELETE DATA</code> operation, servers can consider the risks of disclosing information by the chosen status code when read access to the resource is not granted to agents.</p>
+                  <p about="" id="consider-client-issuer-privacy" rel="spec:advisement" resource="#consider-client-issuer-privacy"><span property="spec:statement">Implementations are <span rel="spec:advisementLevel" resource="spec:Encouraged">encouraged</span> to be aware that <code>acl:ClientCondition</code> and <code>acl:IssuerCondition</code> in an ACL resource extend the existing exposure of agent information to other agents with <code>acl:Control</code> access, additionally revealing which client applications and identity providers an agent might use.</span></p>
+                </div>
+              </section>
+              <section id="accessibility-considerations" inlist="" rel="schema:hasPart" resource="#accessibility-considerations" typeof="spec:AccessibilityConsiderations">
+                <h3 property="schema:name">Accessibility Considerations</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                </div>
+              </section>
+              <section id="internationalization-considerations" inlist="" rel="schema:hasPart" resource="#internationalization-considerations" typeof="spec:InternationalizationConsiderations">
+                <h3 property="schema:name">Internationalization Considerations</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                </div>
+              </section>
+              <section id="security-privacy-review" inlist="" rel="schema:hasPart" resource="#security-privacy-review" typeof="spec:SelfReviewQuestionnaireSecurityPrivacy">
+                <h3 property="schema:name">Security and Privacy Review</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <p><em>This section is non-normative.</em></p>
+                  <p>These questions provide an overview of security and privacy considerations for this specification as guided by [<cite><a class="bibref" href="#bib-security-privacy-questionnaire">SECURITY-PRIVACY-QUESTIONNAIRE</a></cite>].</p>
+                  <dl rel="schema:hasPart">
+                    <dt about="#security-privacy-review-purpose" id="security-privacy-review-purpose"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#purpose" rel="cito:repliesTo">What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?</a></dt>
+                    <dd about="#security-privacy-review-purpose" datatype="rdf:HTML" property="schema:description">There are no known security impacts of the features in this specification.</dd>
+                    <dt about="#security-privacy-review-minimum-data" id="security-privacy-review-minimum-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#minimum-data" rel="cito:repliesTo">Do features in your specification expose the minimum amount of information necessary to enable their intended uses?</a></dt>
+                    <dd about="#security-privacy-review-minimum-data" datatype="rdf:HTML" property="schema:description">Yes.</dd>
+                    <dt about="#security-privacy-review-personal-data" id="security-privacy-review-personal-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#personal-data" rel="cito:repliesTo">How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them?</a></dt>
+                    <dd about="#security-privacy-review-personal-data" datatype="rdf:HTML" property="schema:description">ACL resources can contain any data including that which identifies or refers to <cite><a href="#agent">agents</a></cite> and <cite><a href="#agent-group">agent groups</a></cite>. Access to ACL resources is only granted to <cite><a href="#access-subjects">Access Subjects</a></cite> with the <cite><a href="#acl-mode-control" rel="rdfs:seeAlso"><code>acl:Control</code></a></cite> access mode, and thus by definition, <a href="https://w3ctag.github.io/design-principles/#consent">meaningful consent</a> to any personal data that agents include about themselves is extended to other agents with control access on the ACL resource. Group resources are subject to the same Authorization conditions as any resource (that is not an ACL resource), and thus information could be exposed.</dd>
+                    <dt about="#security-privacy-review-sensitive-data" id="security-privacy-review-sensitive-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#sensitive-data" rel="cito:repliesTo">How do the features in your specification deal with sensitive information?</a></dt>
+                    <dd about="#security-privacy-review-sensitive-data" datatype="rdf:HTML" property="schema:description">Same implications as <cite><a href="#security-privacy-review-personal-data" rel="rdfs:seeAlso">personal information and personally-identifiable information</a></cite> in ACL resources and group resources. When including sensitive information, the sender can be aware that changes to a group resource’s Authorization can allow non-members or new members to view membership details.</dd>
+                    <dt about="#security-privacy-review-persistent-origin-specific-state" id="security-privacy-review-persistent-origin-specific-state"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#persistent-origin-specific-state" rel="cito:repliesTo">Do the features in your specification introduce new state for an origin that persists across browsing sessions?</a></dt>
+                    <dd about="#security-privacy-review-persistent-origin-specific-state" datatype="rdf:HTML" property="schema:description">No.</dd>
+                    <dt about="#security-privacy-review-underlying-platform-data" id="security-privacy-review-underlying-platform-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#underlying-platform-data" rel="cito:repliesTo">Do the features in your specification expose information about the underlying platform to origins?</a></dt>
+                    <dd about="#security-privacy-review-underlying-platform-data" datatype="rdf:HTML" property="schema:description">No.</dd>
+                    <dt about="#security-privacy-review-send-to-platform" id="security-privacy-review-send-to-platform"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#send-to-platform" rel="cito:repliesTo">Does this specification allow an origin to send data to the underlying platform?</a></dt>
+                    <dd about="#security-privacy-review-send-to-platform" datatype="rdf:HTML" property="schema:description">No. <cite><a href="#acl-resource" rel="cito:discusses">ACL resources</a></cite> are described within the framework of HTTP as RDF documents <cite><a href="#acl-resource-representation" rel="cito:discusses">represented with the Turtle syntax</a></cite>. Servers might be able to redirect ACL resources, (e.g., the <code>https:</code> URLs to <code>file:</code>, <code>data:</code>, or <code>blob:</code> URLs), but no behaviour is defined by this specification.</dd>
+                    <dt about="#security-privacy-review-sensor-data" id="security-privacy-review-sensor-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#sensor-data" rel="cito:repliesTo">Do features in this specification allow an origin access to sensors on a user’s device</a></dt>
+                    <dd about="#security-privacy-review-sensor-data" datatype="rdf:HTML" property="schema:description">No.</dd>
+                    <dt about="#security-privacy-review-other-data" id="security-privacy-review-other-data"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#other-data" rel="cito:repliesTo">What data do the features in this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.</a></dt>
+                    <dd about="#security-privacy-review-other-data" datatype="rdf:HTML" property="schema:description">No detail about another origin’s state is exposed. As the association between a resource and its ACL resource is at the discretion of the resource server, they can be on different origins (<cite><a href="#uri-origin" rel="cito:discusses">URI Origin</a></cite>). Similarly, when a server participates in the <cite><a href="https://fetch.spec.whatwg.org/#cors-protocol" rel="cito:citesAsAuthority">CORS protocol</a></cite> [<cite><a class="bibref" href="#bib-fetch">FETCH</a></cite>], HTTP requests from different origins may be allowed. This feature does not add any new attack surface above and beyond normal <cite><a href="https://fetch.spec.whatwg.org/#cors-request" rel="cito:citesAsAuthority">CORS requests</a></cite>, so no extra mitigation is deemed necessary.</dd>
+                    <dt about="#security-privacy-review-string-to-script" id="security-privacy-review-string-to-script"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#string-to-script" rel="cito:repliesTo">Do features in this specification enable new script execution/loading mechanisms?</a></dt>
+                    <dd about="#security-privacy-review-string-to-script" datatype="rdf:HTML" property="schema:description">No.</dd>
+                    <dt about="#security-privacy-review-remote-device" id="security-privacy-review-remote-device"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#remote-device" rel="cito:repliesTo">Do features in this specification allow an origin to access other devices?</a></dt>
+                    <dd about="#security-privacy-review-remote-device" datatype="rdf:HTML" property="schema:description">No.</dd>
+                    <dt about="#security-privacy-review-native-ui" id="security-privacy-review-native-ui"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#native-ui" rel="cito:repliesTo">Do features in this specification allow an origin some measure of control over a user agent’s native UI?</a></dt>
+                    <dd about="#security-privacy-review-native-ui" datatype="rdf:HTML" property="schema:description">No.</dd>
+                    <dt about="#security-privacy-review-temporary-id" id="security-privacy-review-temporary-id"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#temporary-id" rel="cito:repliesTo">What temporary identifiers do the features in this specification create or expose to the web?</a></dt>
+                    <dd about="#security-privacy-review-temporary-id" datatype="rdf:HTML" property="schema:description">None.</dd>
+                    <dt about="#security-privacy-review-first-third-party" id="security-privacy-review-first-third-party"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#first-third-party" rel="cito:repliesTo">How does this specification distinguish between behaviour in first-party and third-party contexts?</a></dt>
+                    <dd about="#security-privacy-review-first-third-party" datatype="rdf:HTML" property="schema:description">When an HTTP request includes the <code>Origin</code> header (typical Web browsers use <a href="#origin-considerations" rel="cito:discusses">origin based security</a> to warn servers), <a href="#web-origin-authorization" rel="cito:discusses">Authorizations are matched</a> in context of the origin of the HTTP request in addition to requiring agent identification and allowed access modes. While the use of <code>Origin</code> is not intended as client identification, the implication is that unless servers have separate mechanisms to verify the original request made by an application, the <code>Origin</code> header’s field-value can differ.</dd>
+                    <dt about="#security-privacy-review-private-browsing" id="security-privacy-review-private-browsing"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#private-browsing" rel="cito:repliesTo">How do the features in this specification work in the context of a browser’s Private Browsing or Incognito mode?</a></dt>
+                    <dd about="#security-privacy-review-private-browsing" datatype="rdf:HTML" property="schema:description">No different than <q>browser’s 'normal' state</q>.</dd>
+                    <dt about="#security-privacy-review-considerations" id="security-privacy-review-considerations"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#considerations" rel="cito:repliesTo">Does this specification have both "Security Considerations" and "Privacy Considerations" sections?</a></dt>
+                    <dd about="#security-privacy-review-considerations" datatype="rdf:HTML" property="schema:description">Yes, in <cite><a href="#security-considerations" rel="rdfs:seeAlso">Security Considerations</a></cite> and <cite><a href="#privacy-considerations" rel="rdfs:seeAlso">Privacy Considerations</a></cite>.</dd>
+                    <dt about="#security-privacy-review-relaxed-sop" id="security-privacy-review-relaxed-sop"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#relaxed-sop" rel="cito:repliesTo">Do features in your specification enable origins to downgrade default security protections?</a></dt>
+                    <dd about="#security-privacy-review-relaxed-sop" datatype="rdf:HTML" property="schema:description">No.</dd>
+                    <dt about="#security-privacy-review-non-fully-active" id="security-privacy-review-non-fully-active"><a href="https://www.w3.org/TR/security-privacy-questionnaire/#non-fully-active" rel="cito:repliesTo">How does your feature handle non-"fully active" documents?</a></dt>
+                    <dd about="#security-privacy-review-non-fully-active" datatype="rdf:HTML" property="schema:description">Inapplicable.</dd>
+                  </dl>
+                </div>
+              </section>
+            </div>
+          </section>
+          <section class="appendix" id="changelog" inlist="" rel="schema:hasPart" resource="#changelog" typeof="spec:Changelog">
+            <h2 property="schema:name">Changelog</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p><em>This section is non-normative.</em></p>
+              <p>This document is based on <a href="https://solidproject.org/TR/2024/wac-20240512">Web Access Control, Version 1.0.0</a>. A <a href="https://github.com/solid/web-access-control-spec/issues?q=is%3Aopen+is%3Aissue+milestone%3Acg-draft">list of issues addressed</a>, a <a href="https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fsolidproject.org%2FTR%2F2022%2Fwac-20240512&amp;doc2=https%3A%2F%2Fsolid.github.io%2Fweb-access-control-spec%2F">diff from Web Access Control, Version 1.0.0 to this latest version</a>, as well as a <a href="https://github.com/solid/web-access-control-spec/commits/main/index.html">detailed log of changes</a> are available.</p>
+              <p>The following summary of <em>editorial</em>, <em>substantive</em>, and <em>registry</em> <span about="" rel="spec:changelog" resource="#changelog">changes</span> are classified using the <cite>W3C Process Document</cite> <cite><a href="https://www.w3.org/policies/process/#correction-classes">Classes of Changes</a></cite> [<cite><a class="bibref" href="#bib-w3c-process">W3C-PROCESS</a></cite>]:</p>
+              <table id="changes-since-wac-20240512">
+                <caption>Changes since <a href="https://solidproject.org/TR/2024/wac-20240512">Web Access Control, Version 1.0.0</a></caption>
+                <thead>
+                  <tr>
+                    <th>Change Class</th>
+                    <th>Subject</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody about="#changelog" rel="spec:change">
+                  <tr about="#b2bb4e59-20a3-4f3b-b061-d7f98880eabe" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-1" rel="spec:changeClass">1</a></td>
+                    <td><a href="" rel="spec:changeSubject">Document</a></td>
+                    <td property="spec:statement">Amend broken links, style sheets, or invalid markup.</td>
+                  </tr>
+                  <tr about="#e66968b3-bffc-4e1a-bf9d-3e445349a421" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="" rel="spec:changeSubject">Document</a></td>
+                    <td property="spec:statement">Amend language and document details.</td>
+                  </tr>
+                  <tr about="#b3f5363c-6fe1-4860-82c3-58487c103eb5" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-4" rel="spec:changeClass">4</a></td>
+                    <td><a href="#acl-resource-condition-discovery" rel="spec:changeSubject">#acl-resource-condition-discovery</a></td>
+                    <td property="spec:statement">Add requirements for <a href="#acl-resource-condition-discovery">ACL Resource Condition Discovery</a>.</td>
+                  </tr>
+                  <tr about="#c12b51b2-4abc-4726-88a5-07623c0c8c08" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-4" rel="spec:changeClass">4</a></td>
+                    <td><a href="#access-conditions" rel="spec:changeSubject">#access-conditions</a></td>
+                    <td property="spec:statement">Add <a href="#access-conditions">Access Conditions</a> section describing the condition requirement in an Authorization.</td>
+                  </tr>
+                  <tr about="#dad378e7-05ae-4582-a5cf-e6be8fcada57" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-4" rel="spec:changeClass">4</a></td>
+                    <td><a href="#authorization-conformance" rel="spec:changeSubject">#authorization-conformance</a></td>
+                    <td property="spec:statement">Update <a href="#authorization-conformance">Authorization Conformance</a> to include <code>acl:condition</code> as part of an applicable Authorization.</td>
+                  </tr>
+                  <tr about="#e52bf22c-124c-4af2-98f3-c27cdbc79270" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-4" rel="spec:changeClass">4</a></td>
+                    <td><a href="#condition-evaluation" rel="spec:changeSubject">#condition-evaluation</a></td>
+                    <td property="spec:statement">Add <a href="#condition-evaluation" rel="spec:changeSubject">Condition Evaluation</a> section describing the <a href="#server-condition-evaluation">evaluation of conditions</a> and their <a href="#server-condition-evaluation-conjunctive">conjunctive</a> requirement.</td>
+                  </tr>
+                  <tr about="#fc13b6f0-7cdf-463d-b973-de6f0f75c5d6" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="#match-accessto-agent-mode-conditions" rel="spec:changeSubject">#match-accessto-agent-mode-conditions</a></td>
+                    <td property="spec:statement">Add <a href="#match-accessto-agent-mode-conditions">example query</a> demonstrating <a href="#access-conditions">access conditions</a> with <a href="#access-client-condition">client condition</a> and <a href="#access-issuer-condition">issuer condition</a>.</td>
+                  </tr>
+                  <tr about="#a2e78760-5f70-4fc1-95df-754478278bc9" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="#consider-client-issuer-agnostic-control" rel="spec:changeSubject">#consider-client-issuer-agnostic-control</a></td>
+                    <td property="spec:statement">Add security consideration advisement for <a href="#consider-client-agnostic-control">client-issuer-agnostic</a> control scenarios.</td>
+                  </tr>
+                  <tr about="#b26d849b-0ceb-4c62-981b-0cd58da07567" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="#consider-condition-legacy" rel="spec:changeSubject">#consider-condition-legacy</a></td>
+                    <td property="spec:statement">Add security consideration advisement for <a href="#consider-condition-legacy">condition-unaware</a> server scenarios.</td>
+                  </tr>
+                  <tr about="#c77de7da-d990-4f07-9dba-710f5c850d88" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="#consider-client-issuer-privacy" rel="spec:changeSubject">#consider-client-issuer-privacy</a></td>
+                    <td property="spec:statement">Add privacy consideration advisement for <a href="#consider-client-issuer-privacy">client and issuer</a> information exposure.</td>
+                  </tr>
+                  <tr about="#c77de7da-d990-4f07-9dba-710f5c850d88" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="#security-privacy-review-first-third-party" rel="spec:changeSubject">#security-privacy-review-first-third-party</a></td>
+                    <td property="spec:statement">Amend <a href="#security-privacy-review-first-third-party">first- and third-party context</a> in security and privacy review.</td>
+                  </tr>
+                  <tr about="#dfc57b3a-dab6-4bf7-a23d-edb589230850" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="#condition-discovery-via-effective-acl-resource" rel="spec:changeSubject">#condition-discovery-via-effective-acl-resource</a></td>
+                    <td property="spec:statement">Add note about <a href="#condition-discovery-via-effective-acl-resource">discovering condition types via effective ACL resource</a> without additional requests.</td>
+                  </tr>
+                  <tr about="#ec74cbf0-ff4f-496e-bc8e-f407edd6fb7f" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-4" rel="spec:changeClass">4</a></td>
+                    <td><a href="#access-condition-extensions" rel="spec:changeSubject">#access-condition-extensions</a></td>
+                    <td property="spec:statement">Add <a href="#access-condition-extensions">Access Condition Extensions</a> section for describing the extension mechanism for new condition types.</td>
+                  </tr>
+                  <tr about="#f28e1b85-d867-4fba-bac7-b234a59bc9e5" typeof="spec:Change">
+                    <td><a href="https://www.w3.org/policies/process/#class-2" rel="spec:changeClass">2</a></td>
+                    <td><a href="#consider-condition-control" rel="spec:changeSubject">#consider-condition-control</a></td>
+                    <td property="spec:statement">Add security consideration advisement for <a href="#consider-condition-control">preserving Authorization integrity with conditions</a>.</td>
+                  </tr>
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <td colspan="3">
+                      <dl class="change-classes">
+                        <dt>1</dt>
+                        <dd><a href="https://www.w3.org/policies/process/#class-1">No changes to text content</a></dd>
+                        <dt>2</dt>
+                        <dd><a href="https://www.w3.org/policies/process/#class-2">Corrections that do not affect conformance</a></dd>
+                        <dt>3</dt>
+                        <dd><a href="https://www.w3.org/policies/process/#class-3">Corrections that do not add new features</a></dd>
+                        <dt>4</dt>
+                        <dd><a href="https://www.w3.org/policies/process/#class-4">New features</a></dd>
+                        <dt>5</dt>
+                        <dd><a href="https://www.w3.org/policies/process/#class-5">Changes to the contents of a registry table</a></dd>
+                      </dl>
+                    </td>
+                  </tr>
+                </tfoot>
+              </table>
+              <p id="changes-previous">Changes since earlier versions of the Web Access Control are detailed in the <a href="https://solidproject.org/TR/2024/wac-20240512#change-log">changes section of the previous version</a> of the Web Access Control.</p>
+            </div>
+          </section>
+          <section class="appendix" id="acknowledgements" inlist="" rel="schema:hasPart" resource="#acknowledgements">
+            <h2 property="schema:name">Acknowledgements</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <p>The Community Group gratefully acknowledges the work that led to the creation of this specification, and extends sincere appreciation to those individuals that worked on technologies and specifications that deeply influenced our work.</p>
+              <p>The Community Group thanks the following individuals, listed in alphabetical order by full name, for their helpful comments, both large and small, which have contributed to changes in this specification over the years.</p>
+              <ul>
+                <li>Aaron Coburn</li>
+                <li>Abdurrahman Ibrahim Ghanem</li>
+                <li>Alain Bourgeois</li>
+                <li>Alexander James Phillips</li>
+                <li>Amy Guy</li>
+                <li>Andreas Kuckartz</li>
+                <li>Andrei Sambra</li>
+                <li>Andrew Woods</li>
+                <li>Arne Hassel</li>
+                <li>Babydolljenny1985</li>
+                <li>Benjamin Armintor</li>
+                <li>Benjamin Goering</li>
+                <li>Beth Porter</li>
+                <li>Bob Ferris</li>
+                <li>Christoph Braun</li>
+                <li>Dan Brickley</li>
+                <li>David Booth</li>
+                <li>dbernstein</li>
+                <li>Dmitri Zagidulin</li>
+                <li>elf Pavlik</li>
+                <li>Erich Bremer</li>
+                <li>Eric Prud'hommeaux</li>
+                <li>Fabian Cook</li>
+                <li>Frederick Gibson</li>
+                <li>Henry Story</li>
+                <li>Ian Jacobs</li>
+                <li>Jackson Morgan</li>
+                <li>Jake Reschke</li>
+                <li>Jeff Zucker</li>
+                <li>Jeffry Waters</li>
+                <li>Joachim Van Herwegen</li>
+                <li>Joe Presbrey</li>
+                <li>Joep Meindertsma</li>
+                <li>John Walker</li>
+                <li>Justin Bingham</li>
+                <li>Ken Lassesen</li>
+                <li>Kingsley Idehen</li>
+                <li>Kjetil Kjernsmo</li>
+                <li>LoveIsGrief</li>
+                <li>Martynas Jusevičius</li>
+                <li>Matthieu Bosquet</li>
+                <li>Melvin Carvalho</li>
+                <li>Michael Hausenblas</li>
+                <li>Michael Thornburgh</li>
+                <li>Michiel de Jong</li>
+                <li>Mitzi László</li>
+                <li>MohammadReza vahedi</li>
+                <li>Nicola Greco</li>
+                <li>Nicolas Mondada</li>
+                <li>Nicolas Seydoux</li>
+                <li>Otto-AA</li>
+                <li>Pat McBennett</li>
+                <li>Pete Edwards</li>
+                <li>Pierre-Antoine Champin</li>
+                <li>Pieter Colpaert</li>
+                <li>Reese Hodge</li>
+                <li>Ross Horne</li>
+                <li>Ruben Taelman</li>
+                <li>Ruben Verborgh</li>
+                <li>Sandro Hawke</li>
+                <li>Sarven Capadisli</li>
+                <li>Satrajit Ghosh</li>
+                <li>Sergio Fernández</li>
+                <li>Simeon Warner</li>
+                <li>Simon Reinhardt</li>
+                <li>Steven Allen</li>
+                <li>Ted Thibodeau Jr</li>
+                <li>Thhck</li>
+                <li>Tim Berners-Lee</li>
+                <li>Tim McIver</li>
+                <li>Timea Turdean</li>
+                <li>Toby Inkster</li>
+                <li>Tom Haegemans</li>
+                <li>Tomasz Pluskiewicz</li>
+                <li>Vincent Tunru</li>
+                <li>Virginia Balseiro</li>
+                <li>Wouter Termont</li>
+                <li>Yvo Brevoort</li>
+                <li>Zoggy</li>
+                <li><span lang="te" xml:lang="te">దామోదర</span></li>
+              </ul>
+            </div>
+          </section>
+          <section class="appendix" id="references" inlist="" rel="schema:hasPart" resource="#references">
+            <h2 property="schema:name">References</h2>
+            <div datatype="rdf:HTML" property="schema:description">
+              <section id="normative-references" inlist="" rel="schema:hasPart" resource="#normative-references">
+                <h3 property="schema:name">Normative References</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <dl class="bibliography" resource="">
+                    <dt id="bib-fetch">[FETCH]</dt>
+                    <dd><cite><a href="https://fetch.spec.whatwg.org/" rel="cito:citesAsAuthority">Fetch Standard</a></cite>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a></dd>
+                    <dt id="bib-foaf">[FOAF]</dt>
+                    <dd><cite><a href="http://xmlns.com/foaf/spec" rel="cito:citesAsAuthority">FOAF Vocabulary Specification 0.99 (Paddington Edition)</a></cite>. Dan Brickley; Libby Miller.  FOAF project. 14 January 2014. URL: <a href="http://xmlns.com/foaf/spec">http://xmlns.com/foaf/spec</a></dd>
+                    <dt id="bib-infra">[INFRA]</dt>
+                    <dd><cite><a href="https://infra.spec.whatwg.org/" rel="cito:citesAsAuthority">Infra Standard</a></cite>. Anne van Kesteren; Domenic Denicola.  WHATWG. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a></dd>
+                    <dt id="bib-rdf-schema">[RDF-SCHEMA]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/rdf-schema/" rel="cito:citesAsAuthority">RDF Schema 1.1</a></cite>. Dan Brickley; Ramanathan Guha.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/rdf-schema/">https://www.w3.org/TR/rdf-schema/</a></dd>
+                    <dt id="bib-rdf11-concepts">[RDF11-CONCEPTS]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/rdf11-concepts/" rel="cito:citesAsAuthority">RDF 1.1 Concepts and Abstract Syntax</a></cite>. Richard Cyganiak; David Wood; Markus Lanthaler.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/rdf11-concepts/">https://www.w3.org/TR/rdf11-concepts/</a></dd>
+                    <dt id="bib-rfc2119">[RFC2119]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc2119" rel="cito:citesAsAuthority">Key words for use in RFCs to Indicate Requirement Levels</a></cite>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a></dd>
+                    <dt id="bib-rfc3986">[RFC3986]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc3986" rel="cito:citesAsAuthority">Uniform Resource Identifier (URI): Generic Syntax</a></cite>. T. Berners-Lee; R. Fielding; L. Masinter.  IETF. January 2005. Internet Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc3986">https://datatracker.ietf.org/doc/html/rfc3986</a></dd>
+                    <dt id="bib-rfc5789">[RFC5789]</dt>
+                    <dd><cite><a href="https://httpwg.org/specs/rfc5789.html" rel="cito:citesAsAuthority">PATCH Method for HTTP</a></cite>. L. Dusseault; J. Snell.  IETF. March 2010. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc5789.html">https://httpwg.org/specs/rfc5789.html</a></dd>
+                    <dt id="bib-rfc6454">[RFC6454]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc6454" rel="cito:citesAsAuthority">The Web Origin Concept</a></cite>. A. Barth.  IETF. December 2011. Proposed Standard. URL: <a href="https://datatracker.ietf.org/doc/html/rfc6454">https://datatracker.ietf.org/doc/html/rfc6454</a></dd>
+                    <dt id="bib-rfc8174">[RFC8274]</dt>
+                    <dd><cite><a href="https://datatracker.ietf.org/doc/html/rfc8174" rel="cito:citesAsAuthority">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a></cite>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc8174">https://datatracker.ietf.org/doc/html/rfc8174</a></dd>
+                    <dt id="bib-rfc8288">[RFC8288]</dt>
+                    <dd><cite><a href="https://httpwg.org/specs/rfc8288.html" rel="cito:citesAsAuthority">Web Linking</a></cite>. M. Nottingham.  IETF. October 2017. Proposed Standard. URL: <a href="https://httpwg.org/specs/rfc8288.html">https://httpwg.org/specs/rfc8288.html</a></dd>
+                    <dt id="bib-rfc9110">[RFC9110]</dt>
+                    <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc9110" rel="cito:citesAsAuthority">HTTP Semantics</a></cite>. R. Fielding, M. Nottingham, J. Reschke, Editors.  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9110">https://www.rfc-editor.org/rfc/rfc9110</a></dd>
+                    <dt id="bib-rfc9112">[RFC9112]</dt>
+                    <dd><cite><a href="https://www.rfc-editor.org/rfc/rfc9112" rel="cito:citesAsAuthority">HTTP/1.1</a></cite>. R. Fielding, M. Nottingham, J. Reschke, Editors.  IETF. June 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9112">https://www.rfc-editor.org/rfc/rfc9112</a></dd>
+                    <dt id="bib-turtle">[TURTLE]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/turtle/" rel="cito:citesAsAuthority">RDF 1.1 Turtle</a></cite>. Eric Prud'hommeaux; Gavin Carothers.  W3C. 25 February 2014. W3C Recommendation. URL: <a href="https://www.w3.org/TR/turtle/">https://www.w3.org/TR/turtle/</a></dd>
+                    <dt id="bib-vcard-rdf">[VCARD-RDF]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/vcard-rdf/" rel="cito:citesAsAuthority">vCard Ontology - for describing People and Organizations</a></cite>. Renato Iannella; James McKinney.  W3C. 22 May 2014. W3C Note. URL: <a href="https://www.w3.org/TR/vcard-rdf/">https://www.w3.org/TR/vcard-rdf/</a></dd>
+                    <dt id="bib-webarch">[WEBARCH]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/webarch/" rel="cito:citesAsAuthority">Architecture of the World Wide Web, Volume One</a></cite>. Ian Jacobs; Norman Walsh.  W3C. 15 December 2004. W3C Recommendation. URL: <a href="https://www.w3.org/TR/webarch/">https://www.w3.org/TR/webarch/</a></dd>
+                    <dt id="bib-webid">[WEBID]</dt>
+                    <dd><cite><a href="https://www.w3.org/2005/Incubator/webid/spec/identity/" rel="cito:citesAsAuthority">WebID 1.0</a></cite>. Andrei Sambra; Stéphane Corlosquet.  W3C WebID Community Group. 5 March 2014. W3C Editor’s Draft. URL: <a href="https://www.w3.org/2005/Incubator/webid/spec/identity/">https://www.w3.org/2005/Incubator/webid/spec/identity/</a></dd>
+                  </dl>
+                </div>
+              </section>
+              <section id="informative-references" inlist="" rel="schema:hasPart" resource="#informative-references">
+                <h3 property="schema:name">Informative References</h3>
+                <div datatype="rdf:HTML" property="schema:description">
+                  <dl class="bibliography" resource="">
+                    <dt id="bib-activitypub">[ACTIVITYPUB]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/activitypub/" rel="cito:citesAsPotentialSolution">ActivityPub</a></cite>. Christine Lemmer-Webber; Jessica Tallon.  W3C. 23 January 2018. W3C Recommendation. URL: <a href="https://www.w3.org/TR/activitypub/">https://www.w3.org/TR/activitypub/</a></dd>
+                    <dt id="bib-ldp">[LDP]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/ldp/" rel="cito:citesAsPotentialSolution">Linked Data Platform 1.0</a></cite>. Steve Speicher; John Arwe; Ashok Malhotra.  W3C. 26 February 2015. W3C Recommendation. URL: <a href="https://www.w3.org/TR/ldp/">https://www.w3.org/TR/ldp/</a></dd>
+                    <dt id="bib-odrl-model">[ODRL-MODEL]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/odrl-model/" rel="cito:citesAsPotentialSolution">ODRL Information Model 2.2</a></cite>. Renato Iannella; Serena Villata.  W3C. 15 February 2018. W3C Recommendation. URL: <a href="https://www.w3.org/TR/odrl-model/">https://www.w3.org/TR/odrl-model/</a></dd>
+                    <dt id="bib-security-privacy-questionnaire">[SECURITY-PRIVACY-QUESTIONNAIRE]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/security-privacy-questionnaire/" rel="cito:citesAsPotentialSolution">Self-Review Questionnaire: Security and Privacy</a></cite>. Theresa O'Connor; Peter Snyder.  W3C. 16 December 2021. W3C Group Note. URL: <a href="https://www.w3.org/TR/security-privacy-questionnaire/">https://www.w3.org/TR/security-privacy-questionnaire/</a></dd>
+                    <dt id="bib-solid-protocol">[SOLID-PROTOCOL]</dt>
+                    <dd><cite><a href="https://solidproject.org/TR/protocol" rel="cito:citesAsPotentialSolution">Solid Protocol</a></cite>. Sarven Capadisli; Tim Berners-Lee; Kjetil Kjernsmo.  W3C Solid Community Group. 12 May 2024. Draft Community Group Report, Version 0.11.0. URL: <a href="https://solidproject.org/TR/protocol">https://solidproject.org/TR/protocol</a></dd>
+                    <dt id="bib-sparql11-query">[SPARQL11-QUERY]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/sparql11-query/" rel="cito:citesAsPotentialSolution">SPARQL 1.1 Query Language</a></cite>. Steven Harris; Andy Seaborne.  W3C. 21 March 2013. W3C Recommendation. URL: <a href="https://www.w3.org/TR/sparql11-query/">https://www.w3.org/TR/sparql11-query/</a></dd>
+                    <dt id="bib-sparql11-update">[SPARQL11-UPDATE]</dt>
+                    <dd><cite><a href="https://www.w3.org/TR/sparql11-update/" rel="cito:citesAsPotentialSolution">SPARQL 1.1 Update</a></cite>. Paula Gearon; Alexandre Passant; Axel Polleres.  W3C. 21 March 2013. W3C Recommendation. URL: <a href="https://www.w3.org/TR/sparql11-update/">https://www.w3.org/TR/sparql11-update/</a></dd>
+                  </dl>
+                </div>
+              </section>
+            </div>
+          </section>
+        </div>
+      </article>
+    </main>
+    <p id="back-to-top" role="navigation"><a href="#toc"><abbr title="Back to top">↑</abbr></a></p>
+    <script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
A preview link can be found [here](https://htmlpreview.github.io/?https://github.com/solid/specification/blob/feat/wac-1.1-snapshot/2026/wac-20260420.html).

## Purpose

Adds `2026/wac-20260420.html` so [WAC 1.1](https://solid.github.io/web-access-control-spec/) (as of `solid/web-access-control-spec@dc634d5f`, dated 2026-04-20) has a stable URL on `https://solidproject.org/TR/2026/wac-20260420`.

This is a prerequisite for solid26 #783, which currently cites a Wayback Machine snapshot of the editor's draft. Once this PR is merged, the link in solid26 can be swapped to the immutable TR URL.

## What's in 1.1 vs 1.0

WAC 1.1 introduces `acl:condition`, with `ClientCondition` (application-aware matching beyond Origin) and `IssuerCondition`. Deny rules are not added; WAC remains monotonic.

## Snapshot transformations applied to the editor's draft

- **State line**: "Editor's Draft" → "Draft Community Group Report" (linked to `https://www.w3.org/standards/types/#reports`).
- **This version**: editor's-draft URL → `https://solidproject.org/TR/2026/wac-20260420`.
- **Latest published version** rel: `rel:latest-version` → `rel:latest-version mem:original`.
- **Added** `dl#document-editors-draft` and `dl#document-timemap` blocks (consistent with `2024/wac-20240512.html`).
- **Created / Published** dates set to `2026-04-20` (matching the WAC 1.0 snapshot pattern, where each TR snapshot resets these dates).

## For review

@csarven — flagging you as the WAC editor. Could you sanity-check the snapshot transformations and confirm whether anything else needs adjusting before this becomes the canonical TR URL for 1.1?

## Test plan

- [x] Render `2026/wac-20260420.html` and confirm metadata block (state line, This version URL, dates, editors-draft, timemap) reads correctly.
- [x] Confirm internal anchors (`#change-log`, `#acl-link-relation`, etc.) resolve.
- [x] Confirm `mem:original` appears on the latest-published-version link.
- [ ] @csarven sign-off on the snapshot transformations.