### PR TITLE
Add Type Indexes to the Solid Technical Reports listing

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,11 @@ border-bottom: 2pt solid #000;
                     <td>CG-DRAFT, v0.1.0</td>
                   </tr>
                   <tr>
+                    <td><a href="https://solid.github.io/type-indexes/" rel="cito:citesForInformation" typeof="doap:Specification">Type Indexes</a></td>
+                    <td><a href="https://github.com/solid/type-indexes">https://github.com/solid/type-indexes</a></td>
+                    <td>v1.0.0, Editor's Draft</td>
+                  </tr>
+                  <tr>
                     <td><a href="https://shapetrees.org/TR/specification/" rel="cito:citesForInformation" typeof="doap:Specification">Shape Trees</a></td>
                     <td><a href="https://github.com/shapetrees/specification">https://github.com/shapetrees/specification</a></td>
                     <td>Editor’s Draft</td>


### PR DESCRIPTION
A preview link can be found [here](https://htmlpreview.github.io/?https://github.com/solid/specification/blob/feat/tr-list-type-indexes/index.html).

## Summary

Adds [Type Indexes](https://solid.github.io/type-indexes/) to the Work Items table on the Solid Technical Reports index. The spec was not listed even though it is treated as a TR work item across other specifications:

- [Solid Application Interoperability](https://solidproject.org/TR/sai) builds on Type Indexes for resource discovery.
- [Solid WebID Profile § Discovery](https://solid.github.io/webid-profile/#discovery) references Type Indexes (`solid:publicTypeIndex`, `solid:privateTypeIndex`) as an established discovery mechanism.

## What's in this PR

- New row in the Work Items table for Type Indexes — inserted between Solid Application Interoperability and Shape Trees, keeping it adjacent to the data-discovery / interop cluster.

| Field | Value |
|---|---|
| Work Item | [Type Indexes](https://solid.github.io/type-indexes/) |
| Repository | https://github.com/solid/type-indexes |
| Current Stage | v1.0.0, Editor's Draft |

## Test plan

- [ ] Render `index.html` and confirm the new Type Indexes row appears between SAI and Shape Trees.
- [ ] All three links in the row resolve.